### PR TITLE
Fix for Spatial Zones with Zero Total Cross-Sections

### DIFF
--- a/config.py
+++ b/config.py
@@ -247,7 +247,7 @@ class configuration:
   library_directories['gcc'] = [usr_lib]
   library_directories['icpc'] = [usr_lib]
   library_directories['bgxlc'] = [usr_lib]
-  library_directories['nvcc'] = [usr_lib, '/usr/local/cuda-5.5/lib64']
+  library_directories['nvcc'] = [usr_lib, '/usr/local/cuda/lib64']
 
 
   #############################################################################
@@ -261,7 +261,7 @@ class configuration:
   include_directories['gcc'] = list()
   include_directories['icpc'] = list()
   include_directories['bgxlc'] = list()
-  include_directories['nvcc'] = ['/usr/local/cuda-5.5/include']
+  include_directories['nvcc'] = ['/usr/local/cuda/include']
 
 
   ###########################################################################

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -667,8 +667,11 @@ FP_PRECISION CPUSolver::computeFSRSources() {
       fsr_fission_source += fission_source * chi[G];
 
       /* Set the reduced source for FSR r in group G */
-      _reduced_sources(r,G) = (fission_source * chi[G] + scatter_source) *
-                      ONE_OVER_FOUR_PI / sigma_t[G];
+      if (sigma_t[G] > 0)
+        _reduced_sources(r,G) = (fission_source * chi[G] + scatter_source) *
+                        ONE_OVER_FOUR_PI / sigma_t[G];
+      else
+        _reduced_sources(r,G) = 0.;
     }
 
     /* Compute the norm of residual of the source in the FSR */
@@ -1090,8 +1093,12 @@ void CPUSolver::addSourceToScalarFlux() {
 
       for (int e=0; e < _num_groups; e++) {
         _scalar_flux(r,e) *= 0.5;
-        _scalar_flux(r,e) = FOUR_PI * _reduced_sources(r,e) +
-                            (_scalar_flux(r,e) / (sigma_t[e] * volume));
+
+        if (sigma_t[e] > 0.)
+          _scalar_flux(r,e) = FOUR_PI * _reduced_sources(r,e) +
+                              (_scalar_flux(r,e) / (sigma_t[e] * volume));
+        else
+          _scalar_flux(r,e) = 0.;
     }
   }
 

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -666,12 +666,8 @@ FP_PRECISION CPUSolver::computeFSRSources() {
       /* Set the fission source for FSR r in group G */
       fsr_fission_source += fission_source * chi[G];
 
-      /* Set the reduced source for FSR r in group G */
-      if (sigma_t[G] > 0)
-        _reduced_sources(r,G) = (fission_source * chi[G] + scatter_source) *
-                        ONE_OVER_FOUR_PI / sigma_t[G];
-      else
-        _reduced_sources(r,G) = 0.;
+      _reduced_sources(r,G) = (fission_source * chi[G] + scatter_source) *
+                              ONE_OVER_FOUR_PI / sigma_t[G];
     }
 
     /* Compute the norm of residual of the source in the FSR */
