### PR TITLE
Bug fix for irregularly shaped lattices

### DIFF
--- a/openmoc/openmoc.i
+++ b/openmoc/openmoc.i
@@ -377,7 +377,7 @@
   $3 = (Universe**) malloc(($1 * $2) * sizeof(Universe*)); // universes
 
   /* Loop over x */
-  for (int i = 0; i < $2; i++) {
+  for (int i = 0; i < $1; i++) {
 
     /* Get the inner list in the nested list for the lattice */
     PyObject* outer_list = PyList_GetItem($input,i);
@@ -385,19 +385,19 @@
     /* Check that the length of this list is the same as the length
      * of the first list */
     if (PySequence_Length(outer_list) != $2) {
-      PyErr_SetString(PyExc_ValueError, "Size mismatch. Expected $1 x $2 "
-                      "elements for Lattice\n");
+      PyErr_SetString(PyExc_ValueError, "Size mismatch in Universes "
+                      "list for Lattice which must be a 2D list of lists");
       return NULL;
     }
 
     /* Loop over y */
-    for (int j =0; j < $1; j++) {
+    for (int j =0; j < $2; j++) {
       /* Extract the value from the list at this location and convert
        * SWIG wrapper to pointer to underlying C++ class instance */
-      PyObject* o = PyList_GetItem(outer_list,j);
+      PyObject* o = PyList_GetItem(outer_list, j);
       void *p1 = 0;
       SWIG_ConvertPtr(o, &p1, SWIGTYPE_p_Universe, 0 | 0);
-      $3[i*$1+j] = (Universe*) p1;
+      $3[i*$2+j] = (Universe*) p1;
     }
   }
 }

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1079,11 +1079,11 @@ void Lattice::setWidth(double width_x, double width_y) {
  *                                   [u2, u3, u2, u3]])
  * @endcode
  *
- * @param num_x the number of Lattice cells along x
  * @param num_y the number of Lattice cells along y
+ * @param num_x the number of Lattice cells along x
  * @param universes the array of Universes for each Lattice cell
  */
-void Lattice::setUniverses(int num_x, int num_y, Universe** universes) {
+void Lattice::setUniverses(int num_y, int num_x, Universe** universes) {
 
   /* Clear any Universes in the Lattice (from a previous run) */
   for (int i=0; i < _num_x; i++)

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1092,7 +1092,7 @@ void Lattice::setUniverses(int num_x, int num_y, Universe** universes) {
   _universes.clear();
 
   /* Set the Lattice dimensions */
-  setNumX(num_y);
+  setNumX(num_x);
   setNumY(num_y);
 
   Universe* universe;

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1086,7 +1086,7 @@ void Lattice::setWidth(double width_x, double width_y) {
 void Lattice::setUniverses(int num_y, int num_x, Universe** universes) {
 
   /* Clear any Universes in the Lattice (from a previous run) */
-  for (int i=0; i < _num_x; i++)
+  for (int i=0; i < _num_y; i++)
     _universes.at(i).clear();
 
   _universes.clear();
@@ -1100,13 +1100,13 @@ void Lattice::setUniverses(int num_y, int num_x, Universe** universes) {
   /* The Lattice cells are assumed input in row major order starting from the
    * upper left corner. This double loop reorders the Lattice cells from the
    * to start from the lower left corner */
-  for (int i = 0; i < _num_y; i++) {
+  for (int j = 0; j < _num_y; j++) {
 
     _universes.push_back(std::vector< std::pair<int, Universe*> >());
 
-    for (int j = 0; j < _num_x; j++){
-      universe = universes[(_num_y-1-i)*_num_x + j];
-      _universes.at(i).push_back(std::pair<int, Universe*>
+    for (int i = 0; i < _num_x; i++){
+      universe = universes[(_num_y-1-j)*_num_x + i];
+      _universes.at(j).push_back(std::pair<int, Universe*>
                                  (universe->getId(), universe));
     }
   }

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1105,7 +1105,6 @@ void Lattice::setUniverses(int num_x, int num_y, Universe** universes) {
     _universes.push_back(std::vector< std::pair<int, Universe*> >());
 
     for (int j = 0; j < _num_x; j++){
-      printf("i = %d, j = %d, index = %d\n", i, j, (_num_y-1-i)*_num_x + j);
       universe = universes[(_num_y-1-i)*_num_x + j];
       _universes.at(i).push_back(std::pair<int, Universe*>
                                  (universe->getId(), universe));

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -801,7 +801,7 @@ Lattice::Lattice(const int id, const char* name): Universe(id, name) {
  */
 Lattice::~Lattice() {
 
-  for (int i=0; i < _num_x; i++)
+  for (int i=0; i < _num_y; i++)
     _universes.at(i).clear();
 
   _universes.clear();
@@ -1104,7 +1104,8 @@ void Lattice::setUniverses(int num_x, int num_y, Universe** universes) {
 
     _universes.push_back(std::vector< std::pair<int, Universe*> >());
 
-    for (int j = 0; j< _num_x; j++){
+    for (int j = 0; j < _num_x; j++){
+      printf("i = %d, j = %d, index = %d\n", i, j, (_num_y-1-i)*_num_x + j);
       universe = universes[(_num_y-1-i)*_num_x + j];
       _universes.at(i).push_back(std::pair<int, Universe*>
                                  (universe->getId(), universe));


### PR DESCRIPTION
This PR is a bug fix for issue #135. The new implementation allows for the creation of ``Lattices`` with different numbers of ``Universes`` along and x, y dimensions. In addition, the x,y width (or pitch) may now be different for the x and y domains.