### PR TITLE
Accounting for Nu-Scattering in Keff Calculation

### DIFF
--- a/config.py
+++ b/config.py
@@ -385,8 +385,6 @@ class configuration:
                 define_macros = self.macros[self.cc][self.fp],
                 swig_opts = self.swig_flags + ['-D' + self.cc.upper()]))
 
-    print('swig opts = {0}'.format(self.swig_flags + ['-D' + self.cc.upper()]))
-
     # The openmoc.cuda extension if requested by the user at compile
     # time (--with-cuda)
     if self.with_cuda:

--- a/config.py
+++ b/config.py
@@ -385,6 +385,8 @@ class configuration:
                 define_macros = self.macros[self.cc][self.fp],
                 swig_opts = self.swig_flags + ['-D' + self.cc.upper()]))
 
+    print('swig opts = {0}'.format(self.swig_flags + ['-D' + self.cc.upper()]))
+
     # The openmoc.cuda extension if requested by the user at compile
     # time (--with-cuda)
     if self.with_cuda:

--- a/config.py
+++ b/config.py
@@ -244,7 +244,7 @@ class configuration:
   library_directories['gcc'] = [usr_lib]
   library_directories['icpc'] = [usr_lib]
   library_directories['bgxlc'] = [usr_lib]
-  library_directories['nvcc'] = [usr_lib, '/usr/local/cuda/lib64']
+  library_directories['nvcc'] = [usr_lib, '/usr/local/cuda-5.5/lib64']
 
 
   #############################################################################
@@ -258,7 +258,7 @@ class configuration:
   include_directories['gcc'] = list()
   include_directories['icpc'] = list()
   include_directories['bgxlc'] = list()
-  include_directories['nvcc'] = ['/usr/local/cuda/include']
+  include_directories['nvcc'] = ['/usr/local/cuda-5.5/include']
 
 
   ###########################################################################

--- a/openmoc/openmoc.i
+++ b/openmoc/openmoc.i
@@ -22,6 +22,10 @@
   #include "../src/Universe.h"
   #include "../src/Cmfd.h"
 
+  #ifdef ICPC
+  #include "../src/VectorizedSolver.h"
+  #endif
+
   #define printf PySys_WriteStdout
 
 
@@ -307,6 +311,10 @@
 %include ../src/TrackGenerator.h
 %include ../src/Universe.h
 %include ../src/Cmfd.h
+
+#ifdef ICPC
+%include "../src/VectorizedSolver.h"
+#endif
 
 
 #define printf PySys_WriteStdout

--- a/sample-input/benchmarks/c5g7/c5g7.py
+++ b/sample-input/benchmarks/c5g7/c5g7.py
@@ -1,4 +1,4 @@
-from openmoc.intel.single import *
+from openmoc import *
 import openmoc.log as log
 import openmoc.plotter as plotter
 import openmoc.materialize as materialize
@@ -342,7 +342,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = VectorizedSolver(geometry, track_generator)
+solver = CPUSolver(geometry, track_generator)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.setNumThreads(num_threads)
 solver.convergeSource(max_iters)

--- a/sample-input/benchmarks/c5g7/c5g7.py
+++ b/sample-input/benchmarks/c5g7/c5g7.py
@@ -1,4 +1,4 @@
-from openmoc import *
+from openmoc.intel.single import *
 import openmoc.log as log
 import openmoc.plotter as plotter
 import openmoc.materialize as materialize
@@ -342,7 +342,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = VectorizedSolver(geometry, track_generator)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.setNumThreads(num_threads)
 solver.convergeSource(max_iters)

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -701,8 +701,8 @@ void CPUSolver::computeKeff() {
   FP_PRECISION* group_rates = new FP_PRECISION[_num_threads * _num_groups];
 
   /* Loop over all FSRs and compute the volume-weighted total rates */
-  #pragma omp parallel for private(tid, volume, \
-    material, sigma) schedule(guided)
+  //  #pragma omp parallel for private(tid, volume, \
+  //   material, sigma) schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
 
     tid = omp_get_thread_num() * _num_groups;
