### PR TITLE
_mm_free and _mm_malloc switched to the macros MM_FREE and MM_MALLOC

### DIFF
--- a/config.py
+++ b/config.py
@@ -101,7 +101,7 @@ class configuration:
   vector_length = 8
 
   # The vector alignment used in the VectorizedSolver class when allocating
-  # aligned data structures using _mm_malloc and _mm_free
+  # aligned data structures using MM_MALLOC and MM_FREE
   vector_alignment = 16
 
   # List of C/C++/CUDA distutils.extension objects which are created based

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -58,22 +58,22 @@ Material::~Material() {
   /* If data is vector aligned */
   if (_data_aligned) {
     if (_sigma_t != NULL)
-      _mm_free(_sigma_t);
+      MM_FREE(_sigma_t);
 
     if (_sigma_a != NULL)
-      _mm_free(_sigma_a);
+      MM_FREE(_sigma_a);
 
     if (_sigma_s != NULL)
-      _mm_free(_sigma_s);
+      MM_FREE(_sigma_s);
 
     if (_sigma_f != NULL)
-      _mm_free(_sigma_f);
+      MM_FREE(_sigma_f);
 
     if (_nu_sigma_f != NULL)
-      _mm_free(_nu_sigma_f);
+      MM_FREE(_nu_sigma_f);
 
     if (_chi != NULL)
-      _mm_free(_chi);
+      MM_FREE(_chi);
 
     /* Whomever SIMD'izes OpenMOC will need to properly free these
      * using mm_free if they are vector aligned */
@@ -357,22 +357,22 @@ void Material::setNumEnergyGroups(const int num_groups) {
   /* If data is vector aligned */
   if (_data_aligned) {
     if (_sigma_t != NULL)
-      _mm_free(_sigma_t);
+      MM_FREE(_sigma_t);
 
     if (_sigma_a != NULL)
-      _mm_free(_sigma_a);
+      MM_FREE(_sigma_a);
 
     if (_sigma_s != NULL)
-      _mm_free(_sigma_s);
+      MM_FREE(_sigma_s);
 
     if (_sigma_f != NULL)
-      _mm_free(_sigma_f);
+      MM_FREE(_sigma_f);
 
     if (_nu_sigma_f != NULL)
-      _mm_free(_nu_sigma_f);
+      MM_FREE(_nu_sigma_f);
 
     if (_chi != NULL)
-      _mm_free(_chi);
+      MM_FREE(_chi);
   }
 
   /* Data is not vector aligned */
@@ -1126,11 +1126,11 @@ void Material::alignData() {
   int size = _num_vector_groups * VEC_LENGTH * sizeof(FP_PRECISION);
 
   /* Allocate word-aligned memory for cross-section data arrays */
-  FP_PRECISION* new_sigma_t = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
-  FP_PRECISION* new_sigma_a = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
-  FP_PRECISION* new_sigma_f = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
-  FP_PRECISION* new_nu_sigma_f=(FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
-  FP_PRECISION* new_chi = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+  FP_PRECISION* new_sigma_t = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
+  FP_PRECISION* new_sigma_a = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
+  FP_PRECISION* new_sigma_f = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
+  FP_PRECISION* new_nu_sigma_f=(FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
+  FP_PRECISION* new_chi = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
   /* The scattering matrix will be the number of vector groups
    * wide (SIMD) and the actual number of groups long since
@@ -1138,7 +1138,7 @@ void Material::alignData() {
 
   size = _num_vector_groups * VEC_LENGTH * _num_vector_groups;
   size *= VEC_LENGTH * sizeof(FP_PRECISION);
-  FP_PRECISION* new_sigma_s = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+  FP_PRECISION* new_sigma_s = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
   /* Initialize data structures to ones for sigma_t since it is used to
    * divide the source in the solver, and zeroes for everything else */

--- a/src/Material.h
+++ b/src/Material.h
@@ -16,12 +16,18 @@
 #include "log.h"
 #endif
 
-#ifndef ICPC
+#ifdef ICPC
 /** Word-aligned memory allocation for Intel's compiler */
-#define _mm_free(array) free(array)
+#define MM_FREE(array) _mm_free(array)
 
 /** Word-aligned memory allocation for Intel's compiler */
-#define _mm_malloc(size,alignment) malloc(size)
+#define MM_MALLOC(size,alignment) _mm_alloc(size, alignment)
+
+#else
+
+#define MM_FREE(array) free(array)
+#define MM_MALLOC(size,alignment) malloc(size)
+
 #endif
 
 /** Error threshold for determining how close the sum of \f$ \Sigma_a \f$

--- a/src/VectorizedPrivateSolver.cpp
+++ b/src/VectorizedPrivateSolver.cpp
@@ -32,7 +32,7 @@ VectorizedPrivateSolver::~VectorizedPrivateSolver() {
   if (_thread_flux != NULL) {
 
     for (int t=0; t < _num_threads; t++)
-      _mm_free(_thread_flux[t]);
+      MM_FREE(_thread_flux[t]);
 
     delete [] _thread_flux;
     _thread_flux = NULL;
@@ -80,7 +80,7 @@ void VectorizedPrivateSolver::initializeFluxArrays() {
   if (_thread_flux != NULL) {
 
     for (int t=0; t < _num_threads; t++)
-      _mm_free(_thread_flux[t]);
+      MM_FREE(_thread_flux[t]);
 
     delete [] _thread_flux;
   }
@@ -93,7 +93,7 @@ void VectorizedPrivateSolver::initializeFluxArrays() {
     size = _num_FSRs * _num_groups * sizeof(FP_PRECISION);
 
     for (int t=0; t < _num_threads; t++)
-      _thread_flux[t] = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+      _thread_flux[t] = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
   }
   catch(std::exception &e) {
     log_printf(ERROR, "Could not allocate memory for the "

--- a/src/VectorizedSolver.cpp
+++ b/src/VectorizedSolver.cpp
@@ -38,57 +38,57 @@ VectorizedSolver::VectorizedSolver(Geometry* geometry,
 VectorizedSolver::~VectorizedSolver() {
 
   if (_boundary_flux != NULL) {
-    _mm_free(_boundary_flux);
+    MM_FREE(_boundary_flux);
     _boundary_flux = NULL;
   }
 
   if (_boundary_leakage != NULL) {
-    _mm_free(_boundary_leakage);
+    MM_FREE(_boundary_leakage);
     _boundary_leakage = NULL;
   }
 
   if (_scalar_flux != NULL) {
-    _mm_free(_scalar_flux);
+    MM_FREE(_scalar_flux);
     _scalar_flux = NULL;
   }
 
   if (_thread_fsr_flux != NULL) {
-    _mm_free(_thread_fsr_flux);
+    MM_FREE(_thread_fsr_flux);
     _thread_fsr_flux = NULL;
   }
 
   if (_fission_sources != NULL) {
-    _mm_free(_fission_sources);
+    MM_FREE(_fission_sources);
     _fission_sources = NULL;
   }
 
   if (_scatter_sources != NULL) {
-    _mm_free(_scatter_sources);
+    MM_FREE(_scatter_sources);
     _scatter_sources = NULL;
   }
 
   if (_source != NULL) {
-    _mm_free(_source);
+    MM_FREE(_source);
     _source = NULL;
   }
 
   if (_old_source != NULL) {
-    _mm_free(_old_source);
+    MM_FREE(_old_source);
     _old_source = NULL;
   }
 
   if (_reduced_source != NULL) {
-    _mm_free(_reduced_source);
+    MM_FREE(_reduced_source);
     _reduced_source = NULL;
   }
 
   if (_thread_taus != NULL) {
-    _mm_free(_thread_taus);
+    MM_FREE(_thread_taus);
     _thread_taus = NULL;
   }
 
   if (_thread_exponentials != NULL) {
-    _mm_free(_thread_exponentials);
+    MM_FREE(_thread_exponentials);
     _thread_exponentials = NULL;
   }
 
@@ -146,14 +146,14 @@ void VectorizedSolver::buildExpInterpTable() {
   /* Deallocates memory for the exponentials if it was allocated for a
    * previous simulation */
   if (_thread_exponentials != NULL)
-    _mm_free(_thread_exponentials);
+    MM_FREE(_thread_exponentials);
 
   /* Allocates memory for an array of exponential values for each thread
    * - this is not used by default, but can be to allow for vectorized
    * evaluation of the exponentials. Unfortunately this does not appear
    * to give any performance boost. */
   int size = _num_threads * _polar_times_groups * sizeof(FP_PRECISION);
-  _thread_exponentials = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+  _thread_exponentials = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 }
 
 
@@ -168,19 +168,19 @@ void VectorizedSolver::initializeFluxArrays() {
 
   /* Delete old flux arrays if they exist */
   if (_boundary_flux != NULL)
-    _mm_free(_boundary_flux);
+    MM_FREE(_boundary_flux);
 
   if (_boundary_leakage != NULL)
-    _mm_free(_boundary_leakage);
+    MM_FREE(_boundary_leakage);
 
   if (_scalar_flux != NULL)
-    _mm_free(_scalar_flux);
+    MM_FREE(_scalar_flux);
 
   if (_thread_fsr_flux != NULL)
-    _mm_free(_thread_fsr_flux);
+    MM_FREE(_thread_fsr_flux);
 
   if (_thread_taus != NULL)
-    _mm_free(_thread_taus);
+    MM_FREE(_thread_taus);
 
   int size;
 
@@ -189,17 +189,17 @@ void VectorizedSolver::initializeFluxArrays() {
 
     size = 2 * _tot_num_tracks * _num_groups * _num_polar;
     size *= sizeof(FP_PRECISION);
-    _boundary_flux = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
-    _boundary_leakage = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+    _boundary_flux = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
+    _boundary_leakage = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
     size = _num_FSRs * _num_groups * sizeof(FP_PRECISION);
-    _scalar_flux = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+    _scalar_flux = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
     size = _num_threads * _num_groups * sizeof(FP_PRECISION);
-    _thread_fsr_flux = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+    _thread_fsr_flux = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
     size = _num_threads * _polar_times_groups * sizeof(FP_PRECISION);
-    _thread_taus = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+    _thread_taus = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
   }
   catch(std::exception &e) {
@@ -218,38 +218,38 @@ void VectorizedSolver::initializeSourceArrays() {
 
   /* Delete old sources arrays if they exist */
   if (_fission_sources != NULL)
-    _mm_free(_fission_sources);
+    MM_FREE(_fission_sources);
 
   if (_scatter_sources != NULL)
-    _mm_free(_scatter_sources);
+    MM_FREE(_scatter_sources);
 
   if (_source != NULL)
-    _mm_free(_source);
+    MM_FREE(_source);
 
   if (_old_source != NULL)
-    _mm_free(_old_source);
+    MM_FREE(_old_source);
 
   if (_reduced_source != NULL)
-    _mm_free(_reduced_source);
+    MM_FREE(_reduced_source);
 
   if (_source_residuals != NULL)
-    _mm_free(_source_residuals);
+    MM_FREE(_source_residuals);
 
   int size;
 
   /* Allocate aligned memory for all source arrays */
   try{
     size = _num_FSRs * _num_groups * sizeof(FP_PRECISION);
-    _fission_sources = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
-    _source = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
-    _old_source = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
-    _reduced_source = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+    _fission_sources = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
+    _source = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
+    _old_source = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
+    _reduced_source = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
     size = _num_threads * _num_groups * sizeof(FP_PRECISION);
-    _scatter_sources = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+    _scatter_sources = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
     size = _num_FSRs * sizeof(FP_PRECISION);
-    _source_residuals = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+    _source_residuals = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
   }
   catch(std::exception &e) {
     log_printf(ERROR, "Could not allocate memory for the VectorizedSolver's "
@@ -491,10 +491,10 @@ void VectorizedSolver::computeKeff() {
   FP_PRECISION tot_fission = 0.0;
 
   int size = _num_FSRs * sizeof(FP_PRECISION);
-  FP_PRECISION* FSR_rates = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+  FP_PRECISION* FSR_rates = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
   size = _num_threads * _num_groups * sizeof(FP_PRECISION);
-  FP_PRECISION* group_rates = (FP_PRECISION*)_mm_malloc(size, VEC_ALIGNMENT);
+  FP_PRECISION* group_rates = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
   /* Loop over all FSRs and compute the volume-weighted absorption rates */
   #pragma omp parallel for private(tid, volume, \
@@ -576,8 +576,8 @@ void VectorizedSolver::computeKeff() {
   log_printf(DEBUG, "abs = %f, fission = %f, leakage = %f, k_eff = %f",
              tot_abs, tot_fission, _leakage, _k_eff);
 
-  _mm_free(FSR_rates);
-  _mm_free(group_rates);
+  MM_FREE(FSR_rates);
+  MM_FREE(group_rates);
 
 return;
 }


### PR DESCRIPTION
Switched to macros due to problems with `stdlib.h` when using `_openmoc.so` as a library. Most of the changes are from `sed`.
