### PR TITLE
Logger module compatibility with IPython Notebook

### DIFF
--- a/openmoc/compatible/opencg_compatible.py
+++ b/openmoc/compatible/opencg_compatible.py
@@ -475,7 +475,10 @@ def get_compatible_opencg_cells(opencg_cell, opencg_surface, halfspace):
 
 def make_opencg_cells_compatible(opencg_universe):
 
-  if not isinstance(opencg_universe, opencg.Universe):
+  if isinstance(opencg_universe, opencg.Lattice):
+    return
+
+  elif not isinstance(opencg_universe, opencg.Universe):
     msg = 'Unable to make compatible OpenCG Cells for {0} which ' \
           'is not an OpenCG Universe'.format(opencg_universe)
     raise ValueError(msg)

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -462,7 +462,7 @@ void log_printf(logLevel level, const char* format, ...) {
     if (level == ERROR)
       throw std::logic_error(msg_string.c_str());
     else 
-     std::cout << msg_string;
+      printf("%s", msg_string.c_str());
   }
 }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -412,7 +412,7 @@ void log_printf(logLevel level, const char* format, ...) {
         vsprintf(message, format, args);
         va_end(args);
         std::string msg = std::string(message);
-        std::string level_prefix = "[  ERROR  ]  ";
+        std::string level_prefix = "";
 
         /* If message is too long for a line, split into many lines */
         if (int(msg.length()) > line_length)
@@ -459,7 +459,10 @@ void log_printf(logLevel level, const char* format, ...) {
     log_file.close();
 
     /* Write the log message to the shell */
-    printf(msg_string.c_str());
+    if (level == ERROR)
+      throw std::logic_error(msg_string.c_str());
+    else 
+     std::cout << msg_string;
   }
 }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -459,13 +459,8 @@ void log_printf(logLevel level, const char* format, ...) {
     log_file.close();
 
     /* Write the log message to the shell */
-    std::cout << msg_string;
+    printf(msg_string.c_str());
   }
-
-
-  /* If the message was a runtime error, exit the program */
-  if (level == ERROR)
-    exit(1);
 }
 
 

--- a/src/log.h
+++ b/src/log.h
@@ -25,7 +25,10 @@
 #include <math.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include "Python.h"
 #endif
+
+#define printf PySys_WriteStdout
 
 /**
  * @enum logLevels


### PR DESCRIPTION
This PR is from #125 but on the "develop" branch.

This PR presents a few minor modifications to OpenMOC's logger module:

First, a few changes were made to log.h and log.cpp to ensure that log messages are printed to the inline IPython Notebook console.

Second, messages labeled with an ERROR tag no longer call the exit(1) routine. This was originally implemented when OpenMOC was a binary executable; now that OpenMOC is a shared library which is intended to be used as a "plug-n-play" Python package, it no longer makes sense to "exit" the program when an error condition is met. A particular case in point is when a user is using OpenMOC in an IPython Notebook - previously, an error message would cause the entire Notebook kernel to crash. Now, the user will simply see the error message printed to the inline console and may continue to revise the Notebook.