@@ -721,8 +721,8 @@ void CPUSolver::computeKeff() {
   total = pairwise_sum<FP_PRECISION>(FSR_rates, _num_FSRs);
 
   /* Loop over all FSRs and compute the volume-weighted fission rates */
-  #pragma omp parallel for private(tid, volume, \
-    material, sigma) schedule(guided)
+//  #pragma omp parallel for private(tid, volume,	\
+//    material, sigma) schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
 
     tid = omp_get_thread_num() * _num_groups;
@@ -741,8 +741,8 @@ void CPUSolver::computeKeff() {
   fission = pairwise_sum<FP_PRECISION>(FSR_rates, _num_FSRs);
 
   /* Loop over all FSRs and compute the volume-weighted scattering rates */
-  #pragma omp parallel for private(tid, volume, \
-    material) schedule(guided)
+//  #pragma omp parallel for private(tid, volume,	\
+//    material) schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
 
     tid = omp_get_thread_num() * _num_groups;

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -120,7 +120,7 @@ FP_PRECISION CPUSolver::getFSRSource(int fsr_id, int energy_group) {
   if (material->isFissionable()) {
     for (int e=0; e < _num_groups; e++)
       fission_source += _scalar_flux(fsr_id,e) * nu_sigma_f[e];
-    
+
     fission_source /= _k_eff;
   }
 
@@ -687,64 +687,89 @@ void CPUSolver::computeKeff() {
 
   int tid;
   Material* material;
-  FP_PRECISION* sigma_a;
-  FP_PRECISION* nu_sigma_f;
+  FP_PRECISION* sigma;
   FP_PRECISION volume;
 
-  FP_PRECISION tot_abs = 0.0;
-  FP_PRECISION tot_fission = 0.0;
+  FP_PRECISION total = 0.0;
+  FP_PRECISION fission = 0.0;
+  FP_PRECISION scatter = 0.0;
 
   FP_PRECISION* FSR_rates = new FP_PRECISION[_num_FSRs];
   FP_PRECISION* group_rates = new FP_PRECISION[_num_threads * _num_groups];
-  
-  /* Loop over all FSRs and compute the volume-weighted absorption rates */
+
+  /* Loop over all FSRs and compute the volume-weighted total rates */
   #pragma omp parallel for private(tid, volume, \
-    material, sigma_a) schedule(guided)
+    material, sigma) schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
 
     tid = omp_get_thread_num() * _num_groups;
     volume = _FSR_volumes[r];
     material = _FSR_materials[r];
-    sigma_a = material->getSigmaA();
+    sigma = material->getSigmaT();
 
     for (int e=0; e < _num_groups; e++)
-      group_rates[tid+e] = sigma_a[e] * _scalar_flux(r,e);
+      group_rates[tid+e] = sigma[e] * _scalar_flux(r,e);
 
     FSR_rates[r]=pairwise_sum<FP_PRECISION>(&group_rates[tid], _num_groups);
     FSR_rates[r] *= volume;
   }
 
-  /* Reduce absorption rates across FSRs */
-  tot_abs = pairwise_sum<FP_PRECISION>(FSR_rates, _num_FSRs);
+  /* Reduce total rates across FSRs */
+  total = pairwise_sum<FP_PRECISION>(FSR_rates, _num_FSRs);
 
   /* Loop over all FSRs and compute the volume-weighted fission rates */
   #pragma omp parallel for private(tid, volume, \
-    material, nu_sigma_f) schedule(guided)
+    material, sigma) schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
 
     tid = omp_get_thread_num() * _num_groups;
     volume = _FSR_volumes[r];
     material = _FSR_materials[r];
-    nu_sigma_f = material->getNuSigmaF();
+    sigma = material->getNuSigmaF();
 
     for (int e=0; e < _num_groups; e++)
-      group_rates[tid+e] = nu_sigma_f[e] * _scalar_flux(r,e);
+      group_rates[tid+e] = sigma[e] * _scalar_flux(r,e);
 
     FSR_rates[r]=pairwise_sum<FP_PRECISION>(&group_rates[tid], _num_groups);
     FSR_rates[r] *= volume;
   }
 
   /* Reduce fission rates across FSRs */