@@ -1093,12 +1089,8 @@ void CPUSolver::addSourceToScalarFlux() {
 
       for (int e=0; e < _num_groups; e++) {
         _scalar_flux(r,e) *= 0.5;
-
-        if (sigma_t[e] > 0.)
-          _scalar_flux(r,e) = FOUR_PI * _reduced_sources(r,e) +
-                              (_scalar_flux(r,e) / (sigma_t[e] * volume));
-        else
-          _scalar_flux(r,e) = 0.;
+        _scalar_flux(r,e) = FOUR_PI * _reduced_sources(r,e) +
+                            (_scalar_flux(r,e) / (sigma_t[e] * volume));
     }
   }
 

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -680,7 +680,7 @@ void Material::setSigmaT(double* xs, int num_groups) {
 
   for (int i=0; i < _num_groups; i++) {
 
-    /* If the cross-section is too small (e.g., zero) */
+    /* If the cross-section is near zero (e.g., within (-1E-10, 1E-10)) */
     if (fabs(xs[i]) < ZERO_SIGMA_T)
       _sigma_t[i] = FP_PRECISION(ZERO_SIGMA_T);
     else

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -664,6 +664,10 @@ void Material::setNumEnergyGroups(const int num_groups) {
  *          material.setSigmaT(sigma_t)
  * @endcode
  *
+ *          NOTE: This routine will override an zero-valued cross-sections 
+ *          (i.e., in void or gap regions) with a minimum value of 1E-10 to
+ *          void numerical issues in the MOC solver.
+ *
  * @param xs the array of total cross-sections
  * @param num_groups the number of energy groups
  */
@@ -671,10 +675,17 @@ void Material::setSigmaT(double* xs, int num_groups) {
 
   if (_num_groups != num_groups)
     log_printf(ERROR, "Unable to set sigma_t with %d groups for Material "
-               "%d which contains %d energy groups", num_groups, _id, _num_groups);
+               "%d which contains %d energy groups", num_groups, 
+               _id, _num_groups);
 
-  for (int i=0; i < _num_groups; i++)
-    _sigma_t[i] = FP_PRECISION(xs[i]);
+  for (int i=0; i < _num_groups; i++) {
+
+    /* If the cross-section is too small (e.g., zero) */
+    if (fabs(xs[i]) < ZERO_SIGMA_T)
+      _sigma_t[i] = FP_PRECISION(ZERO_SIGMA_T);
+    else
+      _sigma_t[i] = FP_PRECISION(xs[i]);
+  }
 }
 
 

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -711,7 +711,6 @@ void Material::setSigmaTByGroup(double xs, int group) {
     }
     else
       _sigma_t[group-1] = FP_PRECISION(xs);
-  }
 }
 
 

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -681,8 +681,11 @@ void Material::setSigmaT(double* xs, int num_groups) {
   for (int i=0; i < _num_groups; i++) {
 
     /* If the cross-section is near zero (e.g., within (-1E-10, 1E-10)) */
-    if (fabs(xs[i]) < ZERO_SIGMA_T)
+    if (fabs(xs[i]) < ZERO_SIGMA_T) {
+      log_printf(WARNING, "Overriding zero cross-section in "
+                 "group %d for Material %d with 1E-10", i, _id);
       _sigma_t[i] = FP_PRECISION(ZERO_SIGMA_T);
+    }
     else
       _sigma_t[i] = FP_PRECISION(xs[i]);
   }
@@ -700,7 +703,15 @@ void Material::setSigmaTByGroup(double xs, int group) {
     log_printf(ERROR, "Unable to set sigma_t for group %d for Material "
                "%d which contains %d energy groups", group, _id, _num_groups);
 
-  _sigma_t[group-1] = xs;
+    /* If the cross-section is near zero (e.g., within (-1E-10, 1E-10)) */
+    if (fabs(xs) < ZERO_SIGMA_T) {
+      log_printf(WARNING, "Overriding zero cross-section in "
+                 "group %d for Material %d with 1E-10", group, _id);
+      _sigma_t[group-1] = FP_PRECISION(ZERO_SIGMA_T);
+    }
+    else
+      _sigma_t[group-1] = FP_PRECISION(xs);
+  }
 }
 
 

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -652,7 +652,7 @@ void Material::setNumEnergyGroups(const int num_groups) {
  * @brief Set the Material's array of total cross-sections.
  * @details This method is a helper function to allow OpenMOC users to assign
  *          the Material's nuclear data in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the number of energy groups) as input to this function. This
  *          function then fills the NumPy array with the data values for the
  *          Material's total cross-sections. An example of how this function
@@ -665,7 +665,7 @@ void Material::setNumEnergyGroups(const int num_groups) {
  * @endcode
  *
  *          NOTE: This routine will override an zero-valued cross-sections 
- *          (i.e., in void or gap regions) with a minimum value of 1E-10 to
+ *          (e.g., in void or gap regions) with a minimum value of 1E-10 to
  *          void numerical issues in the MOC solver.
  *
  * @param xs the array of total cross-sections
@@ -719,7 +719,7 @@ void Material::setSigmaTByGroup(double xs, int group) {
  * @brief Set the Material's array of absorption scattering cross-sections.
  * @details This method is a helper function to allow OpenMOC users to assign
  *          the Material's nuclear data in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the number of energy groups) as input to this function. This
  *          function then fills the NumPy array with the data values for the
  *          Material's absorption cross-sections. An example of how this
@@ -791,7 +791,7 @@ void Material::setSigmaAByGroup(double xs, int group) {
  * 
  *          This method is a helper function to allow OpenMOC users to assign
  *          the Material's nuclear data in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the square of the number of energy groups) as input to this 
  *          function. This function then fills the NumPy array with the data 
  *          values for the Material's scattering cross-sections. An example 
@@ -845,7 +845,7 @@ void Material::setSigmaSByGroup(double xs, int origin, int destination) {
  * @brief Set the Material's array of fission cross-sections.
  * @details This method is a helper function to allow OpenMOC users to assign
  *          the Material's nuclear data in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the number of energy groups) as input to this function. This
  *          function then fills the NumPy array with the data values for the
  *          Material's fission cross-sections. An example of how this
@@ -939,7 +939,7 @@ void Material::setNuSigmaF(double* xs, int num_groups) {
  *        for some energy group.
  * @details This method is a helper function to allow OpenMOC users to assign
  *          the Material's nuclear data in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the number of energy groups) as input to this function. This
  *          function then fills the NumPy array with the data values for the
  *          Material's nu*fission cross-sections. An example of how this
@@ -979,7 +979,7 @@ void Material::setNuSigmaFByGroup(double xs, int group) {
  * @brief Set the Material's array of chi \f$ \chi \f$ values.
  * @details This method is a helper function to allow OpenMOC users to assign
  *          the Material's nuclear data in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the number of energy groups) as input to this function. This
  *          function then fills the NumPy array with the data values for the
  *          Material's chi distribution. An example of how this function might
@@ -1032,7 +1032,7 @@ void Material::setChiByGroup(double xs, int group) {
  * @brief Set the Material's array of diffusion coefficients.
  * @details This method is a helper function to allow OpenMOC users to assign
  *          the Material's nuclear data in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the number of energy groups) as input to this function. This
  *          function then fills the NumPy array with the data values for the
  *          Material's diffusion coefficients. An example of how this
@@ -1089,7 +1089,7 @@ void Material::setDifCoefByGroup(double xs, int group) {
  * @brief Set the Material's array of diffusion coefficients.
  * @details This method is a helper function to allow OpenMOC users to assign
  *          the Material's nuclear data in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the number of energy groups) as input to this function. This
  *          function then fills the NumPy array with the data values for the
  *          Material's buckling coefficients. An example of how this function
@@ -1145,7 +1145,7 @@ void Material::setBucklingByGroup(double xs, int group) {
  * @brief Set the Material's array of diffusion coefficients.
  * @details This method is a helper function to allow OpenMOC users to assign
  *          the Material's nuclear data in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the number of energy groups) as input to this function. This
  *          function then fills the NumPy array with the data values for the
  *          Material's surface diffusion coefficients. An example of how this
@@ -1205,7 +1205,7 @@ void Material::setDifHatByGroup(double xs, int group, int surface) {
  * @brief Set the Material's array of diffusion coefficients.
  * @details This method is a helper function to allow OpenMOC users to assign
  *          the Material's nuclear data in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the number of energy groups) as input to this function. This
  *          function then fills the NumPy array with the data values for the
  *          Material's CMFD corrected diffusion coefficients. An example of how

--- a/src/Material.h
+++ b/src/Material.h
@@ -17,11 +17,11 @@
 #endif
 
 /** A negligible cross-section value to over-ride user-defined
- *  cross-sectionsvery near zero (e.g., within (-1E-10, 1E-10)) */
+ *  cross-sections very near zero (e.g., within (-1E-10, 1E-10)) */
 #define ZERO_SIGMA_T 1E-10
 
 #ifdef ICPC
-/** Word-aligned memory deallocationallocation for Intel's compiler */
+/** Word-aligned memory allocation for Intel's compiler */
 #define MM_FREE(array) _mm_free(array)
 
 /** Word-aligned memory allocation for Intel's compiler */

--- a/src/Material.h
+++ b/src/Material.h
@@ -16,7 +16,8 @@
 #include "log.h"
 #endif
 
-/** The minimum allowable total cross-section value for any group */
+/** A negligible cross-section value to over-ride user-defined
+ *  cross-sectionsvery near zero (e.g., within (-1E-10, 1E-10)) */
 #define ZERO_SIGMA_T 1E-10
 
 #ifdef ICPC

--- a/src/Material.h
+++ b/src/Material.h
@@ -16,6 +16,9 @@
 #include "log.h"
 #endif
 
+/** The minimum allowable total cross-section value for any group */
+#define ZERO_SIGMA_T 1E-10
+
 #ifdef ICPC
 /** Word-aligned memory deallocationallocation for Intel's compiler */
 #define MM_FREE(array) _mm_free(array)

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -615,7 +615,7 @@ void Solver::printTimerReport() {
   num_digits += (int) log10((double) num_segments);
   num_digits += (int) log10((double) _num_FSRs);
 
-  num_digits = 67 - num_digits;
+  num_digits = 66 - num_digits;
   num_digits /= 4;
 
   std::stringstream msg;

--- a/src/VectorizedSolver.cpp
+++ b/src/VectorizedSolver.cpp
@@ -407,12 +407,8 @@ FP_PRECISION VectorizedSolver::computeFSRSources() {
       /* Set the total source for FSR r in group G */
       fsr_fission_source += fission_source * chi[G]; 
 
-      /* Set the reduced source for FSR r in group G */
-      if (sigma_t[G] > 0)
-        _reduced_sources(r,G) = (fission_source * chi[G] + scatter_source) *
-                        ONE_OVER_FOUR_PI / sigma_t[G];
-      else
-        _reduced_sources(r,G) = 0.;
+      _reduced_sources(r,G) = (fission_source * chi[G] + scatter_source) *
+                              ONE_OVER_FOUR_PI / sigma_t[G];
     }
 
     /* Compute the norm of residual of the source in the FSR */
@@ -473,12 +469,6 @@ void VectorizedSolver::addSourceToScalarFlux() {
       #pragma simd vectorlength(VEC_LENGTH)
       for (int e=v*VEC_LENGTH; e < (v+1)*VEC_LENGTH; e++)
         _scalar_flux(r,e) += FOUR_PI * _reduced_sources(r,e);
-
-      /* Convert NaNs to zero for zero cross-section regions */
-      for (int e=v*VEC_LENGTH; e < (v+1)*VEC_LENGTH; e++)
-        if (sigma_t[e] <= 0.)
-          _scalar_flux(r,e) = 0.
-
     }
   }
 

--- a/src/VectorizedSolver.cpp
+++ b/src/VectorizedSolver.cpp
@@ -407,8 +407,12 @@ FP_PRECISION VectorizedSolver::computeFSRSources() {
       /* Set the total source for FSR r in group G */
       fsr_fission_source += fission_source * chi[G]; 
 
-      _reduced_sources(r,G) = (fission_source * chi[G] + scatter_source)
-                        * ONE_OVER_FOUR_PI / sigma_t[G];
+      /* Set the reduced source for FSR r in group G */
+      if (sigma_t[G] > 0)
+        _reduced_sources(r,G) = (fission_source * chi[G] + scatter_source) *
+                        ONE_OVER_FOUR_PI / sigma_t[G];
+      else
+        _reduced_sources(r,G) = 0.;
     }
 
     /* Compute the norm of residual of the source in the FSR */
@@ -469,6 +473,12 @@ void VectorizedSolver::addSourceToScalarFlux() {
       #pragma simd vectorlength(VEC_LENGTH)
       for (int e=v*VEC_LENGTH; e < (v+1)*VEC_LENGTH; e++)
         _scalar_flux(r,e) += FOUR_PI * _reduced_sources(r,e);
+
+      /* Convert NaNs to zero for zero cross-section regions */
+      for (int e=v*VEC_LENGTH; e < (v+1)*VEC_LENGTH; e++)
+        if (sigma_t[e] <= 0.)
+          _scalar_flux(r,e) = 0.
+
     }
   }
 

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -235,7 +235,7 @@ __global__ void computeFSRSourcesOnDevice(int* FSR_materials,
                                  * chi[G] + scatter_source) * ONE_OVER_FOUR_PI, 
                                  sigma_t[G]);
       else
-        reduced_sources = 0.;
+        reduced_sources(tid,G) = 0.;
     }
 
     /* Compute the norm of residuals of the sources for convergence */

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -230,12 +230,9 @@ __global__ void computeFSRSourcesOnDevice(int* FSR_materials,
       /* Set the fission source for FSR r in group G */
       fsr_fission_source += fission_source * chi[G] * inverse_k_eff;
 
-      if (sigma_t[G] > 0.)
-        reduced_sources(tid,G) = __fdividef((inverse_k_eff * fission_source 
-                                 * chi[G] + scatter_source) * ONE_OVER_FOUR_PI, 
-                                 sigma_t[G]);
-      else
-        reduced_sources(tid,G) = 0.;
+      reduced_sources(tid,G) = __fdividef((inverse_k_eff * fission_source 
+                               * chi[G] + scatter_source) * ONE_OVER_FOUR_PI, 
+                               sigma_t[G]);
     }
 
     /* Compute the norm of residuals of the sources for convergence */
@@ -646,13 +643,9 @@ __global__ void addSourceToScalarFluxOnDevice(FP_PRECISION* scalar_flux,
     /* Iterate over all energy groups */
     for (int i=0; i < *num_groups; i++) {
       scalar_flux(tid,i) *= 0.5;
-
-      if (sigma_t[i] > 0.)
-        scalar_flux(tid,i) = FOUR_PI * reduced_sources(tid,i) +
-                             __fdividef(scalar_flux(tid,i), 
-                             (sigma_t[i] * volume));
-      else
-        scalar_flux(tid,i) = 0.;
+      scalar_flux(tid,i) = FOUR_PI * reduced_sources(tid,i) +
+                           __fdividef(scalar_flux(tid,i), 
+                           (sigma_t[i] * volume));
     }
 
     /* Increment thread id */


### PR DESCRIPTION
This pull request introduces a fix which allows regions with a zero total cross-section to be modeled without leading to NaNs. In the current version of OpenMOC, a zero total cross-section in one or more energy groups in one or more regions will lead to NaNs when evaluating the reduced source and scalar flux terms. On the second power source iteration, the NaNs are propagated throughout, leading to keff to be evaluated to NaN.

There is no perfectly straightforward way to deal with zero total cross-section regions. The quick and dirty approach I came up with was to simply implement conditional checks to assign the reduced source and scalar flux to zero (not physical) in regions / energy groups with a zero total cross-section. Considering that this is a bit of a hacky patch for some problems I've been trying to solve, I'd especially like to hear @samuelshaner and @PrezNattyGibbs thoughts on this since this certainly may be the wrong approach altogether.

This PR also resets the NVIDIA CUDA directory to "/usr/local/cuda" from "/usr/local/cuda-5.5" in ``config.py`` since the latest version of CUDA is 7.0 which is installed by default in "/usr/local/cuda".