### PR TITLE
Fix for Multi-line Messages in Logger

### DIFF
--- a/openmoc/compatible/opencg_compatible.py
+++ b/openmoc/compatible/opencg_compatible.py
@@ -475,7 +475,10 @@ def get_compatible_opencg_cells(opencg_cell, opencg_surface, halfspace):
 
 def make_opencg_cells_compatible(opencg_universe):
 
-  if not isinstance(opencg_universe, opencg.Universe):
+  if isinstance(opencg_universe, opencg.Lattice):
+    return
+
+  elif not isinstance(opencg_universe, opencg.Universe):
     msg = 'Unable to make compatible OpenCG Cells for {0} which ' \
           'is not an OpenCG Universe'.format(opencg_universe)
     raise ValueError(msg)

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -847,7 +847,7 @@ std::string CellBasic::toString() {
   std::map<int, surface_halfspace>::iterator iter;
   string << ", surface ids = ";
   for (iter = _surfaces.begin(); iter != _surfaces.end(); ++iter)
-    string << iter->first << ", ";
+    string << iter->second._halfspace * iter->first << ", ";
 
   return string.str();
 }
@@ -955,7 +955,7 @@ std::string CellFill::toString() {
   std::map<int, surface_halfspace>::iterator iter;
   string << ", surface ids = ";
   for (iter = _surfaces.begin(); iter != _surfaces.end(); ++iter)
-    string << iter->first << ", ";
+    string <<  iter->second._halfspace * iter->first << ", ";
 
   return string.str();
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -519,7 +519,7 @@ std::string create_multiline_msg(std::string level, std::string message) {
       line_length -= 4;
 
     /* Update substring indices */
-    start = end + 1;
+    start = end;
     end += line_length + 1;
   }
 


### PR DESCRIPTION
This PR introduces a fix for multi-line message printing to the console from the ``openmoc.log`` module. The current implementation had a bug which stripped the leading character from each successive line printed to the console for multiline messages (*e.g.*, messages > 80 characters). In addition, this PR updates the ``Cell.toString()`` routine to include the ``Surface`` halfspace when appending the ``Surface`` IDs to the string representation of each ``Cell``.