-  tot_fission = pairwise_sum<FP_PRECISION>(FSR_rates, _num_FSRs);
+  fission = pairwise_sum<FP_PRECISION>(FSR_rates, _num_FSRs);
+
+  /* Loop over all FSRs and compute the volume-weighted scattering rates */
+  #pragma omp parallel for private(tid, volume, \
+    material) schedule(guided)
+  for (int r=0; r < _num_FSRs; r++) {
+
+    tid = omp_get_thread_num() * _num_groups;
+    volume = _FSR_volumes[r];
+    material = _FSR_materials[r];
+
+    FSR_rates[r] = 0.;
+
+    for (int G=0; G < _num_groups; G++) {
+      for (int g=0; g < _num_groups; g++)
+        group_rates[tid+g] = material->getSigmaSByGroupInline(g,G)
+                             * _scalar_flux(r,g);
+
+      FSR_rates[r]+=pairwise_sum<FP_PRECISION>(&group_rates[tid], _num_groups);
+    }
+
+    FSR_rates[r] *= volume;
+  }
+
+  /* Reduce scattering rates across FSRs */
+  scatter = pairwise_sum<FP_PRECISION>(FSR_rates, _num_FSRs);
 
   /* Reduce leakage array across Tracks, energy groups, polar angles */
   int size = 2 * _tot_num_tracks * _polar_times_groups;
   _leakage = pairwise_sum<FP_PRECISION>(_boundary_leakage, size) * 0.5;
 
-  _k_eff = tot_fission / (tot_abs + _leakage);
+  _k_eff = fission / (total - scatter + _leakage);
 
-  log_printf(DEBUG, "abs = %f, fission = %f, leakage = %f, k_eff = %f",
-             tot_abs, tot_fission, _leakage, _k_eff);
+  log_printf(DEBUG, "tot = %f, fiss = %f, scatt = %f, leakage = %f,"
+             "k_eff = %f", total, fission, scatter, _leakage, _k_eff);
 
   delete [] FSR_rates;
   delete [] group_rates;

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -701,8 +701,8 @@ void CPUSolver::computeKeff() {
   FP_PRECISION* group_rates = new FP_PRECISION[_num_threads * _num_groups];
 
   /* Loop over all FSRs and compute the volume-weighted total rates */
-  //  #pragma omp parallel for private(tid, volume, \
-  //   material, sigma) schedule(guided)
+  #pragma omp parallel for private(tid, volume, \
+    material, sigma) schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
 
     tid = omp_get_thread_num() * _num_groups;
@@ -721,8 +721,8 @@ void CPUSolver::computeKeff() {
   total = pairwise_sum<FP_PRECISION>(FSR_rates, _num_FSRs);
 
   /* Loop over all FSRs and compute the volume-weighted fission rates */
-//  #pragma omp parallel for private(tid, volume,	\
-//    material, sigma) schedule(guided)
+  #pragma omp parallel for private(tid, volume, \
+    material, sigma) schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
 
     tid = omp_get_thread_num() * _num_groups;
@@ -741,8 +741,8 @@ void CPUSolver::computeKeff() {
   fission = pairwise_sum<FP_PRECISION>(FSR_rates, _num_FSRs);
 
   /* Loop over all FSRs and compute the volume-weighted scattering rates */
-//  #pragma omp parallel for private(tid, volume,	\
-//    material) schedule(guided)
+  #pragma omp parallel for private(tid, volume, \
+    material) schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
 
     tid = omp_get_thread_num() * _num_groups;

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -630,9 +630,9 @@ FP_PRECISION CPUSolver::computeFSRSources() {
       for (int e=0; e < _num_groups; e++)
         _fission_sources(r,e) = _scalar_flux(r,e) * nu_sigma_f[e];
 
-        fission_source = pairwise_sum<FP_PRECISION>(&_fission_sources(r,0),
-                                                     _num_groups);
-        fission_source *= inverse_k_eff;
+      fission_source = pairwise_sum<FP_PRECISION>(&_fission_sources(r,0),
+                                                  _num_groups);
+      fission_source *= inverse_k_eff;
     }
 
     else
@@ -646,8 +646,8 @@ FP_PRECISION CPUSolver::computeFSRSources() {
         _scatter_sources(tid,g) = material->getSigmaSByGroupInline(g,G)
                       * _scalar_flux(r,g);
 
-        scatter_source=pairwise_sum<FP_PRECISION>(&_scatter_sources(tid,0),
-                                                   _num_groups);
+      scatter_source=pairwise_sum<FP_PRECISION>(&_scatter_sources(tid,0),
+                                                _num_groups);
 
       /* Set the fission source for FSR r in group G */
       fsr_fission_source += fission_source * chi[G];

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -676,12 +676,15 @@ FP_PRECISION CPUSolver::computeFSRSources() {
 
 
 /**
- * @brief Compute \f$ k_{eff} \f$ from the total fission and absorption rates.
+ * @brief Compute \f$ k_{eff} \f$ from the total, fission and scattering
+ *        reaction rates and leakage.
  * @details This method computes the current approximation to the
  *          multiplication factor on this iteration as follows:
- *          \f$ k_{eff} = \frac{\displaystyle\sum \displaystyle\sum \nu
- *                        \Sigma_f \Phi V}{\displaystyle\sum
- *                        \displaystyle\sum \Sigma_a \Phi V} \f$
+ *          \f$ k_{eff} = \frac{\displaystyle\sum_{i \in I}
+ *                        \displaystyle\sum_{g \in G} \nu \Sigma^F_g \Phi V_{i}}
+ *                        {\displaystyle\sum_{i \in I}
+ *                        \displaystyle\sum_{g \in G} (\Sigma^T_g \Phi V_{i} -
+ *                        \Sigma^S_g \Phi V_{i} - L_{i,g})} \f$
  */
 void CPUSolver::computeKeff() {
 

--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -34,12 +34,6 @@
  * @class CPUSolver CPUSolver.h "src/CPUSolver.h"
  * @brief This a subclass of the Solver class for multi-core CPUs using
  *        OpenMP multi-threading.
- * @details This Solver subclass uses OpenMP's multi-threading directives,
- *          including the mutual exclusion locks. Although the algorithm is
- *          more memory efficient than its ThreadPrivateSolver subclass, its
- *          parallel performance scales very poorly. As a result, this class
- *          is not recommended for general use and is primarily intended to
- *          expose the limitations of OpenMP's mutual exclusion formulation.
  */
 class CPUSolver : public Solver {
 

--- a/src/VectorizedSolver.h
+++ b/src/VectorizedSolver.h
@@ -43,6 +43,9 @@ protected:
   /** Number of energy groups divided by vector widths (VEC_LENGTH) */
   int _num_vector_lengths;
 
+  /** The change in angular flux along a track segment for each energy group */
+  FP_PRECISION* _delta_psi;
+
   /** An array for the optical length for each thread in each energy group */
   FP_PRECISION* _thread_taus;
 

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1643,12 +1643,15 @@ void GPUSolver::addSourceToScalarFlux() {
 
 
 /**
- * @brief Compute \f$ k_{eff} \f$ from the total fission and absorption rates.
+ * @brief Compute \f$ k_{eff} \f$ from the total, fission and scattering
+ *        reaction rates and leakage.
  * @details This method computes the current approximation to the
  *          multiplication factor on this iteration as follows:
- *          \f$ k_{eff} = \frac{\displaystyle\sum \displaystyle\sum \nu
- *                        \Sigma_f \Phi V}{\displaystyle\sum
- *                        \displaystyle\sum \Sigma_a \Phi V} \f$
+ *          \f$ k_{eff} = \frac{\displaystyle\sum_{i \in I}
+ *                        \displaystyle\sum_{g \in G} \nu \Sigma^F_g \Phi V_{i}}
+ *                        {\displaystyle\sum_{i \in I}
+ *                        \displaystyle\sum_{g \in G} (\Sigma^T_g \Phi V_{i} -
+ *                        \Sigma^S_g \Phi V_{i} - L_{i,g})} \f$
  */
 void GPUSolver::computeKeff() {
 

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -258,55 +258,71 @@ __global__ void computeFSRSourcesOnDevice(int* FSR_materials,
  * @param FSR_materials an array of the FSR Material UIDs
  * @param materials an array of the dev_material pointers
  * @param scalar_flux an array of FSR scalar fluxes
- * @param tot_absorption an array of FSR absorption rates
- * @param tot_fission an array of FSR fission rates
+ * @param total array of FSR total reaction rates
+ * @param fission an array of FSR fission rates
+ * @param scatter an array of FSR scattering rates
  */
-__global__ void computeFissionAndAbsorption(FP_PRECISION* FSR_volumes,
-                                            int* FSR_materials,
-                                            dev_material* materials,
-                                            FP_PRECISION* scalar_flux,
-                                            FP_PRECISION* tot_absorption,
-                                            FP_PRECISION* tot_fission) {
+__global__ void computeKeffReactionRates(FP_PRECISION* FSR_volumes,
+                                         int* FSR_materials,
+                                         dev_material* materials,
+                                         FP_PRECISION* scalar_flux,
+                                         FP_PRECISION* total,
+                                         FP_PRECISION* fission,
+                                         FP_PRECISION* scatter) {
 
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
 
   dev_material* curr_material;
+  FP_PRECISION* sigma_t;
   FP_PRECISION* nu_sigma_f;
-  FP_PRECISION* sigma_a;
+  FP_PRECISION* sigma_s;
   FP_PRECISION volume;
 
-  FP_PRECISION absorption = 0.;
-  FP_PRECISION fission = 0.;
+  FP_PRECISION tot = 0.;
+  FP_PRECISION fiss = 0.;
+  FP_PRECISION scatt = 0.;
 
   /* Iterate over all FSRs */
   while (tid < *num_FSRs) {
 
     curr_material = &materials[FSR_materials[tid]];
+    sigma_t = curr_material->_sigma_t;
     nu_sigma_f = curr_material->_nu_sigma_f;
-    sigma_a = curr_material->_sigma_a;
+    sigma_s = curr_material->_sigma_s;
     volume = FSR_volumes[tid];
 
-    FP_PRECISION curr_abs = 0.;
-    FP_PRECISION curr_fission = 0.;
+    FP_PRECISION curr_tot = 0.;
+    FP_PRECISION curr_fiss = 0.;
+    FP_PRECISION curr_scatt = 0.;
 
-    /* Iterate over all energy groups and update fission and absorption
+    /* Iterate over all energy groups and update total and fission
      * rates for this thread block */
     for (int e=0; e < *num_groups; e++) {
-      curr_abs += sigma_a[e] * scalar_flux(tid,e);
-      curr_fission += nu_sigma_f[e] * scalar_flux(tid,e);
+      curr_tot += sigma_t[e] * scalar_flux(tid,e);
+      curr_fiss += nu_sigma_f[e] * scalar_flux(tid,e);
     }
 
-    absorption += curr_abs * volume;
-    fission += curr_fission * volume;
+    tot += curr_tot * volume;
+    fiss += curr_fiss * volume;
+
+    /* Iterate over all energy groups and update scattering
+     * rates for this thread block */
+    for (int G=0; G < *num_groups; G++) {
+      for (int g=0; g < *num_groups; g++)
+        curr_scatt += sigma_s[G*(*num_groups)+g] * scalar_flux(tid,g);
+    }
+
+    scatt += curr_scatt * volume;
 
     /* Increment thread id */
     tid += blockDim.x * gridDim.x;
   }
 
-  /* Copy this thread's fission and absorption rates to global memory */
+  /* Copy this thread's total and scatter rates to global memory */
   tid = threadIdx.x + blockIdx.x * blockDim.x;
-  tot_absorption[tid] = absorption;
-  tot_fission[tid] = fission;
+  total[tid] = tot;
+  fission[tid] = fiss;
+  scatter[tid] = scatt;
 
   return;
 }
@@ -699,8 +715,9 @@ GPUSolver::GPUSolver(Geometry* geometry, TrackGenerator* track_generator) :
   _dev_tracks = NULL;
   _FSR_materials = NULL;
 
-  _tot_absorption = NULL;
-  _tot_fission = NULL;
+  _total = NULL;
+  _fission = NULL;
+  _scatter = NULL;
   _leakage = NULL;
 
   if (track_generator != NULL)
@@ -762,14 +779,19 @@ GPUSolver::~GPUSolver() {
     _fission_sources = NULL;
   }
 
-  if (_tot_absorption != NULL) {
-    _tot_absorption_vec.clear();
-    _tot_absorption = NULL;
+  if (_total != NULL) {
+    _total_vec.clear();
+    _total = NULL;
   }
 
-  if (_tot_fission != NULL) {
-    _tot_fission_vec.clear();
-    _tot_fission = NULL;
+  if (_fission != NULL) {
+    _fission_vec.clear();
+    _fission = NULL;
+  }
+
+  if (_scatter != NULL) {
+    _scatter_vec.clear();
+    _scatter = NULL;
   }
 
   if (_source_residuals != NULL) {
@@ -1321,14 +1343,19 @@ void GPUSolver::initializeThrustVectors() {
     _fission_sources_vec.clear();
   }
 
-  if (_tot_absorption != NULL) {
-    _tot_absorption = NULL;
-    _tot_absorption_vec.clear();
+  if (_total != NULL) {
+    _total = NULL;
+    _total_vec.clear();
   }
 
-  if (_tot_fission != NULL) {
-    _tot_fission = NULL;
-    _tot_fission_vec.clear();
+  if (_fission != NULL) {
+    _fission = NULL;
+    _fission_vec.clear();
+  }
+
+  if (_scatter != NULL) {
+    _scatter = NULL;
+    _scatter_vec.clear();
   }
 
   if (_source_residuals != NULL) {
@@ -1347,13 +1374,17 @@ void GPUSolver::initializeThrustVectors() {
     _fission_sources_vec.resize(_B * _T);
     _fission_sources = thrust::raw_pointer_cast(&_fission_sources_vec[0]);
 
-    /* Allocate total absorption reaction rate array on device */
-    _tot_absorption_vec.resize(_B * _T);
-    _tot_absorption = thrust::raw_pointer_cast(&_tot_absorption_vec[0]);
+    /* Allocate total reaction rate array on device */
+    _total_vec.resize(_B * _T);
+    _total = thrust::raw_pointer_cast(&_total_vec[0]);
 
     /* Allocate fission reaction rate array on device */
-    _tot_fission_vec.resize(_B * _T);
-    _tot_fission = thrust::raw_pointer_cast(&_tot_fission_vec[0]);
+    _fission_vec.resize(_B * _T);
+    _fission = thrust::raw_pointer_cast(&_fission_vec[0]);
+
+    /* Allocate scattering reaction rate array on device */
+    _scatter_vec.resize(_B * _T);
+    _scatter = thrust::raw_pointer_cast(&_scatter_vec[0]);
 
     /* Allocate source residual array on device */
     _source_residuals_vec.resize(_B * _T);
@@ -1621,41 +1652,45 @@ void GPUSolver::addSourceToScalarFlux() {
  */
 void GPUSolver::computeKeff() {
 
-  FP_PRECISION tot_absorption;
-  FP_PRECISION tot_fission;
-  FP_PRECISION tot_leakage;
+  FP_PRECISION total;
+  FP_PRECISION fission;
+  FP_PRECISION scatter;
+  FP_PRECISION leakage;
 
-  /* Compute the total fission and absorption rates on the device.
+  /* Compute the total, fission and scattering reaction rates on device.
    * This kernel stores partial rates in a Thrust vector with as many
    * entries as CUDAthreads executed by the kernel */
-  computeFissionAndAbsorption<<<_B, _T>>>(_FSR_volumes, _FSR_materials,
-                                          _materials, _scalar_flux,
-                                          _tot_absorption, _tot_fission);
+  computeKeffReactionRates<<<_B, _T>>>(_FSR_volumes, _FSR_materials,
+                                       _materials, _scalar_flux,
+                                       _total, _fission, _scatter);
 
   cudaDeviceSynchronize();
 
-  /* Compute the total absorption rate by reducing the partial absorption
+  /* Compute the total reaction rate by reducing the partial total
    * rates compiled in the Thrust vector */
-  tot_absorption = thrust::reduce(_tot_absorption_vec.begin(),
-                                  _tot_absorption_vec.end());
+  total = thrust::reduce(_total_vec.begin(), _total_vec.end());
 
-  /* Compute the total fission rate by reducing the partial fission
+  /* Compute the fission rate by reducing the partial fission
    * rates compiled in the Thrust vector */
-  tot_fission = thrust::reduce(_tot_fission_vec.begin(),_tot_fission_vec.end());
+  fission = thrust::reduce(_fission_vec.begin(), _fission_vec.end());
 
-  cudaMemcpy((void*)&tot_fission, (void*)_tot_fission,
+  cudaMemcpy((void*)&fission, (void*)_fission,
              _B * _T * sizeof(FP_PRECISION), cudaMemcpyHostToDevice);
+
+  /* Compute the scattering rate by reducing the partial fission
+   * rates compiled in the Thrust vector */
+  scatter = thrust::reduce(_scatter_vec.begin(), _scatter_vec.end());
 
   /* Compute the total leakage by reducing the partial leakage
    * rates compiled in the Thrust vector */
-  tot_leakage = 0.5 * thrust::reduce(_leakage_vec.begin(), _leakage_vec.end());
+  leakage = 0.5 * thrust::reduce(_leakage_vec.begin(), _leakage_vec.end());
 
 
-  /* Compute the new keff from the fission and absorption rates */
-  _k_eff = tot_fission / (tot_absorption + tot_leakage);
+  /* Compute the new keff from the total, fission, scatter and leakage */
+  _k_eff = fission / (total - scatter + leakage);
 
-  log_printf(DEBUG, "abs = %f, fiss = %f, leak = %f, keff = %f",
-             tot_absorption, tot_fission, tot_leakage, _k_eff);
+  log_printf(DEBUG, "tot = %f, fiss = %f, scatt = %f, leak = %f,"
+             " keff = %f", total, fission, scatter, leakage, _k_eff);
 }
 
 

--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -74,11 +74,14 @@ private:
   /** An array of the cumulative number of Tracks for each azimuthal angle */
   int* _track_index_offsets;
 
-  /** A pointer to the Thrust vector of absorption rates in each FSR */
-  FP_PRECISION* _tot_absorption;
+  /** A pointer to the Thrust vector of total reaction rates in each FSR */
+  FP_PRECISION* _total;
 
   /** A pointer to the Thrust vector of fission rates in each FSR */
-  FP_PRECISION* _tot_fission;
+  FP_PRECISION* _fission;
+
+  /** A pointer to the Thrust vector of scatter rates in each FSR */
+  FP_PRECISION* _scatter;
 
   /** A pointer to the Thrust vector of leakages for each Track */
   FP_PRECISION* _leakage;
@@ -86,11 +89,14 @@ private:
   /** Thrust vector of fission sources in each FSR */
   thrust::device_vector<FP_PRECISION> _fission_sources_vec;
 
-  /** Thrust vector of fission rates in each FSR */
-  thrust::device_vector<FP_PRECISION> _tot_fission_vec;
+  /** Thrust vector of total reaction rates in each FSR */
+  thrust::device_vector<FP_PRECISION> _total_vec;
 
-  /** Thrust vector of absorption rates in each FSR */
-  thrust::device_vector<FP_PRECISION> _tot_absorption_vec;
+  /** Thrust vector of fission rates in each FSR */
+  thrust::device_vector<FP_PRECISION> _fission_vec;
+
+  /** Thrust vector of scatter rates in each FSR */
+  thrust::device_vector<FP_PRECISION> _scatter_vec;
 
   /** Thrust vector of source residuals in each FSR */
   thrust::device_vector<FP_PRECISION> _source_residuals_vec;


### PR DESCRIPTION
This pull requests modifies the ``Solver::computeKeff()`` routine to account for (n,2n), (n,3n), etc. reactions through nu-scatter. This functionality allows the user to assign nu-scatter as the scattering matrix for one more more ``Materials``, and for this to be accounted for in the calculation for keff. The old formulation for computing keff was as follows:

![equation](http://www.sciweavers.org/tex2img.php?eq=%0Ak_%7Beff%7D%20%3D%20%5Cfrac%7B%5Cdisplaystyle%5Csum_%7Bi%20%5Cin%20I%7D%20%5Cdisplaystyle%5Csum_%7Bg%20%5Cin%20G%7D%20%5Cnu%5E%7BF%7D_%7Bi%2Cg%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5CSigma%5E%7BF%7D_%7Bi%2Cg%7D%20%5CPhi_%7Bi%2Cg%7D%20V_%7Bi%7D%7D%7B%5Cdisplaystyle%5Csum_%7Bi%20%5Cin%20I%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cdisplaystyle%5Csum_%7Bg%20%5Cin%20G%7D%20%5CSigma%5E%7BA%7D_%7Bi%2Cg%7D%20%5CPhi_%7Bi%2Cg%7D%20V_%7Bi%7D%20-%20L_%7Bi%2Cg%7D%7D&bc=White&fc=Black&im=jpg&fs=12&ff=arev&edit=0)

The new formulation uses total-nu-scatter instead of absorption in the denominator:

![equation](http://www.sciweavers.org/tex2img.php?eq=%0Ak_%7Beff%7D%20%3D%20%5Cfrac%7B%5Cdisplaystyle%5Csum_%7Bi%20%5Cin%20I%7D%20%5Cdisplaystyle%5Csum_%7Bg%20%5Cin%20G%7D%20%5Cnu%5E%7BF%7D_%7Bi%2Cg%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5CSigma%5E%7BF%7D_%7Bi%2Cg%7D%20%5CPhi_%7Bi%2Cg%7D%20V_%7Bi%7D%7D%7B%5Cdisplaystyle%5Csum_%7Bi%20%5Cin%20I%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cdisplaystyle%5Csum_%7Bg%20%5Cin%20G%7D%20%5Cleft%28%5CSigma%5E%7BT%7D_%7Bi%2Cg%7D%20-%20%5Cnu%5E%7BS%7D_%7Bi%2Cg%7D%5CSigma%5E%7BS%7D_%7Bi%2Cg%7D%5Cright%29%5CPhi_%7Bi%2Cg%7D%20%20V_%7Bi%7D%20-%20L_%7Bi.g%7D%7D&bc=White&fc=Black&im=jpg&fs=12&ff=arev&edit=0)

This new formulation was implemented for the ``CPUSolver``, ``VectorizedSolver`` and ``GPUSolver`` subclasses of the abstract ``Solver`` class. 

One item to consider before merging this PR is that the precise value for keff is no longer strictly reproducible for parallel calculations. This seems to only  true in the sub-pcm level. Interestingly enough, it appears to be more of an issue for small problems than for large problems. I only notice this issue when compiling OpenMOC with single precision - I observed no discrepancies when using double precision using the ``--fp=double`` compile time command line argument.

I believe this issue is the result of roundoff error propagation during summations of large arrays. This is the reason we began using [pairwise sum](http://en.wikipedia.org/wiki/Pairwise_summation) throughout the code a year and a half ago. Although the new code still uses pairwise summations of the total, fission and scattering reaction rates, the roundoff error issue is exacerbated due to the fact that I am summing across the group-to-group scattering rates.

One potential fix might be to break up the ``_sigma_s`` attribute for the ``Material`` class into ``_sigma_s`` and ``_sigma_matrix`` attributes. The user would simply need to pass in the scattering matrix to the ``Material::setSigmaS(...)`` routine to be stored in ``_sigma_s_matrix``. Under the hood, the rows of the matrix would be summed up and stored in ``_sigma_s``. Then, when ``Solver::computeKeff()`` is called, the only ``_sigma_s`` would be used rather than the matrix. This *should* reduce roundoff error propagation by implicitly embedding a pairwise sum in into the keff calculation. In addition, it would improve performance, particularly for problems with >100 energy groups.