### PR TITLE
Modular CMFD surface current tallying

### DIFF
--- a/config.py
+++ b/config.py
@@ -236,7 +236,7 @@ class configuration:
   shared_libraries['icpc'] = ['stdc++', 'iomp5', 'pthread', 'irc',
                               'imf','rt', 'mkl_rt','m',]
   shared_libraries['bgxlc'] = ['stdc++', 'pthread', 'm', 'xlsmp', 'rt']
-  shared_libraries['nvcc'] = ['cudart']
+  shared_libraries['nvcc'] = ['cudadevrt', 'cudart']
 
 
   #############################################################################

--- a/config.py
+++ b/config.py
@@ -128,6 +128,7 @@ class configuration:
                     'src/Material.cpp',
                     'src/Point.cpp',
                     'src/PolarQuad.cpp',
+                    'src/ExpEvaluator.cpp',
                     'src/Solver.cpp',
                     'src/CPUSolver.cpp',
                     'src/Surface.cpp',
@@ -145,6 +146,7 @@ class configuration:
                      'src/Material.cpp',
                      'src/Point.cpp',
                      'src/PolarQuad.cpp',
+                     'src/ExpEvaluator.cpp',
                      'src/Solver.cpp',
                      'src/CPUSolver.cpp',
                      'src/VectorizedSolver.cpp',
@@ -163,6 +165,7 @@ class configuration:
                       'src/Material.cpp',
                       'src/Point.cpp',
                       'src/PolarQuad.cpp',
+                      'src/ExpEvaluator.cpp',
                       'src/Solver.cpp',
                       'src/CPUSolver.cpp',
                       'src/Surface.cpp',
@@ -173,6 +176,7 @@ class configuration:
                       'src/Cmfd.cpp']
 
   sources['nvcc'] = ['openmoc/cuda/openmoc_cuda_wrap.cpp',
+                     'src/ExpEvaluator.cpp',
                      'src/accel/cuda/GPUQuery.cu',
                      'src/accel/cuda/clone.cu',
                      'src/accel/cuda/GPUSolver.cu']

--- a/config.py
+++ b/config.py
@@ -176,7 +176,7 @@ class configuration:
                       'src/Cmfd.cpp']
 
   sources['nvcc'] = ['openmoc/cuda/openmoc_cuda_wrap.cpp',
-                     'src/ExpEvaluator.cpp',
+                     'src/accel/cuda/GPUExpEvaluator.cu',
                      'src/accel/cuda/GPUQuery.cu',
                      'src/accel/cuda/clone.cu',
                      'src/accel/cuda/GPUSolver.cu']
@@ -197,7 +197,8 @@ class configuration:
   compiler_flags['bgxlc'] = ['-c', '-O2', '-qarch=qp', '-qreport',
                              '-qsimd=auto', '-qtune=qp', '-qunroll=auto',
                              '-qsmp=omp', '-qpic']
-  compiler_flags['nvcc'] =  ['-c', '-O3', '--compiler-options', '-fpic',
+  compiler_flags['nvcc'] =  ['--relocatable-device-code', 'true', 
+                             '-c', '-O3', '--compiler-options', '-fpic',
                              '-gencode=arch=compute_20,code=sm_20',
                              '-gencode=arch=compute_30,code=sm_30']
 

--- a/openmoc/bgq/double/openmoc_bgq_double.i
+++ b/openmoc/bgq/double/openmoc_bgq_double.i
@@ -2,6 +2,7 @@
 
 %{
   #define SWIG_FILE_WITH_INIT
+  #include "../../../src/constants.h"
   #include "../../../src/Cell.h"
   #include "../../../src/Geometry.h"
   #include "../../../src/LocalCoords.h"
@@ -247,6 +248,8 @@
 
 
 %include <exception.i>
+%include <std_map.i>
+%include ../../../src/constants.h
 %include ../../../src/Cell.h
 %include ../../../src/Geometry.h
 %include ../../../src/LocalCoords.h

--- a/openmoc/bgq/single/openmoc_bgq_single.i
+++ b/openmoc/bgq/single/openmoc_bgq_single.i
@@ -2,6 +2,7 @@
 
 %{
   #define SWIG_FILE_WITH_INIT
+  #include "../../../src/constants.h"
   #include "../../../src/Cell.h"
   #include "../../../src/Geometry.h"
   #include "../../../src/LocalCoords.h"
@@ -195,6 +196,8 @@
 
 
 %include <exception.i>
+%include <std_map.i>
+%include ../../../src/constants.h
 %include ../../../src/Cell.h
 %include ../../../src/Geometry.h
 %include ../../../src/LocalCoords.h

--- a/openmoc/cuda/double/openmoc_cuda_double.i
+++ b/openmoc/cuda/double/openmoc_cuda_double.i
@@ -2,6 +2,7 @@
 
 %{
   #define SWIG_FILE_WITH_INIT
+  #include "../../../src/constants.h"
   #include "../../../src/Solver.h"
   #include "../../../src/accel/cuda/GPUSolver.h"
   #include "../../../src/accel/cuda/GPUQuery.h"
@@ -52,6 +53,8 @@
 
 
 %include <exception.i>
+%include <std_map.i>
+%include ../../../src/constants.h
 %include ../../../src/Solver.h
 %include ../../../src/accel/cuda/GPUSolver.h
 %include ../../../src/accel/cuda/GPUQuery.h

--- a/openmoc/cuda/openmoc_cuda.i
+++ b/openmoc/cuda/openmoc_cuda.i
@@ -2,6 +2,7 @@
 
 %{
   #define SWIG_FILE_WITH_INIT
+  #include "../../src/constants.h"
   #include "../../src/Solver.h"
   #include "../../src/accel/cuda/GPUSolver.h"
   #include "../../src/accel/cuda/GPUQuery.h"
@@ -51,6 +52,8 @@
 
 
 %include <exception.i>
+%include <std_map.i>
+%include ../../src/constants.h
 %include ../../src/Solver.h
 %include ../../src/accel/cuda/GPUSolver.h
 %include ../../src/accel/cuda/GPUQuery.h

--- a/openmoc/cuda/single/openmoc_cuda_single.i
+++ b/openmoc/cuda/single/openmoc_cuda_single.i
@@ -2,6 +2,7 @@
 
 %{
   #define SWIG_FILE_WITH_INIT
+  #include "../../../src/constants.h"
   #include "../../../src/Solver.h"
   #include "../../../src/accel/cuda/GPUSolver.h"
   #include "../../../src/accel/cuda/GPUQuery.h"
@@ -51,6 +52,8 @@
 
 
 %include <exception.i>
+%include <std_map.i>
+%include ../../../src/constants.h
 %include ../../../src/Solver.h
 %include ../../../src/accel/cuda/GPUSolver.h
 %include ../../../src/accel/cuda/GPUQuery.h

--- a/openmoc/gnu/double/openmoc_gnu_double.i
+++ b/openmoc/gnu/double/openmoc_gnu_double.i
@@ -2,6 +2,7 @@
 
 %{
   #define SWIG_FILE_WITH_INIT
+  #include "../../../src/constants.h"
   #include "../../../src/Cell.h"
   #include "../../../src/Geometry.h"
   #include "../../../src/LocalCoords.h"
@@ -248,6 +249,8 @@
 
 
 %include <exception.i>
+%include <std_map.i>
+%include ../../../src/constants.h
 %include ../../../src/Cell.h
 %include ../../../src/Geometry.h
 %include ../../../src/LocalCoords.h

--- a/openmoc/gnu/single/openmoc_gnu_single.i
+++ b/openmoc/gnu/single/openmoc_gnu_single.i
@@ -2,6 +2,7 @@
 
 %{
   #define SWIG_FILE_WITH_INIT
+  #include "../../../src/constants.h"
   #include "../../../src/Cell.h"
   #include "../../../src/Geometry.h"
   #include "../../../src/LocalCoords.h"
@@ -248,6 +249,8 @@
 
 
 %include <exception.i>
+%include <std_map.i>
+%include ../../../src/constants.h
 %include ../../../src/Cell.h
 %include ../../../src/Geometry.h
 %include ../../../src/LocalCoords.h

--- a/openmoc/intel/double/openmoc_intel_double.i
+++ b/openmoc/intel/double/openmoc_intel_double.i
@@ -2,6 +2,7 @@
 
 %{
   #define SWIG_FILE_WITH_INIT
+  #include "../../../src/constants.h"
   #include "../../../src/Cell.h"
   #include "../../../src/Geometry.h"
   #include "../../../src/LocalCoords.h"
@@ -247,6 +248,8 @@
 
 
 %include <exception.i>
+%include <std_map.i>
+%include ../../../src/constants.h
 %include ../../../src/Cell.h
 %include ../../../src/Geometry.h
 %include ../../../src/LocalCoords.h

--- a/openmoc/intel/single/openmoc_intel_single.i
+++ b/openmoc/intel/single/openmoc_intel_single.i
@@ -2,6 +2,7 @@
 
 %{
   #define SWIG_FILE_WITH_INIT
+  #include "../../../src/constants.h"
   #include "../../../src/Cell.h"
   #include "../../../src/Geometry.h"
   #include "../../../src/LocalCoords.h"
@@ -247,6 +248,8 @@
 
 
 %include <exception.i>
+%include <std_map.i>
+%include ../../../src/constants.h
 %include ../../../src/Cell.h
 %include ../../../src/Geometry.h
 %include ../../../src/LocalCoords.h
@@ -265,4 +268,3 @@
 %include ../../../src/Cmfd.h
 
 typedef float FP_PRECISION;
-

--- a/openmoc/openmoc.i
+++ b/openmoc/openmoc.i
@@ -261,6 +261,16 @@
  * getCellIds method for the data processing routines in openmoc.process */
 %apply (int* ARGOUT_ARRAY1, int DIM1) {(int* cell_ids, int num_cells)}
 
+/* The typemap used to match the method signature for the 
+ * PolarQuad::setSinThetas method. This allows users to set the polar angle 
+ * quadrature sine thetas using a NumPy array */
+%apply (double* IN_ARRAY1, int DIM1) {(double* sin_thetas, int num_polar)}
+
+/* The typemap used to match the method signature for the 
+ * PolarQuad::setWeights method. This allows users to set the polar angle 
+ * quadrature weights using a NumPy array */
+%apply (double* IN_ARRAY1, int DIM1) {(double* weights, int num_polar)}
+
 #endif
 
 

--- a/openmoc/openmoc.i
+++ b/openmoc/openmoc.i
@@ -6,6 +6,7 @@
 
 %{
   #define SWIG_FILE_WITH_INIT
+  #include "../src/constants.h"
   #include "../src/Cell.h"
   #include "../src/Geometry.h"
   #include "../src/boundary_type.h"
@@ -415,6 +416,7 @@
 
 %include <exception.i>
 %include <std_map.i>
+%include ../src/constants.h
 %include ../src/Cell.h
 %include ../src/Geometry.h
 %include ../src/boundary_type.h

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -791,7 +791,7 @@ def plot_energy_fluxes(solver, fsrs, group_bounds=None, norm=True, loglog=True):
   if isinstance(group_bounds, (tuple, list, np.ndarray)):
 
     if not all(low < up for low, up in zip(group_bounds, group_bounds[1:])):
-      py_printf('ERROR', 'Unable to plot hte flux vs. energy since the ' + \
+      py_printf('ERROR', 'Unable to plot the flux vs. energy since the ' + \
                 'energy group bounds are not monotonically increasing')
 
     elif len(group_bounds) != geometry.getNumEnergyGroups()+1:

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -720,7 +720,7 @@ def plot_spatial_fluxes(solver, energy_groups=[1],
     fig = plt.figure()
     plt.imshow(np.flipud(fluxes[index,:,:]), extent=coords['bounds'])
     plt.colorbar()
-    plt.title('FSR Scalar Flux (Group {0}'.format(group))
+    plt.title('FSR Scalar Flux (Group {0})'.format(group))
     filename = directory + 'fsr-flux-group-' + str(group) + '.png'
     fig.savefig(filename, bbox_inches='tight')
     plt.close(fig)

--- a/sample-input/benchmarks/LRA/LRA-cmfd.py
+++ b/sample-input/benchmarks/LRA/LRA-cmfd.py
@@ -231,7 +231,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.setNumThreads(num_threads)
 solver.convergeSource(max_iters)

--- a/sample-input/benchmarks/LRA/LRA.py
+++ b/sample-input/benchmarks/LRA/LRA.py
@@ -221,7 +221,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.setNumThreads(num_threads)
 solver.convergeSource(max_iters)

--- a/sample-input/benchmarks/c5g7/c5g7-cmfd.py
+++ b/sample-input/benchmarks/c5g7/c5g7-cmfd.py
@@ -325,6 +325,11 @@ track_generator.generateTracks()
 solver = CPUSolver(geometry, track_generator)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.setNumThreads(num_threads)
+
+polar_quad = openmoc.LeonardPolarQuad()
+polar_quad.setNumPolarAngles(3)
+solver.setPolarQuadrature(polar_quad)
+
 solver.convergeSource(max_iters)
 solver.printTimerReport()
 

--- a/sample-input/benchmarks/c5g7/c5g7-cmfd.py
+++ b/sample-input/benchmarks/c5g7/c5g7-cmfd.py
@@ -322,7 +322,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.setNumThreads(num_threads)
 solver.convergeSource(max_iters)

--- a/sample-input/benchmarks/c5g7/c5g7-gpu.py
+++ b/sample-input/benchmarks/c5g7/c5g7-gpu.py
@@ -18,7 +18,7 @@ num_azim = options.getNumAzimAngles()
 tolerance = options.getTolerance()
 max_iters = options.getMaxIterations()
 
-log.set_log_level('INFO')
+log.set_log_level('NORMAL')
 
 log.py_printf('TITLE', 'Simulating the OECD\'s C5G7 Benchmark Problem...')
 
@@ -310,6 +310,7 @@ track_generator.generateTracks()
 
 solver = GPUSolver(geometry, track_generator)
 solver.setSourceConvergenceThreshold(tolerance)
+#solver.useExponentialIntrinsic()
 solver.convergeSource(max_iters)
 solver.printTimerReport()
 

--- a/sample-input/benchmarks/c5g7/c5g7-gpu.py
+++ b/sample-input/benchmarks/c5g7/c5g7-gpu.py
@@ -18,7 +18,7 @@ num_azim = options.getNumAzimAngles()
 tolerance = options.getTolerance()
 max_iters = options.getMaxIterations()
 
-log.set_log_level('NORMAL')
+log.set_log_level('INFO')
 
 log.py_printf('TITLE', 'Simulating the OECD\'s C5G7 Benchmark Problem...')
 

--- a/sample-input/benchmarks/c5g7/c5g7-gpu.py
+++ b/sample-input/benchmarks/c5g7/c5g7-gpu.py
@@ -310,7 +310,6 @@ track_generator.generateTracks()
 
 solver = GPUSolver(geometry, track_generator)
 solver.setSourceConvergenceThreshold(tolerance)
-#solver.useExponentialIntrinsic()
 solver.convergeSource(max_iters)
 solver.printTimerReport()
 

--- a/sample-input/benchmarks/c5g7/c5g7-gpu.py
+++ b/sample-input/benchmarks/c5g7/c5g7-gpu.py
@@ -308,7 +308,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = GPUSolver(geometry, track_generator)
+solver = GPUSolver(track_generator)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.convergeSource(max_iters)
 solver.printTimerReport()

--- a/sample-input/benchmarks/c5g7/c5g7.py
+++ b/sample-input/benchmarks/c5g7/c5g7.py
@@ -308,7 +308,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.setNumThreads(num_threads)
 solver.convergeSource(max_iters)

--- a/sample-input/benchmarks/homogeneous-one-group/homogeneous-one-group.py
+++ b/sample-input/benchmarks/homogeneous-one-group/homogeneous-one-group.py
@@ -106,7 +106,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setNumThreads(num_threads)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.convergeSource(max_iters)

--- a/sample-input/benchmarks/homogeneous-two-group/homogeneous-two-groups.py
+++ b/sample-input/benchmarks/homogeneous-two-group/homogeneous-two-groups.py
@@ -106,7 +106,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setNumThreads(num_threads)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.convergeSource(max_iters)

--- a/sample-input/benchmarks/romano/romano.py
+++ b/sample-input/benchmarks/romano/romano.py
@@ -122,7 +122,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setNumThreads(num_threads)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.convergeSource(max_iters)

--- a/sample-input/bundled-lattice/bundled-lattice.py
+++ b/sample-input/bundled-lattice/bundled-lattice.py
@@ -218,7 +218,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setNumThreads(num_threads)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.convergeSource(max_iters)

--- a/sample-input/nested-lattice/nested-lattice.py
+++ b/sample-input/nested-lattice/nested-lattice.py
@@ -155,7 +155,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setNumThreads(num_threads)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.convergeSource(max_iters)

--- a/sample-input/pin-cell/pin-cell.py
+++ b/sample-input/pin-cell/pin-cell.py
@@ -103,7 +103,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setNumThreads(num_threads)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.convergeSource(max_iters)

--- a/sample-input/simple-lattice/simple-lattice.py
+++ b/sample-input/simple-lattice/simple-lattice.py
@@ -144,7 +144,7 @@ track_generator.generateTracks()
 ###########################   Running a Simulation   ##########################
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setNumThreads(num_threads)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.convergeSource(max_iters)

--- a/sample-input/tiny-lattice/tiny-lattice.py
+++ b/sample-input/tiny-lattice/tiny-lattice.py
@@ -121,7 +121,7 @@ track_generator.generateTracks()
 #                            Running a Simulation
 ###############################################################################
 
-solver = CPUSolver(geometry, track_generator)
+solver = CPUSolver(track_generator)
 solver.setNumThreads(num_threads)
 solver.setSourceConvergenceThreshold(tolerance)
 solver.convergeSource(max_iters)

--- a/setup.py
+++ b/setup.py
@@ -376,8 +376,8 @@ def customize_linker(self):
 
     # If the filename for the extension contains cuda, use g++ to link
     if 'cuda' in output_filename:
-      self.set_executable('linker_so', 'g++')
-      self.set_executable('linker_exe', 'g++')
+      self.set_executable('linker_so', 'nvcc')
+      self.set_executable('linker_exe', 'nvcc')
 
     # Now call distutils-defined link method
     super_link(target_desc, objects,

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -630,7 +630,7 @@ void CPUSolver::transportSweep() {
       /* Loop over each Track segment in forward direction */
       for (int s=0; s < num_segments; s++) {
         curr_segment = &segments[s];
-        scalarFluxTally(curr_segment, azim_index, track_flux,
+        tallyScalarFlux(curr_segment, azim_index, track_flux,
                         thread_fsr_flux, true);
       }
 
@@ -642,7 +642,7 @@ void CPUSolver::transportSweep() {
 
       for (int s=num_segments-1; s > -1; s--) {
         curr_segment = &segments[s];
-        scalarFluxTally(curr_segment, azim_index, track_flux,
+        tallyScalarFlux(curr_segment, azim_index, track_flux,
                         thread_fsr_flux, false);
       }
       delete thread_fsr_flux;
@@ -667,7 +667,7 @@ void CPUSolver::transportSweep() {
  * @param fsr_flux a pointer to the temporary FSR flux buffer
  * @param fwd
  */
-void CPUSolver::scalarFluxTally(segment* curr_segment,
+void CPUSolver::tallyScalarFlux(segment* curr_segment,
                                 int azim_index,
                                 FP_PRECISION* track_flux,
                                 FP_PRECISION* fsr_flux,

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -278,24 +278,6 @@ void CPUSolver::buildExpInterpTable() {
 
   log_printf(INFO, "Building exponential interpolation table...");
 
-  FP_PRECISION azim_weight;
-
-  if (_polar_weights != NULL)
-    delete [] _polar_weights;
-
-  _polar_weights = new FP_PRECISION[_num_azim*_num_polar];
-
-  /* Compute the total azimuthal weight for tracks at each polar angle */
-  #pragma omp parallel for private(azim_weight) schedule(guided)
-  for (int i=0; i < _num_azim; i++) {
-
-    azim_weight = _azim_weights[i];
-
-    for (int p=0; p < _num_polar; p++)
-      _polar_weights(i,p) = 
-           azim_weight * _polar_quad->getMultiple(p) * FOUR_PI;
-  }
-
   /* Find largest optical path length track segment */
   FP_PRECISION tau = _track_generator->getMaxOpticalLength();
 

--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -63,7 +63,7 @@ protected:
    * @param fsr_flux a pointer to the temporary FSR scalar flux buffer
    * @param fwd
    */
-  virtual void scalarFluxTally(segment* curr_segment, int azim_index,
+  virtual void tallyScalarFlux(segment* curr_segment, int azim_index,
                                FP_PRECISION* track_flux, FP_PRECISION* fsr_flux,
                                bool fwd);
 

--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -61,11 +61,19 @@ protected:
    * @param azim_index a pointer to the azimuthal angle index for this segment
    * @param track_flux a pointer to the Track's angular flux
    * @param fsr_flux a pointer to the temporary FSR scalar flux buffer
-   * @param fwd
    */
   virtual void tallyScalarFlux(segment* curr_segment, int azim_index,
-                               FP_PRECISION* track_flux, FP_PRECISION* fsr_flux,
-                               bool fwd);
+                               FP_PRECISION* track_flux, FP_PRECISION* fsr_flux);
+
+  /**
+   * @brief Computes the contribution to surface current from a Track segment.
+   * @param curr_segment a pointer to the Track segment of interest
+   * @param azim_index a pointer to the azimuthal angle index for this segment
+   * @param track_flux a pointer to the Track's angular flux
+   * @param fwd the direction of integration along the segment
+   */
+  virtual void tallySurfaceCurrent(segment* curr_segment, int azim_index,
+                                   FP_PRECISION* track_flux, bool fwd);
 
   /**
    * @brief Updates the boundary flux for a Track given boundary conditions.
@@ -77,12 +85,13 @@ protected:
   virtual void transferBoundaryFlux(int track_id, int azim_index,
                                     bool direction,
                                     FP_PRECISION* track_flux);
+
   void addSourceToScalarFlux();
   void computeKeff();
   void transportSweep();
 
 public:
-  CPUSolver(Geometry* geometry=NULL, TrackGenerator* track_generator=NULL);
+  CPUSolver(TrackGenerator* track_generator=NULL);
   virtual ~CPUSolver();
 
   int getNumThreads();
@@ -93,7 +102,6 @@ public:
   void setNumThreads(int num_threads);
 
   void computeFSRFissionRates(double* fission_rates, int num_FSRs);
-
 };
 
 

--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -45,17 +45,12 @@ protected:
   /** OpenMP mutual exclusion locks for atomic FSR scalar flux updates */
   omp_lock_t* _FSR_locks;
 
-  /** OpenMP mutual exclusion locks for atomic surface current updates */
-  omp_lock_t* _cmfd_surface_locks;
-
   void initializeFluxArrays();
   void initializeSourceArrays();
   void initializeFSRs();
-  void initializeCmfd();
 
   void zeroTrackFluxes();
   void flattenFSRFluxes(FP_PRECISION value);
-  void zeroSurfaceCurrents();
   void flattenFSRSources(FP_PRECISION value);
   void normalizeFluxes();
   FP_PRECISION computeFSRSources();
@@ -94,7 +89,6 @@ public:
   FP_PRECISION getFSRScalarFlux(int fsr_id, int energy_group);
   FP_PRECISION* getFSRScalarFluxes();
   FP_PRECISION getFSRSource(int fsr_id, int energy_group);
-  FP_PRECISION* getSurfaceCurrents();
 
   void setNumThreads(int num_threads);
 

--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -50,7 +50,6 @@ protected:
 
   void initializeFluxArrays();
   void initializeSourceArrays();
-  void buildExpInterpTable();
   void initializeFSRs();
   void initializeCmfd();
 
@@ -86,21 +85,6 @@ protected:
   void addSourceToScalarFlux();
   void computeKeff();
   void transportSweep();
-
-  /**
-   * @brief Computes the exponential term in the transport equation for a
-   *        track segment.
-   * @details This method uses either a linear interpolation table (default)
-   *          or the exponential intrinsic exp(...) function if requested by
-   *          the user through a call to the Solver::useExponentialIntrinsic()
-   *          routine.
-   * @param sigma_t the total group cross-section at this energy
-   * @param length the length of the Track segment projected in the xy-plane
-   * @param p the polar angle index
-   * @return the evaluated exponential
-   */
-  virtual FP_PRECISION computeExponential(FP_PRECISION sigma_t,
-                                          FP_PRECISION length, int p);
 
 public:
   CPUSolver(Geometry* geometry=NULL, TrackGenerator* track_generator=NULL);

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -1185,7 +1185,7 @@ void Cmfd::tallySurfaceCurrent(segment* curr_segment,
     omp_set_lock(&_surface_locks[curr_segment->_cmfd_surface_bwd]);
 
     /* Increment current (polar and azimuthal weighted flux, group) */
-    _surface_currents(curr_segment->_cmfd_surface_fwd, e) += current;
+    _surface_currents(curr_segment->_cmfd_surface_bwd, e) += current;
 
     /* Release Cmfd Mesh surface mutual exclusion lock */
     omp_unset_lock(&_surface_locks[curr_segment->_cmfd_surface_bwd]);

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -43,9 +43,10 @@ Cmfd::Cmfd() {
   _new_source = NULL;
   _group_indices = NULL;
   _group_indices_map = NULL;
+  _surface_currents = NULL;
+  _surface_locks = NULL;
 
   /* Initialize boundaries to be reflective */
-	//  _boundaries = new int[4];
   _boundaries = new boundaryType[4];
   _boundaries[0] = REFLECTIVE;
   _boundaries[1] = REFLECTIVE;
@@ -89,6 +90,13 @@ Cmfd::~Cmfd() {
 
   if (_new_source != NULL)
     delete [] _new_source;
+
+  if (_surface_locks != NULL)
+    delete [] _surface_locks;
+
+  if (_surface_currents != NULL)
+    delete [] _surface_currents;
+
 }
 
 
@@ -1152,6 +1160,93 @@ void Cmfd::initializeMaterials(){
 }
 
 
+//FIXME
+void Cmfd::tallySurfaceCurrent(segment* curr_segment, 
+                               FP_PRECISION current, bool fwd, int e) {
+
+  //FIXME: Can this be simplified???
+  if (curr_segment->_cmfd_surface_fwd != -1 && fwd){
+
+    /* Atomically increment the Cmfd Mesh surface current from the
+     * temporary array using mutual exclusion locks */
+    omp_set_lock(&_surface_locks[curr_segment->_cmfd_surface_fwd]);
+
+    /* Increment current (polar and azimuthal weighted flux, group) */
+    _surface_currents(curr_segment->_cmfd_surface_fwd, e) += current;
+
+    /* Release Cmfd Mesh surface mutual exclusion lock */
+    omp_unset_lock(&_surface_locks[curr_segment->_cmfd_surface_fwd]);
+
+  }
+  else if (curr_segment->_cmfd_surface_bwd != -1 && !fwd){
+
+    /* Atomically increment the Cmfd Mesh surface current from the
+     * temporary array using mutual exclusion locks */
+    omp_set_lock(&_surface_locks[curr_segment->_cmfd_surface_bwd]);
+
+    /* Increment current (polar and azimuthal weighted flux, group) */
+    _surface_currents(curr_segment->_cmfd_surface_fwd, e) += current;
+
+    /* Release Cmfd Mesh surface mutual exclusion lock */
+    omp_unset_lock(&_surface_locks[curr_segment->_cmfd_surface_bwd]);
+  }
+}
+
+
+//FIXME
+/**
+ * @brief Set the Cmfd Mesh surface currents for each Mesh cell and energy
+ *        group to zero.
+ */
+void Cmfd::zeroSurfaceCurrents() {
+
+  #pragma omp parallel for schedule(guided)
+  for (int r=0; r < _num_x*_num_y; r++) {
+    for (int s=0; s < 8; s++) {
+      for (int e=0; e < _num_moc_groups; e++)
+        _surface_currents(r*8+s,e) = 0.0;
+    }
+  }
+
+  return;
+}
+
+
+
+//FIXME
+/*
+ * @brief Initializes Cmfd object for acceleration prior to source iteration.
+ * @details Instantiates a dummy Cmfd object if one was not assigned to
+ *          the Solver by the user and initializes FSRs, Materials, fluxes
+ *          and the Mesh. This method intializes a global array for the
+ *          surface currents.
+ */
+void Cmfd::initializeSurfaceCurrents() {
+
+  /* Delete old Cmfd surface currents array it it exists */
+  if (_surface_currents != NULL)
+    delete [] _surface_currents;
+
+  if (_surface_locks != NULL)
+    delete [] _surface_locks;
+
+  /* Allocate memory for the Cmfd Mesh surface currents array */
+  int num_mesh_cells = _num_x * _num_y;
+  int size = num_mesh_cells * _num_cmfd_groups * 8;
+  _surface_currents = new FP_PRECISION[size];
+
+  /* Allocate memory for OpenMP locks for each Cmfd Mesh surface */ 
+  _surface_locks = new omp_lock_t[num_mesh_cells * 8];
+
+  /* Loop over all mesh cell surfaces to initialize OpenMP locks */
+  #pragma omp parallel for schedule(guided)
+  for (int r=0; r < num_mesh_cells * 8; r++)
+    omp_init_lock(&_surface_locks[r]);
+
+  return;
+}
+
+
 /**
  * @brief Initializes the vector of vectors that links CMFD cells with FSRs.
  * @details This method is called by the geometry once the CMFD mesh has been
@@ -1285,15 +1380,6 @@ int Cmfd::getNumMOCGroups(){
  */
 int Cmfd::getNumCells(){
   return _num_x*_num_y;
-}
-
-
-/**
- * @brief Set the pointer to the Mesh surface currents array.
- * @param pointer to the surface currents array
- */
-void Cmfd::setSurfaceCurrents(FP_PRECISION* surface_currents){
-  _surface_currents = surface_currents;
 }
 
 

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -28,6 +28,12 @@
 #endif
 
 
+/** Indexing macro for the surface currents for each CMFD Mesh surface and
+ *  each energy group */
+#define _surface_currents(r,e) (_surface_currents[(r)*_num_cmfd_groups \
+						  + getCmfdGroup((e))])
+
+
 /**
  * @class Cmfd Cmfd.h "src/Cmfd.h"
  * @brief A class for Coarse Mesh Finite Difference (CMFD) acceleration.
@@ -119,11 +125,13 @@ private:
   double _cell_height;
 
   /** Array of geometry boundaries */
-	//  int* _boundaries;
   boundaryType* _boundaries;
 
   /** Array of surface currents for each CMFD cell */
   FP_PRECISION* _surface_currents;
+
+  /** OpenMP mutual exclusion locks for atomic surface current updates */
+  omp_lock_t* _surface_locks;
 
   /** Vector of vectors of FSRs containing in each cell */
   std::vector< std::vector<int> > _cell_fsrs;
@@ -156,6 +164,7 @@ public:
   void initializeGroupMap();
   void initializeFlux();
   void initializeMaterials();
+  void initializeSurfaceCurrents();
   void rescaleFlux();
   void linearSolve(FP_PRECISION** mat, FP_PRECISION* vec_x, FP_PRECISION* vec_b,
                    FP_PRECISION conv, int max_iter=10000);
@@ -166,6 +175,10 @@ public:
   void addFSRToCell(int cmfd_cell, int fsr_id);
   void updateBoundaryFlux(Track** tracks, FP_PRECISION* boundary_flux, 
                           int num_tracks);
+  //FIXME
+  void tallySurfaceCurrent(segment* curr_segment, 
+                           FP_PRECISION current, bool fwd, int e);
+  void zeroSurfaceCurrents();
 
   /* Get parameters */
   int getNumCmfdGroups();
@@ -189,7 +202,6 @@ public:
   void setHeight(double height);
   void setNumX(int num_x);
   void setNumY(int num_y);
-  void setSurfaceCurrents(FP_PRECISION* surface_currents);
   void setNumFSRs(int num_fsrs);
   void setNumMOCGroups(int num_moc_groups);
   void setOpticallyThick(bool thick);

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -165,6 +165,7 @@ public:
   void initializeFlux();
   void initializeMaterials();
   void initializeSurfaceCurrents();
+
   void rescaleFlux();
   void linearSolve(FP_PRECISION** mat, FP_PRECISION* vec_x, FP_PRECISION* vec_b,
                    FP_PRECISION conv, int max_iter=10000);
@@ -175,10 +176,9 @@ public:
   void addFSRToCell(int cmfd_cell, int fsr_id);
   void updateBoundaryFlux(Track** tracks, FP_PRECISION* boundary_flux, 
                           int num_tracks);
-  //FIXME
-  void tallySurfaceCurrent(segment* curr_segment, 
-                           FP_PRECISION current, bool fwd, int e);
   void zeroSurfaceCurrents();
+  void tallySurfaceCurrent(segment* curr_segment, FP_PRECISION current, 
+                           bool fwd, int e);
 
   /* Get parameters */
   int getNumCmfdGroups();

--- a/src/ExpEvaluator.cpp
+++ b/src/ExpEvaluator.cpp
@@ -3,6 +3,8 @@
 
 /**
  * @brief Constructor initializes array pointers to NULL.
+ * @details The constructor sets the interpolation scheme as the default
+ *          for computing exponentials.
  */
 ExpEvaluator::ExpEvaluator() { 
   _interpolate = true;
@@ -22,6 +24,7 @@ ExpEvaluator::~ExpEvaluator() {
 
 /**
  * @brief Set the PolarQuad to use when computing exponentials.
+ * @param polar_quad a PolarQuad object pointer
  */
 void ExpEvaluator::setPolarQuadrature(PolarQuad* polar_quad) {
   _polar_quad = polar_quad;
@@ -69,7 +72,8 @@ FP_PRECISION ExpEvaluator::getTableSpacing() {
 
 
 /**
- *
+ * @brief Get the number of entries in the exponential interpolation table.
+ * @param entries in the interpolation table
  *
  */
 int ExpEvaluator::getTableSize() {

--- a/src/ExpEvaluator.cpp
+++ b/src/ExpEvaluator.cpp
@@ -5,6 +5,7 @@
  * @brief Constructor initializes array pointers to NULL.
  */
 ExpEvaluator::ExpEvaluator() { 
+  _interpolate = true;
   _exp_table = NULL;
   _polar_quad = NULL;
 }

--- a/src/ExpEvaluator.h
+++ b/src/ExpEvaluator.h
@@ -20,7 +20,9 @@
  * @class ExpEvaluator ExpEvaluator.h "src/ExpEvaluator.h"
  * @brief This is a class for evaluating exponentials.
  * @details The ExpEvaluator includes different algorithms to evaluate
- *          exponentials with varying degrees of accuracy and speed.
+ *          exponentials with varying degrees of accuracy and speed. This
+ *          is a helper class for the Solver and its subclasses and it not
+ *          intended to be initialized as a standalone object.
  */
 class ExpEvaluator {
 
@@ -83,4 +85,4 @@ inline int round_to_int(double x) {
 }
 
 
-#endif /* EXPEVALUATOR_H_ */
+ #endif /* EXPEVALUATOR_H_ */

--- a/src/ExpEvaluator.h
+++ b/src/ExpEvaluator.h
@@ -1,0 +1,98 @@
+/**
+ * @file ExpEvaluator.h
+ * @brief The ExpEvaluator class.
+ * @date April 9, 2015.
+ * @author William Boyd, MIT, Course 22 (wboyd@mit.edu)
+ */
+
+#ifndef EXPEVALUATOR_H_
+#define EXPEVALUATOR_H_
+
+#ifdef __cplusplus
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include "log.h"
+#include "PolarQuad.h"
+#endif
+
+//FIXME
+#ifdef NVCC
+#define CUDA_CALLABLE __host__ __device__
+#else
+#define CUDA_CALLABLE
+#endif
+
+
+/**
+ * @class ExpEvaluator ExpEvaluator.h "src/ExpEvaluator.h"
+ * @brief This is a class for evaluating exponentials.
+ * @details The ExpEvaluator includes different algorithms to evaluate
+ *          exponentials with varying degrees of accuracy and speed.
+ */
+class ExpEvaluator {
+
+private:
+
+  /** A boolean indicating whether or not to use linear interpolation */
+  bool _interpolate_exponential;
+
+  /** The exponential linear interpolation table */
+  FP_PRECISION* _exp_table;
+
+  /** The spacing for the exponential linear interpolation table */
+  FP_PRECISION _exp_table_spacing;
+
+  /** The inverse spacing for the exponential linear interpolation table */
+  FP_PRECISION _inverse_exp_table_spacing;
+
+  /** The PolarQuad object of interest */
+  PolarQuad* _polar_quad;
+
+  /** Twice the number of polar angles */
+  int _two_times_num_polar;
+  
+public:
+
+  ExpEvaluator();
+  virtual ~ExpEvaluator();
+
+  void setPolarQuadrature(PolarQuad* polar_quad);
+  void useExponentialInterpolation();
+  void useExponentialIntrinsic();
+
+  bool isUsingExponentialInterpolation();
+
+  void initialize(double max_tau, double tolerance);
+  FP_PRECISION computeExponential(FP_PRECISION tau, int polar);
+};
+
+
+/**
+ * @brief Rounds a single precision floating point value to an integer.
+ * @param x a float precision floating point value
+ * @brief the rounded integer value
+ */
+CUDA_CALLABLE inline int round_to_int(float x) {
+#ifdef NVCC
+  return __float2int_rd(x);
+#else
+  return lrintf(x);
+#endif
+}
+
+
+/**
+ * @brief Rounds a double precision floating point value to an integer.
+ * @param x a double precision floating point value
+ * @brief the rounded integer value
+ */
+CUDA_CALLABLE inline int round_to_int(double x) {
+#ifdef NVCC
+  return __double2int_rd(x);
+#else
+  return lrint(x);
+#endif
+}
+
+
+#endif /* EXPEVALUATOR_H_ */

--- a/src/ExpEvaluator.h
+++ b/src/ExpEvaluator.h
@@ -45,6 +45,9 @@ private:
 
   /** Twice the number of polar angles */
   int _two_times_num_polar;
+
+  int round_to_int(float x);
+  int round_to_int(double x);
   
 public:
 
@@ -70,7 +73,7 @@ public:
  * @param x a float precision floating point value
  * @brief the rounded integer value
  */
-inline int round_to_int(float x) {
+inline int ExpEvaluator::round_to_int(float x) {
   return lrintf(x);
 }
 
@@ -80,7 +83,7 @@ inline int round_to_int(float x) {
  * @param x a double precision floating point value
  * @brief the rounded integer value
  */
-inline int round_to_int(double x) {
+inline int ExpEvaluator::round_to_int(double x) {
   return lrint(x);
 }
 

--- a/src/ExpEvaluator.h
+++ b/src/ExpEvaluator.h
@@ -45,9 +45,6 @@ private:
 
   /** Twice the number of polar angles */
   int _two_times_num_polar;
-
-  int round_to_int(float x);
-  int round_to_int(double x);
   
 public:
 
@@ -73,7 +70,7 @@ public:
  * @param x a float precision floating point value
  * @brief the rounded integer value
  */
-inline int ExpEvaluator::round_to_int(float x) {
+inline int round_to_int(float x) {
   return lrintf(x);
 }
 
@@ -83,7 +80,7 @@ inline int ExpEvaluator::round_to_int(float x) {
  * @param x a double precision floating point value
  * @brief the rounded integer value
  */
-inline int ExpEvaluator::round_to_int(double x) {
+inline int round_to_int(double x) {
   return lrint(x);
 }
 

--- a/src/ExpEvaluator.h
+++ b/src/ExpEvaluator.h
@@ -15,13 +15,6 @@
 #include "PolarQuad.h"
 #endif
 
-//FIXME
-#ifdef NVCC
-#define CUDA_CALLABLE __host__ __device__
-#else
-#define CUDA_CALLABLE
-#endif
-
 
 /**
  * @class ExpEvaluator ExpEvaluator.h "src/ExpEvaluator.h"
@@ -34,16 +27,16 @@ class ExpEvaluator {
 private:
 
   /** A boolean indicating whether or not to use linear interpolation */
-  bool _interpolate_exponential;
-
-  /** The exponential linear interpolation table */
-  FP_PRECISION* _exp_table;
-
-  /** The spacing for the exponential linear interpolation table */
-  FP_PRECISION _exp_table_spacing;
+  bool _interpolate;
 
   /** The inverse spacing for the exponential linear interpolation table */
   FP_PRECISION _inverse_exp_table_spacing;
+
+  /** The number of entries in the exponential linear interpolation table */
+  int _table_size;
+
+  /** The exponential linear interpolation table */
+  FP_PRECISION* _exp_table;
 
   /** The PolarQuad object of interest */
   PolarQuad* _polar_quad;
@@ -57,10 +50,13 @@ public:
   virtual ~ExpEvaluator();
 
   void setPolarQuadrature(PolarQuad* polar_quad);
-  void useExponentialInterpolation();
-  void useExponentialIntrinsic();
+  void useInterpolation();
+  void useIntrinsic();
 
-  bool isUsingExponentialInterpolation();
+  bool isUsingInterpolation();
+  FP_PRECISION getTableSpacing();
+  int getTableSize();
+  FP_PRECISION* getExpTable();
 
   void initialize(double max_tau, double tolerance);
   FP_PRECISION computeExponential(FP_PRECISION tau, int polar);
@@ -72,12 +68,8 @@ public:
  * @param x a float precision floating point value
  * @brief the rounded integer value
  */
-CUDA_CALLABLE inline int round_to_int(float x) {
-#ifdef NVCC
-  return __float2int_rd(x);
-#else
+inline int round_to_int(float x) {
   return lrintf(x);
-#endif
 }
 
 
@@ -86,12 +78,8 @@ CUDA_CALLABLE inline int round_to_int(float x) {
  * @param x a double precision floating point value
  * @brief the rounded integer value
  */
-CUDA_CALLABLE inline int round_to_int(double x) {
-#ifdef NVCC
-  return __double2int_rd(x);
-#else
+inline int round_to_int(double x) {
   return lrint(x);
-#endif
 }
 
 

--- a/src/Material.h
+++ b/src/Material.h
@@ -13,12 +13,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
+#include "constants.h"
 #include "log.h"
 #endif
-
-/** A negligible cross-section value to over-ride user-defined
- *  cross-sections very near zero (e.g., within (-1E-10, 1E-10)) */
-#define ZERO_SIGMA_T 1E-10
 
 #ifdef ICPC
 /** Word-aligned memory allocation for Intel's compiler */
@@ -36,12 +33,6 @@
 #define MM_MALLOC(size,alignment) malloc(size)
 
 #endif
-
-/** Error threshold for determining how close the sum of \f$ \Sigma_a \f$
- *  and \f$ \Sigma_s \f$ must match that of \f$ \Sigma_t \f$ for each energy
- *  group
- */
-#define SIGMA_T_THRESH 1E-3
 
 
 int material_id();

--- a/src/PolarQuad.cpp
+++ b/src/PolarQuad.cpp
@@ -158,7 +158,7 @@ void PolarQuad::setNumPolarAngles(const int num_polar) {
  * @brief Set the PolarQuad's array of sines of each polar angle.
  * @details This method is a helper function to allow OpenMOC users to assign
  *          the PolarQuad's sin thetas in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the number of polar angles) as input to this function. This
  *          function then fills the NumPy array with the data values for the
  *          PolarQuad's sin thetas. An example of how this function might be
@@ -188,9 +188,12 @@ void PolarQuad::setSinThetas(double* sin_thetas, int num_polar) {
   _sin_thetas = new FP_PRECISION[_num_polar];
 
   /* Extract sin thetas from user input */
-  for (int p=0; p < _num_polar; p++)
+  for (int p=0; p < _num_polar; p++) {
+    if (sin_thetas[p] < 0. || sin_thetas[p] > 1.)
+      log_printf(ERROR, "Unable to set sin theta to %f which is "
+                 "not in the range [0,1]", sin_thetas[p]);
     _sin_thetas[p] = FP_PRECISION(sin_thetas[p]);
-
+  }
 }
 
 
@@ -198,7 +201,7 @@ void PolarQuad::setSinThetas(double* sin_thetas, int num_polar) {
  * @brief Set the PolarQuad's array of weights for each angle.
  * @details This method is a helper function to allow OpenMOC users to assign
  *          the PolarQuad's angular weights in Python. A user must initialize a
- *          NumPy array of the correct size (i.e., a float64 array the length
+ *          NumPy array of the correct size (e.g., a float64 array the length
  *          of the number of polar angles) as input to this function. This
  *          function then fills the NumPy array with the data values for the
  *          PolarQuad's weights. An example of how this function might be
@@ -302,7 +305,7 @@ std::string PolarQuad::toString() {
       string << _weights[p] << ", ";
   }
 
-  string << "\n\tmultiples= ";
+  string << "\n\tmultiples = ";
   if (_multiples != NULL) {
     for (int p = 0; p < _num_polar; p++)
       string << _multiples[p] << ", ";

--- a/src/PolarQuad.cpp
+++ b/src/PolarQuad.cpp
@@ -5,7 +5,6 @@
  * @brief Dummy constructor sets the default number of angles to zero.
  */
 PolarQuad::PolarQuad() {
-
   _num_polar = 0;
   _sin_thetas = NULL;
   _weights = NULL;
@@ -48,8 +47,12 @@ int PolarQuad::getNumPolarAngles() const {
 FP_PRECISION PolarQuad::getSinTheta(const int n) const {
 
   if (n < 0 || n >= _num_polar)
-    log_printf(ERROR, "Attempted to retrieve sin theta for polar angle = %d"
-               " but only %d polar angles are defined", n, _num_polar);
+    log_printf(ERROR, "Attempted to retrieve sin theta for polar angle = "
+               "%d but only %d polar angles are defined", n, _num_polar);
+
+  else if (_sin_thetas == NULL)
+    log_printf(ERROR, "Attempted to retrieve sin theta for polar angle = %d "
+               "but the sin thetas have not been initialized", n);
 
   return _sin_thetas[n];
 }
@@ -63,8 +66,12 @@ FP_PRECISION PolarQuad::getSinTheta(const int n) const {
 FP_PRECISION PolarQuad::getWeight(const int n) const {
 
   if (n < 0 || n >= _num_polar)
-    log_printf(ERROR, "Attempted to retrieve the weight for polar angle = %d "
-               "but only %d polar angles are defined", n, _num_polar);
+    log_printf(ERROR, "Attempted to retrieve the weight for polar angle = "
+               "%d but only %d polar angles are defined", n, _num_polar);
+
+  else if (_weights == NULL)
+    log_printf(ERROR, "Attempted to retrieve weight for polar angle = %d "
+               "but the weights have not been initialized", n);
 
   return _weights[n];
 }
@@ -79,8 +86,12 @@ FP_PRECISION PolarQuad::getWeight(const int n) const {
 FP_PRECISION PolarQuad::getMultiple(const int n) const {
 
   if (n < 0 || n >= _num_polar)
-    log_printf(ERROR, "Attempted to retrieve the multiple for polar angle = %d"
-               "but only %d polar angles are defined", n, _num_polar);
+    log_printf(ERROR, "Attempted to retrieve the multiple for polar angle = "
+               "%d but only %d polar angles are defined", n, _num_polar);
+
+  else if (_multiples == NULL)
+    log_printf(ERROR, "Attempted to retrieve multiple for polar angle = %d "
+               "but the multiples have not been initialized", n);
 
   return _multiples[n];
 }
@@ -91,6 +102,11 @@ FP_PRECISION PolarQuad::getMultiple(const int n) const {
  * @return a pointer to the array of \f$ sin\theta_{p} \f$
  */
 FP_PRECISION* PolarQuad::getSinThetas() {
+
+  if (_sin_thetas == NULL)
+    log_printf(ERROR, "Attempted to retrieve the sin thetas array "
+               "but it has not been initialized");
+
   return _sin_thetas;
 }
 
@@ -100,6 +116,11 @@ FP_PRECISION* PolarQuad::getSinThetas() {
  * @return a pointer to the polar weights array
  */
 FP_PRECISION* PolarQuad::getWeights() {
+
+  if (_weights == NULL)
+    log_printf(ERROR, "Attempted to retrieve the weights array "
+               "but it has not been initialized");
+
   return _weights;
 }
 
@@ -110,6 +131,11 @@ FP_PRECISION* PolarQuad::getWeights() {
  * @return a pointer to the multiples array
  */
 FP_PRECISION* PolarQuad::getMultiples() {
+
+  if (_multiples == NULL)
+    log_printf(ERROR, "Attempted to retrieve the multiples array "
+               "but it has not been initialized");
+
   return _multiples;
 }
 
@@ -224,7 +250,8 @@ void PolarQuad::initialize() {
     log_printf(ERROR, "Unable to initialize PolarQuad with zero polar angles. "
                "Set the number of polar angles before initialization.");
 
-  return;
+  if (_sin_thetas != NULL && _weights != NULL)
+    precomputeMultiples();
 }
 
 

--- a/src/PolarQuad.cpp
+++ b/src/PolarQuad.cpp
@@ -148,7 +148,7 @@ void PolarQuad::setNumPolarAngles(const int num_polar) {
  * @param sin_thetas the array of sines of each polar angle
  * @param num_polar the number of polar angles
  */
-void PolarQuad::setSinThetas(FP_PRECISION* sin_thetas, int num_polar) {
+void PolarQuad::setSinThetas(double* sin_thetas, int num_polar) {
 
   if (_num_polar != num_polar)
     log_printf(ERROR, "Unable to set %d sin thetas for PolarQuad "
@@ -188,7 +188,7 @@ void PolarQuad::setSinThetas(FP_PRECISION* sin_thetas, int num_polar) {
  * @param weights the array of weights for each polar angle
  * @param num_polar the number of polar angles
  */
-void PolarQuad::setWeights(FP_PRECISION* weights, int num_polar) {
+void PolarQuad::setWeights(double* weights, int num_polar) {
 
   if (_num_polar != num_polar)
     log_printf(ERROR, "Unable to set %d weights for PolarQuad "
@@ -317,8 +317,8 @@ void TYPolarQuad::initialize() {
   PolarQuad::initialize();
 
   /* Allocate temporary arrays for tabulated quadrature values */
-  FP_PRECISION* sin_thetas = new FP_PRECISION[_num_polar];
-  FP_PRECISION* weights = new FP_PRECISION[_num_polar];
+  double* sin_thetas = new double[_num_polar];
+  double* weights = new double[_num_polar];
 
   /* Tabulated values for the sine thetas and weights for the
    * Tabuchi-Yamamoto polar angle quadrature */
@@ -387,8 +387,8 @@ void LeonardPolarQuad::initialize() {
   PolarQuad::initialize();
 
   /* Allocate temporary arrays for tabulated quadrature values */
-  FP_PRECISION* sin_thetas = new FP_PRECISION[_num_polar];
-  FP_PRECISION* weights = new FP_PRECISION[_num_polar];
+  double* sin_thetas = new double[_num_polar];
+  double* weights = new double[_num_polar];
 
   /* Tabulated values for the sine thetas and weights for the
    * Leonard polar angle quadrature */
@@ -453,8 +453,8 @@ void GLPolarQuad::initialize() {
   PolarQuad::initialize();
 
   /* Allocate temporary arrays for tabulated quadrature values */
-  FP_PRECISION* sin_thetas = new FP_PRECISION[_num_polar];
-  FP_PRECISION* weights = new FP_PRECISION[_num_polar];
+  double* sin_thetas = new double[_num_polar];
+  double* weights = new double[_num_polar];
 
   /* Tabulated values for the sine thetas and weights for the
    * Leonard polar angle quadrature */
@@ -552,8 +552,8 @@ void EqualWeightPolarQuad::initialize() {
   PolarQuad::initialize();
 
   /* Allocate temporary arrays for tabulated quadrature values */
-  FP_PRECISION* sin_thetas = new FP_PRECISION[_num_polar];
-  FP_PRECISION* weights = new FP_PRECISION[_num_polar];
+  double* sin_thetas = new double[_num_polar];
+  double* weights = new double[_num_polar];
 
   double sin_theta_a, sin_theta_b;
   sin_theta_a = 1.;
@@ -606,8 +606,8 @@ void EqualAnglePolarQuad::initialize() {
   PolarQuad::initialize();
 
   /* Allocate temporary arrays for tabulated quadrature values */
-  FP_PRECISION* sin_thetas = new FP_PRECISION[_num_polar];
-  FP_PRECISION* weights = new FP_PRECISION[_num_polar];
+  double* sin_thetas = new double[_num_polar];
+  double* weights = new double[_num_polar];
 
   double sin_theta_a, sin_theta_b;
   double theta_a, theta_b;

--- a/src/PolarQuad.cpp
+++ b/src/PolarQuad.cpp
@@ -459,39 +459,39 @@ void GLPolarQuad::initialize() {
   /* Tabulated values for the sine thetas and weights for the
    * Leonard polar angle quadrature */
   if (_num_polar == 1) {
-    sin_thetas[0] = 0.5773502691;
+    sin_thetas[0] = sin(acos(0.5773502691));
     weights[0] = 1.0;
   }
   else if (_num_polar == 2) {
-    sin_thetas[0] = 0.3399810435;
-    sin_thetas[1] = 0.8611363115;
+    sin_thetas[0] = sin(acos(0.3399810435));
+    sin_thetas[1] = sin(acos(0.8611363115));
     weights[0] = 0.6521451549;
     weights[1] = 0.3478548451;
   }
   else if (_num_polar == 3) {
-    sin_thetas[0] = 0.2386191860;
-    sin_thetas[1] = 0.6612093864;
-    sin_thetas[2] = 0.9324695142;
+    sin_thetas[0] = sin(acos(0.2386191860));
+    sin_thetas[1] = sin(acos(0.6612093864));
+    sin_thetas[2] = sin(acos(0.9324695142));
     weights[0] = 0.4679139346;
     weights[1] = 0.3607615730;
     weights[2] = 0.1713244924;
   }
   else if (_num_polar == 4) {
-    sin_thetas[0] = 0.1834346424;
-    sin_thetas[1] = 0.5255324099;
-    sin_thetas[2] = 0.7966664774;
-    sin_thetas[3] = 0.9602898564;
+    sin_thetas[0] = sin(acos(0.1834346424));
+    sin_thetas[1] = sin(acos(0.5255324099));
+    sin_thetas[2] = sin(acos(0.7966664774));
+    sin_thetas[3] = sin(acos(0.9602898564));
     weights[0] = 0.3626837834;
     weights[1] = 0.3137066459;
     weights[2] = 0.2223810344;
     weights[3] = 0.1012285363;
   }
   else if (_num_polar == 5) {
-    sin_thetas[0] = 0.1488743387;
-    sin_thetas[1] = 0.4333953941;
-    sin_thetas[2] = 0.6794095682;
-    sin_thetas[3] = 0.8650633666;
-    sin_thetas[4] = 0.9739065285;
+    sin_thetas[0] = sin(acos(0.1488743387));
+    sin_thetas[1] = sin(acos(0.4333953941));
+    sin_thetas[2] = sin(acos(0.6794095682));
+    sin_thetas[3] = sin(acos(0.8650633666));
+    sin_thetas[4] = sin(acos(0.9739065285));
     weights[0] = 0.2955242247;
     weights[1] = 0.2692667193;
     weights[2] = 0.2190863625;
@@ -499,12 +499,12 @@ void GLPolarQuad::initialize() {
     weights[4] = 0.0666713443;
   }
   else if (_num_polar == 6) {
-    sin_thetas[0] = 0.1252334085;
-    sin_thetas[1] = 0.3678314989;
-    sin_thetas[2] = 0.5873179542;
-    sin_thetas[3] = 0.7699026741;
-    sin_thetas[4] = 0.9041172563;
-    sin_thetas[5] = 0.9815606342;
+    sin_thetas[0] = sin(acos(0.1252334085));
+    sin_thetas[1] = sin(acos(0.3678314989));
+    sin_thetas[2] = sin(acos(0.5873179542));
+    sin_thetas[3] = sin(acos(0.7699026741));
+    sin_thetas[4] = sin(acos(0.9041172563));
+    sin_thetas[5] = sin(acos(0.9815606342));
     weights[0] = 0.2491470458;
     weights[1] = 0.2334925365;
     weights[2] = 0.2031674267;
@@ -555,16 +555,16 @@ void EqualWeightPolarQuad::initialize() {
   double* sin_thetas = new double[_num_polar];
   double* weights = new double[_num_polar];
 
-  double sin_theta_a, sin_theta_b;
-  sin_theta_a = 1.;
+  double cos_theta_a, cos_theta_b;
+  cos_theta_a = 1.;
 
   /* Generate the sin thetas and weights using equations 420-422 of the
    * DOE Nucl. Eng. Handbook "Lattice Physics Computations" */
   for (int p=0; p < _num_polar; p++) {
-    sin_theta_b = sin_theta_a - (1. / _num_polar);
-    sin_thetas[p] = 0.5 * (sin_theta_a + sin_theta_b);
-    weights[p] = sin_theta_a - sin_theta_b;
-    sin_theta_a = sin_theta_b;
+    cos_theta_b = cos_theta_a - (1. / _num_polar);
+    sin_thetas[p] = sin(acos(0.5 * (cos_theta_a + cos_theta_b)));
+    weights[p] = cos_theta_a - cos_theta_b;
+    cos_theta_a = cos_theta_b;
   }
 
   /* Set the arrays of sin thetas and weights */
@@ -609,7 +609,7 @@ void EqualAnglePolarQuad::initialize() {
   double* sin_thetas = new double[_num_polar];
   double* weights = new double[_num_polar];
 
-  double sin_theta_a, sin_theta_b;
+  double cos_theta_a, cos_theta_b;
   double theta_a, theta_b;
   double delta_theta = M_PI / (2. * _num_polar);
   theta_a = 0.;
@@ -618,10 +618,10 @@ void EqualAnglePolarQuad::initialize() {
    * DOE Nucl. Eng. Handbook "Lattice Physics Computations" */
   for (int p=0; p < _num_polar; p++) {
     theta_b = theta_a + delta_theta;
-    sin_theta_a = cos(theta_a);
-    sin_theta_b = cos(theta_b);
-    sin_thetas[p] = 0.5 * (sin_theta_a + sin_theta_b);
-    weights[p] = sin_theta_a - sin_theta_b;
+    cos_theta_a = cos(theta_a);
+    cos_theta_b = cos(theta_b);
+    sin_thetas[p] = sin(acos((0.5 * (cos_theta_a + cos_theta_b))));
+    weights[p] = cos_theta_a - cos_theta_b;
     theta_a = theta_b;
   }
 

--- a/src/PolarQuad.h
+++ b/src/PolarQuad.h
@@ -14,12 +14,9 @@
 
 #ifdef __cplusplus
 #include <sstream>
+#include "constants.h"
 #include "log.h"
 #endif
-
-
-/** Tolerance for difference of the sum of polar weights with respect to 1.0 */
-#define POLAR_WEIGHT_SUM_TOL 1E-5
 
 
 /**

--- a/src/PolarQuad.h
+++ b/src/PolarQuad.h
@@ -58,8 +58,8 @@ public:
   FP_PRECISION* getMultiples();
 
   virtual void setNumPolarAngles(const int num_polar);
-  void setSinThetas(FP_PRECISION* sin_thetas, int num_polar);
-  void setWeights(FP_PRECISION* weights, int num_polar);
+  void setSinThetas(double* sin_thetas, int num_polar);
+  void setWeights(double* weights, int num_polar);
 
   virtual void initialize();
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -223,7 +223,7 @@ bool Solver::isUsingDoublePrecision() {
  * @return true if so, false otherwise
  */
 bool Solver::isUsingExponentialInterpolation() {
-  return _exp_evaluator->isUsingExponentialInterpolation();
+  return _exp_evaluator->isUsingInterpolation();
 }
 
 
@@ -343,7 +343,7 @@ void Solver::setSourceConvergenceThreshold(FP_PRECISION source_thresh) {
  *        exponential in the transport equation.
  */
 void Solver::useExponentialInterpolation() {
-  _exp_evaluator->useExponentialInterpolation();
+  _exp_evaluator->useInterpolation();
 }
 
 
@@ -352,7 +352,7 @@ void Solver::useExponentialInterpolation() {
  *        to compute the exponential in the transport equation
  */
 void Solver::useExponentialIntrinsic() {
-  _exp_evaluator->useExponentialIntrinsic();
+  _exp_evaluator->useIntrinsic();
 }
 
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -2,14 +2,9 @@
 /**
  * @brief Constructor initializes an empty Solver class with array pointers
  *        set to NULL.
- * @details If the constructor receives Geometry and TrackGenerator 
- *          objects it will retrieve the number of energy groups
- *          and FSRs from the Geometry and azimuthal angles from the
- *          TrackGenerator.
- * @param geometry an optional pointer to a Geometry object
  * @param track_generator an optional pointer to a TrackGenerator object
  */
-Solver::Solver(Geometry* geometry, TrackGenerator* track_generator) {
+Solver::Solver(TrackGenerator* track_generator) {
 
   /* Default values */
   _num_materials = 0;
@@ -38,11 +33,6 @@ Solver::Solver(Geometry* geometry, TrackGenerator* track_generator) {
   _old_fission_sources = NULL;
   _reduced_sources = NULL;
   _source_residuals = NULL;
-
-  if (geometry != NULL){
-    _cmfd = geometry->getCmfd();
-    setGeometry(geometry);
-  }
 
   if (track_generator != NULL)
     setTrackGenerator(track_generator);
@@ -124,6 +114,21 @@ Geometry* Solver::getGeometry() {
 }
 
 
+
+/**
+ * @brief Returns a pointer to the TrackGenerator.
+ * @return a pointer to the TrackGenerator
+ */
+TrackGenerator* Solver::getTrackGenerator() {
+
+  if (_track_generator == NULL)
+    log_printf(ERROR, "Unable to return the Solver's TrackGenetrator "
+               "since it has not yet been set");
+
+  return _track_generator;
+}
+
+
 /**
  * @brief Returns the calculated volume for a flat source region.
  * @param fsr_id the flat source region ID of interest
@@ -140,20 +145,6 @@ FP_PRECISION Solver::getFSRVolume(int fsr_id) {
                "volumes have not yet been computed", fsr_id);
 
   return _FSR_volumes[fsr_id];
-}
-
-
-/**
- * @brief Returns a pointer to the TrackGenerator.
- * @return a pointer to the TrackGenerator
- */
-TrackGenerator* Solver::getTrackGenerator() {
-
-  if (_track_generator == NULL)
-    log_printf(ERROR, "Unable to return the Solver's TrackGenetrator "
-               "since it has not yet been set");
-
-  return _track_generator;
 }
 
 
@@ -227,16 +218,8 @@ bool Solver::isUsingExponentialInterpolation() {
 
 /**
  * @brief Sets the Geometry for the Solver.
- * @details The Geometry must already have initialized FSR offset maps
- *          and segmentized the TrackGenerator's tracks. Each of these
- *          should be initiated in Python prior to assigning a Geometry
- *          to the Solver:
- *
- * @code
- *          geometry.initializeFlatSourceRegions()
- *          track_generator.generateTracks()
- * @endcode
- *
+ * @details This is a private setter method for the Solver and is not
+ *          intended to be called by the user.
  * @param geometry a pointer to a Geometry object
  */
 void Solver::setGeometry(Geometry* geometry) {
@@ -246,6 +229,7 @@ void Solver::setGeometry(Geometry* geometry) {
                "Geometry has not yet initialized FSRs");
 
   _geometry = geometry;
+  _cmfd = geometry->getCmfd();
   _num_FSRs = _geometry->getNumFSRs();
   _num_groups = _geometry->getNumEnergyGroups();
   _polar_times_groups = _num_groups * _num_polar;
@@ -261,6 +245,7 @@ void Solver::setGeometry(Geometry* geometry) {
  *          to the Solver:
  *
  * @code
+ *          geometry.initializeFlatSourceRegions()
  *          track_generator.generateTracks()
  *          solver.setTrackGenerator(track_generator)
  * @endcode
@@ -289,6 +274,9 @@ void Solver::setTrackGenerator(TrackGenerator* track_generator) {
       counter++;
     }
   }
+
+  /* Retrieve and store the Geometry from the TrackGenerator */  
+  setGeometry(_track_generator->getGeometry());
 }
 
 
@@ -462,11 +450,8 @@ void Solver::initializeCmfd(){
   _cmfd->setFSRMaterials(_FSR_materials);
   _cmfd->setFSRFluxes(_scalar_flux);
   _cmfd->setPolarQuadrature(_polar_quad);
-
-  //FIXME: Perhaps all arrays should be initi
   _cmfd->initializeSurfaceCurrents();
 }
-
 
 
 /**
@@ -561,10 +546,8 @@ FP_PRECISION Solver::convergeSource(int max_iterations) {
   /* An initial guess for the eigenvalue */
   _k_eff = 1.0;
 
-  /* The residual on the source */
+  /* The new/old residuals on the fission source */
   FP_PRECISION residual = 0.0;
-
-  /* The old residual and k_eff */
   FP_PRECISION residual_old = 1.0;
   FP_PRECISION keff_old = 1.0;
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -332,16 +332,7 @@ void Solver::setTrackGenerator(TrackGenerator* track_generator) {
 void Solver::setPolarQuadrature(PolarQuad* polar_quad) {
   _user_polar_quad = true;
   _polar_quad = polar_quad;
-  setNumPolarAngles(polar_quad->getNumPolarAngles());
-}
-
-
-/**
- * @brief Sets the number of polar angles to use
- * @param num_polar the number of polar angles
- */
-void Solver::setNumPolarAngles(int num_polar) {
-  _num_polar = num_polar;
+  _num_polar = _polar_quad->getNumPolarAngles();
   _two_times_num_polar = 2 * _num_polar;
   _polar_times_groups = _num_groups * _num_polar;
 }

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -18,10 +18,8 @@ Solver::Solver(Geometry* geometry, TrackGenerator* track_generator) {
 
   _num_FSRs = 0;
   _num_fissionable_FSRs = 0;
-  _num_mesh_cells = 0;
   _FSR_volumes = NULL;
   _FSR_materials = NULL;
-  _surface_currents = NULL;
 
   _track_generator = NULL;
   _geometry = NULL;
@@ -252,9 +250,6 @@ void Solver::setGeometry(Geometry* geometry) {
   _num_groups = _geometry->getNumEnergyGroups();
   _polar_times_groups = _num_groups * _num_polar;
   _num_materials = _geometry->getNumMaterials();
-
-  if (_cmfd != NULL)
-    _num_mesh_cells = _cmfd->getNumCells();
 }
 
 
@@ -467,6 +462,9 @@ void Solver::initializeCmfd(){
   _cmfd->setFSRMaterials(_FSR_materials);
   _cmfd->setFSRFluxes(_scalar_flux);
   _cmfd->setPolarQuadrature(_polar_quad);
+
+  //FIXME: Perhaps all arrays should be initi
+  _cmfd->initializeSurfaceCurrents();
 }
 
 

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -22,11 +22,6 @@
 /** Indexing macro for the scalar flux in each FSR and energy grou */
 #define _scalar_flux(r,e) (_scalar_flux[(r)*_num_groups + (e)])
 
-/** Indexing macro for the surface currents for each CMFD Mesh surface and
- *  each energy group */
-#define _surface_currents(r,e) (_surface_currents[(r)*_cmfd->getNumCmfdGroups() \
-                                                  + _cmfd->getCmfdGroup((e))])
-
 /** Indexing macro for the total source divided by the total cross-section
  *  (\f$ \frac{Q}{\Sigma_t} \f$) in each FSR and energy group */
 #define _reduced_sources(r,e) (_reduced_sources[(r)*_num_groups + (e)])
@@ -76,9 +71,6 @@ protected:
 
   /** The number of fissionable flat source regions */
   int _num_fissionable_FSRs;
-
-  /** The number of mesh cells */
-  int _num_mesh_cells;
 
   /** The FSR "volumes" (i.e., areas) indexed by FSR UID */
   FP_PRECISION* _FSR_volumes;
@@ -137,9 +129,6 @@ protected:
 
   /** The scalar flux for each energy group in each FSR */
   FP_PRECISION* _scalar_flux;
-
-  /** The CMFD Mesh surface currents in each energy group */
-  FP_PRECISION* _surface_currents;
 
   /** The fission source in each FSR and energy group */
   FP_PRECISION* _fission_sources;

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -160,9 +160,6 @@ protected:
   /** The current iteration's approximation to k-effective */
   FP_PRECISION _k_eff;
 
-  /** An array of k-effective at each iteration */
-  std::vector<FP_PRECISION> _residual_vector;
-
   /** The total leakage across vacuum boundaries */
   FP_PRECISION _leakage;
 

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -240,12 +240,14 @@ protected:
 
 
 public:
-  Solver(Geometry* geom=NULL, TrackGenerator* track_generator=NULL);
+  Solver(TrackGenerator* track_generator=NULL);
   virtual ~Solver();
 
+  virtual void setGeometry(Geometry* geometry);
+
   Geometry* getGeometry();
-  FP_PRECISION getFSRVolume(int fsr_id);
   TrackGenerator* getTrackGenerator();
+  FP_PRECISION getFSRVolume(int fsr_id);
   int getNumPolarAngles();
   int getNumIterations();
   double getTotalTime();
@@ -277,7 +279,6 @@ public:
    */
   virtual FP_PRECISION getFSRSource(int fsr_id, int energy_group) =0;
 
-  virtual void setGeometry(Geometry* geometry);
   virtual void setTrackGenerator(TrackGenerator* track_generator);
   virtual void setPolarQuadrature(PolarQuad* polar_quad);
   virtual void setSourceConvergenceThreshold(FP_PRECISION source_thresh);

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -328,7 +328,6 @@ public:
   virtual void setGeometry(Geometry* geometry);
   virtual void setTrackGenerator(TrackGenerator* track_generator);
   virtual void setPolarQuadrature(PolarQuad* polar_quad);
-  virtual void setNumPolarAngles(int num_polar);
   virtual void setSourceConvergenceThreshold(FP_PRECISION source_thresh);
 
   void useExponentialInterpolation();

--- a/src/Surface.h
+++ b/src/Surface.h
@@ -11,13 +11,10 @@
 
 #ifdef __cplusplus
 #include <limits>
+#include "constants.h"
 #include "LocalCoords.h"
 #include "boundary_type.h"
 #endif
-
-/** Error threshold for determining how close a point needs to be to a surface
- * to be considered on it */
-#define ON_SURFACE_THRESH 1E-12
 
 
 /* Forward declarations to resolve circular dependencies */

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -47,33 +47,6 @@ TrackGenerator::~TrackGenerator() {
 
 
 /**
- * @brief Sets the number of shared memory OpenMP threads to use (>0).
- * @param num_threads the number of threads
- */
-void TrackGenerator::setNumThreads(int num_threads) {
-
-  if (num_threads <= 0)
-    log_printf(ERROR, "Unable to set the number of threads for the "
-               "TrackGenerator to %d since it is less than or equal to 0"
-               , num_threads);
-
-  _num_threads = num_threads;
-
-  /* Set the number of threads for OpenMP */
-  omp_set_num_threads(_num_threads);
-}
-
-
-/**
- * @brief Returns the number of shared memory OpenMP threads in use.
- * @return the number of threads
- */
-int TrackGenerator::getNumThreads() {
-  return _num_threads;
-}
-
-
-/**
  * @brief Return the number of azimuthal angles in \f$ [0, 2\pi] \f$
  * @return the number of azimuthal angles in \f$ 2\pi \f$
  */
@@ -185,6 +158,208 @@ FP_PRECISION* TrackGenerator::getAzimWeights() {
                "weights since Tracks have not yet been generated.");
 
   return _azim_weights;
+}
+
+
+/**
+ * @brief Get the maximum allowable optical lenght for a track segment
+ * @return The max optical length
+ */
+FP_PRECISION TrackGenerator::getMaxOpticalLength() {
+  return _max_optical_length;
+}
+
+/**
+ * @brief Get the total number of tracks in the TrackGenerator
+ * @return the total number of tracks
+ */
+int TrackGenerator::getTotNumTracks() {
+  return _tot_num_tracks;
+}
+
+/**
+ * @brief Get the total number of track segments in the TrackGenerator
+ * @return the total number of track segments
+ */
+int TrackGenerator::getTotNumSegments() {
+  return _tot_num_segments;
+}
+
+
+/**
+ * @brief Returns the number of shared memory OpenMP threads in use.
+ * @return the number of threads
+ */
+int TrackGenerator::getNumThreads() {
+  return _num_threads;
+}
+
+
+/**
+ * @brief Computes and returns an array of volumes indexed by FSR.
+ * @details Note: It is the function caller's responsibility to deallocate
+ *          the memory reserved for the FSR volume array.
+ * @return a pointer to the array of FSR volumes
+ */
+FP_PRECISION* TrackGenerator::getFSRVolumes() {
+
+  if (!containsTracks())
+    log_printf(ERROR, "Unable to get the FSR volumes since tracks "
+               "have not yet been generated");
+
+  int num_FSRs = _geometry->getNumFSRs();
+  FP_PRECISION *FSR_volumes = new FP_PRECISION[num_FSRs];
+  memset(FSR_volumes, 0., num_FSRs*sizeof(FP_PRECISION));
+
+  int azim_index, num_segments;
+  segment* curr_segment;
+  segment* segments;
+  FP_PRECISION volume;
+
+  /* Calculate each FSR's "volume" by accumulating the total length of * 
+   * all Track segments multipled by the Track "widths" for each FSR.  */
+  for (int i=0; i < _num_azim; i++) {
+    for (int j=0; j < _num_tracks[i]; j++) {
+
+      azim_index = _tracks[i][j].getAzimAngleIndex();
+      num_segments = _tracks[i][j].getNumSegments();
+      segments = _tracks[i][j].getSegments();
+
+      for (int s=0; s < num_segments; s++) {
+        curr_segment = &segments[s];
+        volume = curr_segment->_length * _azim_weights[azim_index];
+        FSR_volumes[curr_segment->_region_id] += volume;
+      }
+    }
+  }
+
+  return FSR_volumes;
+}
+
+
+/**
+ * @brief Computes and returns the volume of an FSR.
+ * @param fsr_id the ID for the FSR of interest
+ * @return the FSR volume
+ */
+FP_PRECISION TrackGenerator::getFSRVolume(int fsr_id) {
+
+  if (!containsTracks())
+    log_printf(ERROR, "Unable to get the FSR %d volume since tracks "
+               "have not yet been generated");
+
+  else if (fsr_id < 0 || fsr_id > _geometry->getNumFSRs())
+    log_printf(ERROR, "Unable to get the volume for FSR %d since the FSR IDs "
+               "lie in the range (0, %d)", fsr_id, _geometry->getNumFSRs());
+
+  int azim_index, num_segments;
+  segment* curr_segment;
+  segment* segments;
+  FP_PRECISION volume;
+
+  /* Calculate the FSR's "volume" by accumulating the total length of * 
+   * all Track segments multipled by the Track "widths" for the FSR.  */
+  for (int i=0; i < _num_azim; i++) {
+    for (int j=0; j < _num_tracks[i]; j++) {
+
+      num_segments = _tracks[i][j].getNumSegments();
+      segments = _tracks[i][j].getSegments();
+
+      for (int s=0; s < num_segments; s++) {
+        curr_segment = &segments[s];
+        if (curr_segment->_region_id == fsr_id)
+          volume += curr_segment->_length * _azim_weights[azim_index];
+      }
+    }
+  }
+
+  return volume;
+}
+
+
+/**
+ * @brief Sets the number of shared memory OpenMP threads to use (>0).
+ * @param num_threads the number of threads
+ */
+void TrackGenerator::setNumThreads(int num_threads) {
+
+  if (num_threads <= 0)
+    log_printf(ERROR, "Unable to set the number of threads for the "
+               "TrackGenerator to %d since it is less than or equal to 0"
+               , num_threads);
+
+  _num_threads = num_threads;
+
+  /* Set the number of threads for OpenMP */
+  omp_set_num_threads(_num_threads);
+}
+
+
+/**
+ * @brief Set the number of azimuthal angles in \f$ [0, 2\pi] \f$.
+ * @param num_azim the number of azimuthal angles in \f$ 2\pi \f$
+ */
+void TrackGenerator::setNumAzim(int num_azim) {
+
+  if (num_azim < 0)
+    log_printf(ERROR, "Unable to set a negative number of azimuthal angles "
+               "%d for the TrackGenerator.", num_azim);
+
+  if (num_azim % 4 != 0)
+    log_printf(ERROR, "Unable to set the number of azimuthal angles to %d for "
+               "the TrackGenerator since it is not a multiple of 4", num_azim);
+
+  /* Subdivide out angles in [pi,2pi] */
+  _num_azim = num_azim / 2.0;
+
+  _contains_tracks = false;
+  _use_input_file = false;
+  _tracks_filename = "";
+}
+
+
+/**
+ * @brief Set the suggested track spacing (cm).
+ * @param spacing the suggested track spacing
+ */
+void TrackGenerator::setTrackSpacing(double spacing) {
+  if (spacing < 0)
+    log_printf(ERROR, "Unable to set a negative track spacing %f for the "
+               "TrackGenerator.", spacing);
+
+  _spacing = spacing;
+  _tot_num_tracks = 0;
+  _tot_num_segments = 0;
+  _contains_tracks = false;
+  _use_input_file = false;
+  _tracks_filename = "";
+}
+
+
+/**
+ * @brief Set a pointer to the Geometry to use for track generation.
+ * @param geometry a pointer to the Geometry
+ */
+void TrackGenerator::setGeometry(Geometry* geometry) {
+  _geometry = geometry;
+  _tot_num_tracks = 0;
+  _tot_num_segments = 0;
+  _contains_tracks = false;
+  _use_input_file = false;
+  _tracks_filename = "";
+}
+
+
+/**
+ * @brief Set the maximum allowable optical length for a track segment
+ * @param max_optical_length The max optical length
+ */
+void TrackGenerator::setMaxOpticalLength(FP_PRECISION max_optical_length) {
+  if (max_optical_length <= 0)
+    log_printf(ERROR, "Cannot set max optical length to %f because it "
+               "must be positive.", max_optical_length); 
+        
+  _max_optical_length = max_optical_length;
 }
 
 
@@ -304,61 +479,6 @@ void TrackGenerator::retrieveSegmentCoords(double* coords, int num_segments) {
   }
 
     return;
-}
-
-
-/**
- * @brief Set the number of azimuthal angles in \f$ [0, 2\pi] \f$.
- * @param num_azim the number of azimuthal angles in \f$ 2\pi \f$
- */
-void TrackGenerator::setNumAzim(int num_azim) {
-
-  if (num_azim < 0)
-    log_printf(ERROR, "Unable to set a negative number of azimuthal angles "
-               "%d for the TrackGenerator.", num_azim);
-
-  if (num_azim % 4 != 0)
-    log_printf(ERROR, "Unable to set the number of azimuthal angles to %d for "
-               "the TrackGenerator since it is not a multiple of 4", num_azim);
-
-  /* Subdivide out angles in [pi,2pi] */
-  _num_azim = num_azim / 2.0;
-
-  _contains_tracks = false;
-  _use_input_file = false;
-  _tracks_filename = "";
-}
-
-
-/**
- * @brief Set the suggested track spacing (cm).
- * @param spacing the suggested track spacing
- */
-void TrackGenerator::setTrackSpacing(double spacing) {
-  if (spacing < 0)
-    log_printf(ERROR, "Unable to set a negative track spacing %f for the "
-               "TrackGenerator.", spacing);
-
-  _spacing = spacing;
-  _tot_num_tracks = 0;
-  _tot_num_segments = 0;
-  _contains_tracks = false;
-  _use_input_file = false;
-  _tracks_filename = "";
-}
-
-
-/**
- * @brief Set a pointer to the Geometry to use for track generation.
- * @param geometry a pointer to the Geometry
- */
-void TrackGenerator::setGeometry(Geometry* geometry) {
-  _geometry = geometry;
-  _tot_num_tracks = 0;
-  _tot_num_segments = 0;
-  _contains_tracks = false;
-  _use_input_file = false;
-  _tracks_filename = "";
 }
 
 
@@ -1424,38 +1544,68 @@ bool TrackGenerator::readTracksFromFile() {
 
 
 /**
- * @brief Set the maximum allowable optical length for a track segment
- * @param max_optical_length The max optical length
+ * @brief Assign a correct volume for some FSR.
+ * @details This routine adjusts the length of each track segment crossing
+ *          a FSR such that the integrated volume is identical to the true
+ *          volume assigned by the user.
+ * @param fsr_id the ID of the FSR of interest
+ * @param fsr_volume the correct FSR volume to use
  */
-void TrackGenerator::setMaxOpticalLength(FP_PRECISION max_optical_length) {
-  if (max_optical_length <= 0)
-    log_printf(ERROR, "Cannot set max optical length to %f because it "
-               "must be positive.", max_optical_length); 
-        
-  _max_optical_length = max_optical_length;
-}
+void TrackGenerator::correctFSRVolume(int fsr_id, FP_PRECISION fsr_volume) {
 
-/**
- * @brief Get the maximum allowable optical lenght for a track segment
- * @return The max optical length
- */
-FP_PRECISION TrackGenerator::getMaxOpticalLength() {
-  return _max_optical_length;
-}
+  /* Compute the current volume approximation for the flat source region */
+  FP_PRECISION curr_volume = getFSRVolume(fsr_id);
 
-/**
- * @brief Get the total number of tracks in the TrackGenerator
- * @return the total number of tracks
- */
-int TrackGenerator::getTotNumTracks() {
-  return _tot_num_tracks;
-}
+  log_printf(INFO, "Correcting FSR %d volume from %f to %f", 
+             fsr_id, curr_volume, fsr_volume);
 
-/**
- * @brief Get the total number of track segments in the TrackGenerator
- * @return the total number of track segments
- */
-int TrackGenerator::getTotNumSegments() {
-  return _tot_num_segments;
-}
+  int num_segments, azim_index;
+  double dx_eff, dy_eff, d_eff;
+  double volume, corr_factor;
+  segment* curr_segment;
+  segment* segments;
 
+  /* Correct volume separately for each azimuthal angle */
+  for (int i=0; i < _num_azim; i++) {
+
+    /* Initialize volume to zero for this azimuthal angle */
+    volume = 0;
+
+    /* Compute effective track spacing for this azimuthal angle */
+    dx_eff = (_geometry->getWidth() / _num_x[i]);
+    dy_eff = (_geometry->getHeight() / _num_y[i]);
+    d_eff = (dx_eff * sin(_tracks[i][0].getPhi()));
+
+    /* Compute the current estimated volume of the FSR for this angle */
+    for (int j=0; j < _num_tracks[i]; j++) {
+
+      num_segments = _tracks[i][j].getNumSegments();
+      segments = _tracks[i][j].getSegments();
+
+      for (int s=0; s < num_segments; s++) {
+        curr_segment = &segments[s];
+        if (curr_segment->_region_id == fsr_id)
+          volume += curr_segment->_length * d_eff;
+      }
+    }
+
+    /* Compute correction factor to the volume */
+    corr_factor = fsr_volume / volume;
+
+    log_printf(DEBUG, "Volume correction factor for FSR %d and azim "
+               "angle %d is %f", fsr_id, i, corr_factor);
+
+    /* Correct the length of each segment which crosses the FSR */
+    for (int j=0; j < _num_tracks[i]; j++) {
+
+      num_segments = _tracks[i][j].getNumSegments();
+      segments = _tracks[i][j].getSegments();
+
+      for (int s=0; s < num_segments; s++) {
+        curr_segment = &segments[s];
+        if (curr_segment->_region_id == fsr_id)
+          curr_segment->_length *= corr_factor;
+      }
+    }
+  }
+}

--- a/src/TrackGenerator.h
+++ b/src/TrackGenerator.h
@@ -94,6 +94,7 @@ private:
   bool readTracksFromFile();
 
 public:
+
   TrackGenerator(Geometry* geometry, int num_azim, double spacing);
   virtual ~TrackGenerator();
 
@@ -111,6 +112,8 @@ public:
   int getTotNumSegments();
   int getTotNumTracks();
   int getNumThreads();
+  FP_PRECISION* getFSRVolumes();
+  FP_PRECISION getFSRVolume(int fsr_id);
 
   /* Set parameters */
   void setNumAzim(int num_azim);
@@ -124,6 +127,7 @@ public:
   void retrieveTrackCoords(double* coords, int num_tracks);
   void retrieveSegmentCoords(double* coords, int num_segments);
   void generateTracks();
+  void correctFSRVolume(int fsr_id, FP_PRECISION fsr_volume);
 };
 
 #endif /* TRACKGENERATOR_H_ */

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -12,17 +12,11 @@
 #include <limits>
 #include <map>
 #include <vector>
+#include "constants.h"
 #include "LocalCoords.h"
 #include "boundary_type.h"
 #endif
 
-/** Error threshold for determining how close to the boundary of a Lattice cell
- * a Point needs to be to be considered on it */
-#define ON_LATTICE_CELL_THRESH 1E-12
-
-/** Distance a Point is moved to cross over a Surface into a new Cell during
- * Track segmentation */
-#define TINY_MOVE 1E-10
 
 /* Forward declarations to resolve circular dependencies */
 class LocalCoords;

--- a/src/VectorizedSolver.cpp
+++ b/src/VectorizedSolver.cpp
@@ -2,19 +2,11 @@
 
 
 /**
- * @brief Constructor initializes empty arrays for source, flux, etc.
- * @details The construcor retrieves the number of energy groups and FSRs
- *          and azimuthal angles from the Geometry and TrackGenerator if
- *          they were provided by the user, and uses this to initialize
- *          empty arrays for the FSRs, boundary angular fluxes, FSR scalar
- *          fluxes, FSR sources and FSR fission rates. The constructor
- *          initalizes the number of threads to a default of 1.
- * @param geometry an optional pointer to the Geometry object
+ * @brief Constructor initializes NULL arrays for source, flux, etc.
  * @param track_generator an optional pointer to a TrackGenerator object
  */
-VectorizedSolver::VectorizedSolver(Geometry* geometry,
-                                   TrackGenerator* track_generator) :
-  CPUSolver(geometry, track_generator) {
+VectorizedSolver::VectorizedSolver(TrackGenerator* track_generator) :
+  CPUSolver(track_generator) {
 
   if (_cmfd != NULL)
     log_printf(ERROR, "The VectorizedSolver is not set up to use CMFD");
@@ -22,9 +14,6 @@ VectorizedSolver::VectorizedSolver(Geometry* geometry,
   _delta_psi = NULL;
   _thread_taus = NULL;
   _thread_exponentials = NULL;
-
-  if (geometry != NULL)
-    setGeometry(geometry);
 
   if (track_generator != NULL)
     setTrackGenerator(track_generator);
@@ -107,7 +96,7 @@ int VectorizedSolver::getNumVectorWidths() {
 
 /**
  * @brief Sets the Geometry for the Solver and aligns all Material
- * cross-section data for SIMD vector instructions.
+ *        cross-section data for SIMD vector instructions.
  * @param geometry a pointer to the Geometry
  */
 void VectorizedSolver::setGeometry(Geometry* geometry) {

--- a/src/VectorizedSolver.cpp
+++ b/src/VectorizedSolver.cpp
@@ -641,7 +641,7 @@ return;
  * @param fsr_flux a pointer to the temporary FSR flux buffer
  * @param fwd
  */
-void VectorizedSolver::scalarFluxTally(segment* curr_segment,
+void VectorizedSolver::tallyScalarFlux(segment* curr_segment,
                                        int azim_index,
                                        FP_PRECISION* track_flux,
                                        FP_PRECISION* fsr_flux,

--- a/src/VectorizedSolver.h
+++ b/src/VectorizedSolver.h
@@ -68,8 +68,7 @@ protected:
   void computeExponentials(segment* curr_segment, FP_PRECISION* exponentials);
 
 public:
-  VectorizedSolver(Geometry* geometry=NULL,
-                   TrackGenerator* track_generator=NULL);
+  VectorizedSolver(TrackGenerator* track_generator=NULL);
   virtual ~VectorizedSolver();
 
   int getNumVectorWidths();

--- a/src/VectorizedSolver.h
+++ b/src/VectorizedSolver.h
@@ -81,7 +81,6 @@ protected:
 public:
   VectorizedSolver(Geometry* geometry=NULL,
                    TrackGenerator* track_generator=NULL);
-
   virtual ~VectorizedSolver();
 
   int getNumVectorWidths();

--- a/src/VectorizedSolver.h
+++ b/src/VectorizedSolver.h
@@ -59,7 +59,7 @@ protected:
 
   void normalizeFluxes();
   FP_PRECISION computeFSRSources();
-  void scalarFluxTally(segment* curr_segment, int azim_index,
+  void tallyScalarFlux(segment* curr_segment, int azim_index,
                        FP_PRECISION* track_flux,
                        FP_PRECISION* fsr_flux, bool fwd);
   void transferBoundaryFlux(int track_id, int azim_index, bool direction,

--- a/src/accel/cuda/GPUExpEvaluator.cu
+++ b/src/accel/cuda/GPUExpEvaluator.cu
@@ -44,24 +44,35 @@ void clone_exp_evaluator(ExpEvaluator* evaluator_h,
   cudaMemcpyToSymbol(interpolate, (void*)&interpolate_exp,
                      sizeof(bool), 0, cudaMemcpyHostToDevice);
 
-  /* Copy inverse table spacing to constant memory on the device */
-  FP_PRECISION inverse_spacing_h = 1.0 / evaluator_h->getTableSpacing();
-  cudaMemcpyToSymbol(inverse_exp_table_spacing, (void*)&inverse_spacing_h,
-                     sizeof(FP_PRECISION), 0, cudaMemcpyHostToDevice);
-
   /* Allocate memory for the interpolation table on the device */
   if (evaluator_h->isUsingInterpolation()) {
+
+    /* Copy inverse table spacing to constant memory on the device */
+    FP_PRECISION inverse_spacing_h = 1.0 / evaluator_h->getTableSpacing();
+    cudaMemcpyToSymbol(inverse_exp_table_spacing, (void*)&inverse_spacing_h,
+                       sizeof(FP_PRECISION), 0, cudaMemcpyHostToDevice);
+    
+
     int exp_table_size_h = evaluator_h->getTableSize();
     FP_PRECISION* exp_table_h = evaluator_h->getExpTable();
+
+    printf("exp table size = %d\n", exp_table_size_h);
   
     FP_PRECISION* exp_table_d;
     cudaMalloc((void**)&exp_table_d, exp_table_size_h * sizeof(FP_PRECISION));
-    cudaMemcpy((void*)exp_table_d, (void*)exp_table_h,
+    cudaMemcpy((void**)exp_table_d, (void*)exp_table_h,
                exp_table_size_h * sizeof(FP_PRECISION), 
                cudaMemcpyHostToDevice);
 
     /* Transfer exponential interpolation table pointer to GPUExpEvaluator */
-    evaluator_d->_exp_table = exp_table_d;
+//    cudaMemcpy((void*)&material_d->_sigma_t, (void*)&sigma_t, sizeof(double*),
+//               cudaMemcpyHostToDevice);
+
+    cudaMemcpy((void*)&evaluator_d->_exp_table, (void*)&exp_table_d, sizeof(FP_PRECISION*),
+               cudaMemcpyHostToDevice);
+
+
+//    evaluator_d->_exp_table = &exp_table_d;
   }
 
   return;

--- a/src/accel/cuda/GPUExpEvaluator.cu
+++ b/src/accel/cuda/GPUExpEvaluator.cu
@@ -1,0 +1,109 @@
+#include "GPUExpEvaluator.h"
+
+
+/** A boolean whether to use linear interpolation to compute exponentials */
+__constant__ bool interpolate[1];
+
+/** The inverse spacing for the exponential linear interpolation table */
+__constant__ FP_PRECISION inverse_exp_table_spacing[1];
+
+/** An array for the sines of the polar angle in the polar Quadrature set */
+extern __constant__ FP_PRECISION sin_thetas[MAX_POLAR_ANGLES];
+
+/** Twice the number of polar angles */
+extern __constant__ int two_times_num_polar[1];
+
+
+/**
+ * @brief Rounds a single precision floating point value to an integer.
+ * @param x a float precision floating point value
+ * @brief the rounded integer value
+ */
+__device__ inline int round_to_int_d(float x) {
+  return __float2int_rd(x);
+}
+
+
+/**
+ * @brief Rounds a double precision floating point value to an integer.
+ * @param x a double precision floating point value
+ * @brief the rounded integer value
+ */
+__device__ inline int round_to_int_d(double x) {
+  return __double2int_rd(x);
+}
+
+
+//FIXME
+void clone_exp_evaluator(ExpEvaluator* evaluator_h,
+                         GPUExpEvaluator* evaluator_d) {
+
+  /* Copy a boolean indicating whether or not to use the linear interpolation
+   * table or the exp intrinsic function to constant memory on the device */
+  bool interpolate_exp = evaluator_h->isUsingInterpolation();
+  cudaMemcpyToSymbol(interpolate, (void*)&interpolate_exp,
+                     sizeof(bool), 0, cudaMemcpyHostToDevice);
+
+  /* Copy inverse table spacing to constant memory on the device */
+  FP_PRECISION inverse_spacing_h = 1.0 / evaluator_h->getTableSpacing();
+  cudaMemcpyToSymbol(inverse_exp_table_spacing, (void*)&inverse_spacing_h,
+                     sizeof(FP_PRECISION), 0, cudaMemcpyHostToDevice);
+
+  /* Allocate memory for the interpolation table on the device */
+  if (evaluator_h->isUsingInterpolation()) {
+    int exp_table_size_h = evaluator_h->getTableSize();
+    FP_PRECISION* exp_table_h = evaluator_h->getExpTable();
+  
+    FP_PRECISION* exp_table_d;
+    cudaMalloc((void**)&exp_table_d, exp_table_size_h * sizeof(FP_PRECISION));
+    cudaMemcpy((void*)exp_table_d, (void*)exp_table_h,
+               exp_table_size_h * sizeof(FP_PRECISION), 
+               cudaMemcpyHostToDevice);
+
+    /* Transfer exponential interpolation table pointer to GPUExpEvaluator */
+    evaluator_d->_exp_table = exp_table_d;
+  }
+
+  return;
+}
+
+
+/**
+ * @brief Computes the exponential term for a optical length and polar angle. 
+ * @details This method computes \f$ 1 - exp(-\tau/sin(\theta_p)) \f$
+ *          for some optical path length and polar angle. This method
+ *          uses either a linear interpolation table (default) or the
+ *          exponential intrinsic exp(...) function.
+ * @param tau the optical path length (e.g., sigma_t times length)
+ * @param polar the polar angle index
+ * @return the evaluated exponential
+ */
+__device__ FP_PRECISION GPUExpEvaluator::computeExponential(FP_PRECISION tau,
+                                                            int polar) {
+
+  FP_PRECISION exponential;
+
+  #ifdef CUDA
+
+  /* Evaluate the exponential using the linear interpolation table */
+  if (*interpolate) {
+    int index;
+
+    index = round_to_int_d(tau * (*inverse_exp_table_spacing));
+    index *= (*two_times_num_polar);
+    exponential = (1. - (_exp_table[index + 2 * polar] * tau +
+                         _exp_table[index + 2 * polar +1]));
+  }
+
+  /* Evalute the exponential using the intrinsic exp(...) function */
+  else {
+    #ifdef SINGLE
+    exponential = 1.0 - __expf(- tau / sin_thetas[polar]);
+    #else
+    exponential = 1.0 - exp(- tau / sin_thetas[polar]);
+    #endif
+  }
+  #endif
+
+  return exponential;
+}

--- a/src/accel/cuda/GPUExpEvaluator.cu
+++ b/src/accel/cuda/GPUExpEvaluator.cu
@@ -34,7 +34,15 @@ __device__ inline int round_to_int_d(double x) {
 }
 
 
-//FIXME
+/**
+ * @brief Given a pointer to an ExpEvaluator on the host and a 
+ *        GPUExpEvaluator on the GPU, copy all of the properties from 
+*         the ExpEvaluator object on the host to the GPU.
+ * @details This routine is called by the GPUSolver::initializeExpEvaluator()
+ *          private class method and is not intended to be called directly.
+ * @param eavluator_h pointer to a ExpEvaluator on the host
+ * @param evaluator_d pointer to a GPUExpEvaluator on the GPU
+ */
 void clone_exp_evaluator(ExpEvaluator* evaluator_h,
                          GPUExpEvaluator* evaluator_d) {
 

--- a/src/accel/cuda/GPUExpEvaluator.h
+++ b/src/accel/cuda/GPUExpEvaluator.h
@@ -21,9 +21,6 @@
 #define MAX_POLAR_ANGLES 10
 
 
-void clone_exp_evaluator(ExpEvaluator* evaluator_h,
-                         GPUExpEvaluator* evaluator_d);
-
 /**
  * @class GPUExpEvaluator GPUExpEvaluator.h "src/accel/cuda/ExpEvaluator.h"
  * @brief This is a class for evaluating exponentials on GPUs.
@@ -44,6 +41,10 @@ public:
 
   __device__ FP_PRECISION computeExponential(FP_PRECISION tau, int polar);
 };
+
+
+void clone_exp_evaluator(ExpEvaluator* evaluator_h,
+                         GPUExpEvaluator* evaluator_d);
 
 
 #endif /* EXPEVALUATOR_H_ */

--- a/src/accel/cuda/GPUExpEvaluator.h
+++ b/src/accel/cuda/GPUExpEvaluator.h
@@ -16,15 +16,21 @@
 #include "../../ExpEvaluator.h"
 #endif
 
+
 /** The maximum number of polar angles to reserve constant memory on GPU */
 #define MAX_POLAR_ANGLES 10
 
+
+void clone_exp_evaluator(ExpEvaluator* evaluator_h,
+                         GPUExpEvaluator* evaluator_d);
 
 /**
  * @class GPUExpEvaluator GPUExpEvaluator.h "src/accel/cuda/ExpEvaluator.h"
  * @brief This is a class for evaluating exponentials on GPUs.
  * @details The ExpEvaluator includes different algorithms to evaluate
- *          exponentials with varying degrees of accuracy and speed.
+ *          exponentials with varying degrees of accuracy and speed. This
+ *          is a helper class for the Solver and its subclasses and it not
+ *          intended to be initialized as a standalone object.
  */
 class GPUExpEvaluator {
 
@@ -36,13 +42,8 @@ public:
   /** The exponential linear interpolation table */
   FP_PRECISION* _exp_table;
 
-
   __device__ FP_PRECISION computeExponential(FP_PRECISION tau, int polar);
 };
-
-
-void clone_exp_evaluator(ExpEvaluator* evaluator_h,
-                         GPUExpEvaluator* evaluator_d);
 
 
 #endif /* EXPEVALUATOR_H_ */

--- a/src/accel/cuda/GPUExpEvaluator.h
+++ b/src/accel/cuda/GPUExpEvaluator.h
@@ -1,0 +1,48 @@
+/**
+ * @file GPUExpEvaluator.h
+ * @brief The GPUExpEvaluator class.
+ * @details This class is based on the ExpEvaluator class for execution
+ *          on NVIDIA GPUs.
+ * @date April 11, 2015.
+ * @author William Boyd, MIT, Course 22 (wboyd@mit.edu)
+ */
+
+#ifndef GPUEXPEVALUATOR_H_
+#define GPUEXPEVALUATOR_H_
+
+#ifdef __cplusplus
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include "../../ExpEvaluator.h"
+#endif
+
+/** The maximum number of polar angles to reserve constant memory on GPU */
+#define MAX_POLAR_ANGLES 10
+
+
+/**
+ * @class GPUExpEvaluator GPUExpEvaluator.h "src/accel/cuda/ExpEvaluator.h"
+ * @brief This is a class for evaluating exponentials on GPUs.
+ * @details The ExpEvaluator includes different algorithms to evaluate
+ *          exponentials with varying degrees of accuracy and speed.
+ */
+class GPUExpEvaluator {
+
+private:
+
+public:
+
+  //FIXME: Put in shared memory!!
+  /** The exponential linear interpolation table */
+  FP_PRECISION* _exp_table;
+
+
+  __device__ FP_PRECISION computeExponential(FP_PRECISION tau, int polar);
+};
+
+
+void clone_exp_evaluator(ExpEvaluator* evaluator_h,
+                         GPUExpEvaluator* evaluator_d);
+
+
+#endif /* EXPEVALUATOR_H_ */

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -610,17 +610,13 @@ __global__ void computeFSRFissionRatesOnDevice(double* fission_rates,
 
 /**
  * @brief Constructor initializes arrays for dev_tracks and dev_materials..
- * @details The constructor retrieves the number of energy groups and FSRs
- *          and azimuthal angles from the Geometry and TrackGenerator if
- *          passed in as parameters by the user. The constructor initalizes
- *          the number of CUDA threads and thread blocks each to a default
- *          of 64.
- * @param geometry an optional pointer to the Geometry
+ * @details The constructor initalizes the number of CUDA threads and thread 
+ *          blocks each to a default of 64.
  * @param track_generator an optional pointer to the TrackjGenerator
  */
-GPUSolver::GPUSolver(Geometry* geometry, TrackGenerator* track_generator) :
+GPUSolver::GPUSolver(TrackGenerator* track_generator) :
 
-  Solver(geometry, track_generator) {
+  Solver(track_generator) {
 
   /* The default number of thread blocks and threads per thread block */
   _B = 64;
@@ -634,9 +630,6 @@ GPUSolver::GPUSolver(Geometry* geometry, TrackGenerator* track_generator) :
   _fission = NULL;
   _scatter = NULL;
   _leakage = NULL;
-
-  if (geometry != NULL)
-    setGeometry(geometry);
 
   if (track_generator != NULL)
     setTrackGenerator(track_generator);

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1038,12 +1038,7 @@ void GPUSolver::initializePolarQuadrature() {
 
   log_printf(INFO, "Initializing polar quadrature on the GPU...");
 
-  /* Deletes the old Quadrature if one existed */
-  if (_quad != NULL)
-    delete _quad;
-
-  _quad = new Quadrature(_quadrature_type, _num_polar);
-  _polar_times_groups = _num_groups * _num_polar;
+  Solver::initializePolarQuadrature();
 
   /* Copy the number of polar angles to constant memory on the GPU */
   cudaMemcpyToSymbol(num_polar, (void*)&_num_polar, sizeof(int), 0,
@@ -1057,21 +1052,6 @@ void GPUSolver::initializePolarQuadrature() {
    * on the GPU */
   cudaMemcpyToSymbol(polar_times_groups, (void*)&_polar_times_groups,
                      sizeof(int), 0, cudaMemcpyHostToDevice);
-
-  /* Compute polar times azimuthal angle weights */
-  if (_polar_weights != NULL)
-    delete [] _polar_weights;
-
-  _polar_weights =
-      (FP_PRECISION*)malloc(_num_polar * _num_azim * sizeof(FP_PRECISION));
-
-  FP_PRECISION* multiples = _quad->getMultiples();
-  FP_PRECISION* azim_weights = _track_generator->getAzimWeights();
-
-  for (int i=0; i < _num_azim; i++) {
-    for (int j=0; j < _num_polar; j++)
-      _polar_weights[i*_num_polar+j] = azim_weights[i]*multiples[j]*FOUR_PI;
-  }
 
   /* Copy the polar weights to constant memory on the GPU */
   cudaMemcpyToSymbol(polar_weights, (void*)_polar_weights,

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1439,7 +1439,7 @@ void GPUSolver::buildExpInterpTable(){
 
   /* Copy the sines of the polar angles which is needed if the user
    * requested the use of the exp intrinsic to evaluate exponentials */
-  cudaMemcpyToSymbol(sinthetas, (void*)_quad->getSinThetas(),
+  cudaMemcpyToSymbol(sinthetas, (void*)_polar_quad->getSinThetas(),
                      _num_polar * sizeof(FP_PRECISION), 0,
                      cudaMemcpyHostToDevice);
 
@@ -1471,9 +1471,10 @@ void GPUSolver::buildExpInterpTable(){
   /* Create exponential interpolation table */
   for (int i = 0; i < num_array_values; i ++){
     for (int p = 0; p < _num_polar; p++){
-      expon = exp(- (i * _exp_table_spacing) / _quad->getSinTheta(p));
-      slope = - expon / _quad->getSinTheta(p);
-      intercept = expon * (1 + (i * _exp_table_spacing)/_quad->getSinTheta(p));
+      expon = exp(- (i * _exp_table_spacing) / _polar_quad->getSinTheta(p));
+      slope = - expon / _polar_quad->getSinTheta(p);
+      intercept = expon * (1 + (i * _exp_table_spacing) / 
+                  _polar_quad->getSinTheta(p));
       exp_table[_two_times_num_polar * i + 2 * p] = slope;
       exp_table[_two_times_num_polar * i + 2 * p + 1] = intercept;
     }

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -720,9 +720,9 @@ GPUSolver::~GPUSolver() {
     _leakage = NULL;
   }
 
-  if (_exp_evaluator != NULL) {
-    delete _exp_evaluator;
-  }
+//  if (_exp_evaluator != NULL) {
+//    delete _exp_evaluator;
+//  }
 }
 
 
@@ -998,14 +998,16 @@ void GPUSolver::initializeExpEvaluator(){
 //    delete [] _exp_table;
 
   /* Allocate memory for a GPUExpEvaluator on the device */
-  GPUExpEvaluator* dev_exp_evaluator = new GPUExpEvaluator();
+//  GPUExpEvaluator* dev_exp_evaluator = new GPUExpEvaluator();
+  GPUExpEvaluator* dev_exp_evaluator;
+  cudaMalloc((void**)&dev_exp_evaluator, sizeof(GPUExpEvaluator));
 
   /* Clone ExpEvaluator from the host into GPUExpEvaluator on the device */
   clone_exp_evaluator(_exp_evaluator, dev_exp_evaluator);
 
   /* Copy the GPUExpEvaluator into constant memory on the GPU */
   cudaMemcpyToSymbol(exp_evaluator, (void*)&dev_exp_evaluator, 
-                     sizeof(GPUExpEvaluator), 0, cudaMemcpyHostToDevice);
+                     sizeof(GPUExpEvaluator), 0, cudaMemcpyDeviceToDevice);
   
   return;
 }
@@ -1103,11 +1105,14 @@ void GPUSolver::initializeMaterials() {
     std::map<int, Material*> host_materials=_geometry->getAllMaterials();
     std::map<int, Material*>::iterator iter;
     int material_index = 0;
+
+    printf("going into materials loop. # materials = %d\n", _num_materials);
     
     /* Iterate through all Materials and clone them as dev_material structs
      * on the device */
     cudaMalloc((void**)&_materials, _num_materials * sizeof(dev_material));
     for (iter=host_materials.begin(); iter != host_materials.end(); ++iter){
+      printf("this material\n");
       clone_material(iter->second, &_materials[material_index]);
       _material_IDs_to_indices[iter->second->getId()] = material_index;
       material_index++;

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -332,7 +332,7 @@ __device__ double atomicAdd(double* address, double val) {
  * @param polar_weights the array of polar Quadrature weights
  * @param scalar_flux the array of FSR scalar fluxes
  */
-__device__ void scalarFluxTally(dev_segment* curr_segment,
+__device__ void tallyScalarFlux(dev_segment* curr_segment,
                                 int azim_index,
                                 int energy_group,
                                 dev_material* materials,
@@ -490,7 +490,7 @@ __global__ void transportSweepOnDevice(FP_PRECISION* scalar_flux,
     /* Loop over each Track segment in forward direction */
     for (int i=0; i < num_segments; i++) {
       curr_segment = &curr_track->_segments[i];
-      scalarFluxTally(curr_segment, azim_index, energy_group, materials,
+      tallyScalarFlux(curr_segment, azim_index, energy_group, materials,
                       track_flux, reduced_sources, polar_weights, scalar_flux);
     }
 
@@ -504,7 +504,7 @@ __global__ void transportSweepOnDevice(FP_PRECISION* scalar_flux,
 
     for (int i=num_segments-1; i > -1; i--) {
       curr_segment = &curr_track->_segments[i];
-      scalarFluxTally(curr_segment, azim_index, energy_group, materials,
+      tallyScalarFlux(curr_segment, azim_index, energy_group, materials,
                       track_flux, reduced_sources, polar_weights, scalar_flux);
   }
 

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -27,9 +27,8 @@ __constant__ FP_PRECISION polar_weights[MAX_POLAR_ANGLES*MAX_AZIM_ANGLES];
 /** The total number of Tracks */
 __constant__ int tot_num_tracks[1];
 
-//FIXME
 /** An GPUExpEvaluator object to compute exponentials */
-__device__ __constant__ GPUExpEvaluator exp_evaluator;
+__constant__ GPUExpEvaluator exp_evaluator;
 
 
 /**
@@ -719,10 +718,6 @@ GPUSolver::~GPUSolver() {
     _leakage_vec.clear();
     _leakage = NULL;
   }
-
-//  if (_exp_evaluator != NULL) {
-//    delete _exp_evaluator;
-//  }
 }
 
 
@@ -992,13 +987,9 @@ void GPUSolver::initializeExpEvaluator(){
 
   Solver::initializeExpEvaluator();
 
-  //FIXME
-  /* Allocate array for the table */
-//  if (_exp_table != NULL)
-//    delete [] _exp_table;
+  log_printf(INFO, "Initializing the exponential evaluator on the GPU...");
 
   /* Allocate memory for a GPUExpEvaluator on the device */
-//  GPUExpEvaluator* dev_exp_evaluator = new GPUExpEvaluator();
   GPUExpEvaluator* dev_exp_evaluator;
   cudaMalloc((void**)&dev_exp_evaluator, sizeof(GPUExpEvaluator));
 
@@ -1006,9 +997,9 @@ void GPUSolver::initializeExpEvaluator(){
   clone_exp_evaluator(_exp_evaluator, dev_exp_evaluator);
 
   /* Copy the GPUExpEvaluator into constant memory on the GPU */
-  cudaMemcpyToSymbol(exp_evaluator, (void*)&dev_exp_evaluator, 
+  cudaMemcpyToSymbol(exp_evaluator, (void*)dev_exp_evaluator, 
                      sizeof(GPUExpEvaluator), 0, cudaMemcpyDeviceToDevice);
-  
+
   return;
 }
 
@@ -1106,13 +1097,10 @@ void GPUSolver::initializeMaterials() {
     std::map<int, Material*>::iterator iter;
     int material_index = 0;
 
-    printf("going into materials loop. # materials = %d\n", _num_materials);
-    
     /* Iterate through all Materials and clone them as dev_material structs
      * on the device */
     cudaMalloc((void**)&_materials, _num_materials * sizeof(dev_material));
     for (iter=host_materials.begin(); iter != host_materials.end(); ++iter){
-      printf("this material\n");
       clone_material(iter->second, &_materials[material_index]);
       _material_IDs_to_indices[iter->second->getId()] = material_index;
       material_index++;

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -18,53 +18,18 @@ __constant__ int two_times_num_polar[1];
 /** The number of polar angles times energy groups */
 __constant__ int polar_times_groups[1];
 
-//FIXME
 /** An array for the sines of the polar angle in the polar Quadrature set */
-//__constant__ FP_PRECISION sinthetas[MAX_POLAR_ANGLES];
+__constant__ FP_PRECISION sin_thetas[MAX_POLAR_ANGLES];
 
 /** An array of the weights for the polar angles from the Quadrature set */
 __constant__ FP_PRECISION polar_weights[MAX_POLAR_ANGLES*MAX_AZIM_ANGLES];
-
-/** A pointer to an array with the number of tracks per azimuthal angle */
-__constant__ int num_tracks[MAX_AZIM_ANGLES/2];
 
 /** The total number of Tracks */
 __constant__ int tot_num_tracks[1];
 
 //FIXME
-/** The maximum index of the exponential linear interpolation table */
-//__constant__ int exp_table_max_index[1];
-
-//FIXME
-/** The spacing for the exponential linear interpolation table */
-//__constant__ FP_PRECISION exp_table_spacing[1];
-
-//FIXME
-/** The inverse spacing for the exponential linear interpolation table */
-//__constant__ FP_PRECISION inverse_exp_table_spacing[1];
-
-
-
-/**
- * @brief Fast method to round a single precision floating point value
- *        to an integer on the GPU.
- * @param x float floating point value to round
- * @return the rounded down integer value
- */
-__device__ int round_to_int(float x) {
-  return __float2int_rd(x);
-}
-
-
-/**
- * @brief Fast method to round a double precision floating point value
- *        to an integer on the GPU.
- * @param x double floating point value to round
- * @return the rounded down integer value
- */
-__device__ int round_to_int(double x) {
-  return __double2int_rd(x);
-}
+/** An GPUExpEvaluator object to compute exponentials */
+__device__ __constant__ GPUExpEvaluator exp_evaluator;
 
 
 /**
@@ -354,50 +319,6 @@ __device__ double atomicAdd(double* address, double val) {
 
 
 /**
- * @brief Computes the exponential term in the transport equation for a
- *        Track segment on the GPU.
- * @details This method computes \f$ 1 - exp(-l\Sigma^T_g/sin(\theta_p)) \f$
- *          for a segment with total group cross-section and for
- *          some polar angle.
- * @param sigma_t the total group cross-section at this energy
- * @param length the length of the line segment projected in the xy-plane
- * @param _exp_table the exponential linear interpolation table
- * @param p the polar angle index
- * @return the evaluated exponential
- */
-__device__ FP_PRECISION computeExponential(FP_PRECISION sigma_t,
-                                           FP_PRECISION length,
-                                           FP_PRECISION* _exp_table,
-                                           int p) {
-
-  FP_PRECISION exponential;
-  FP_PRECISION tau = sigma_t * length;
-
-  /* Evaluate the exponential using the linear interpolation table */
-  if (*interpolate_exponential) {
-    int index;
-
-    index = round_to_int(tau * (*inverse_exp_table_spacing));
-    index *= (*two_times_num_polar);
-    exponential = (1. - (_exp_table[index+2 * p] * tau +
-                         _exp_table[index + 2 * p +1]));
-  }
-
-  /* Evalute the exponential using the intrinsic exp(...) function */
-  else {
-    FP_PRECISION sintheta = sinthetas[p];
-    #ifdef SINGLE
-    exponential = 1.0 - __expf(- tau / sintheta);
-    #else
-    exponential = 1.0 - exp(- tau / sintheta);
-    #endif
-  }
-
-  return exponential;
-}
-
-
-/**
  * @brief Computes the contribution to the FSR scalar flux from a Track segment
  *        in a single energy group on the GPU.
  * @details This method integrates the angular flux for a Track segment across
@@ -410,7 +331,6 @@ __device__ FP_PRECISION computeExponential(FP_PRECISION sigma_t,
  * @param track_flux a pointer to the Track's angular flux
  * @param reduced_sources the array of FSR sources / total xs
  * @param polar_weights the array of polar Quadrature weights
- * @param _exp_table the exponential interpolation table
  * @param scalar_flux the array of FSR scalar fluxes
  */
 __device__ void scalarFluxTally(dev_segment* curr_segment,
@@ -420,7 +340,6 @@ __device__ void scalarFluxTally(dev_segment* curr_segment,
                                 FP_PRECISION* track_flux,
                                 FP_PRECISION* reduced_sources,
                                 FP_PRECISION* polar_weights,
-                                ExpEvaluator* _exp_evaluator,
                                 FP_PRECISION* scalar_flux) {
 
   int fsr_id = curr_segment->_region_uid;
@@ -435,14 +354,12 @@ __device__ void scalarFluxTally(dev_segment* curr_segment,
   /* Zero the FSR scalar flux contribution from this segment and energy group */
   FP_PRECISION fsr_flux = 0.0;
 
-  /* Compute the exponential interpolation table index */
-
   /* Loop over polar angles */
   for (int p=0; p < *num_polar; p++) {
     exponential = 
-      exp_evaluator->computeExponential(sigma_t[energy_group] * length, p);
-    delta_psi = (track_flux[p] - reduced_sources(fsr_id,energy_group)) *
-               exponential;
+      exp_evaluator.computeExponential(sigma_t[energy_group] * length, p);
+    delta_psi = (track_flux[p] - reduced_sources(fsr_id,energy_group));
+    delta_psi *= exponential;
     fsr_flux += delta_psi * polar_weights(azim_index,p);
     track_flux[p] -= delta_psi;
   }
@@ -521,7 +438,6 @@ __device__ void transferBoundaryFlux(dev_track* curr_track,
  * @param leakage an array of angular flux leakaages
  * @param materials an array of dev_material pointers
  * @param tracks an array of Tracks
- * @param _exp_table an array for the exponential interpolation table
  * @param tid_offset the Track offset for azimuthal angle halfspace
  * @param tid_max the upper bound on the Track IDs for this azimuthal
  *                angle halfspace
@@ -532,7 +448,6 @@ __global__ void transportSweepOnDevice(FP_PRECISION* scalar_flux,
                                        FP_PRECISION* leakage,
                                        dev_material* materials,
                                        dev_track* tracks,
-                                       ExpEvaluator* _exp_evaluator,
                                        int tid_offset,
                                        int tid_max) {
 
@@ -577,8 +492,7 @@ __global__ void transportSweepOnDevice(FP_PRECISION* scalar_flux,
     for (int i=0; i < num_segments; i++) {
       curr_segment = &curr_track->_segments[i];
       scalarFluxTally(curr_segment, azim_index, energy_group, materials,
-                      track_flux, reduced_sources, polar_weights,
-                      _exp_evaluator, scalar_flux);
+                      track_flux, reduced_sources, polar_weights, scalar_flux);
     }
 
     /* Transfer boundary angular flux to outgoing Track */
@@ -592,8 +506,7 @@ __global__ void transportSweepOnDevice(FP_PRECISION* scalar_flux,
     for (int i=num_segments-1; i > -1; i--) {
       curr_segment = &curr_track->_segments[i];
       scalarFluxTally(curr_segment, azim_index, energy_group, materials,
-                      track_flux, reduced_sources, polar_weights,
-                      _exp_evaluator, scalar_flux);
+                      track_flux, reduced_sources, polar_weights, scalar_flux);
   }
 
     /* Transfer boundary angular flux to outgoing Track */
@@ -808,8 +721,7 @@ GPUSolver::~GPUSolver() {
   }
 
   if (_exp_evaluator != NULL) {
-    cudaFree(_exp_evaluator);
-    _exp_evaluator = NULL;
+    delete _exp_evaluator;
   }
 }
 
@@ -1067,7 +979,7 @@ void GPUSolver::initializePolarQuadrature() {
 
   /* Copy the sines of the polar angles which is needed if the user
    * requested the use of the exp intrinsic to evaluate exponentials */
-  cudaMemcpyToSymbol(sinthetas, (void*)_polar_quad->getSinThetas(),
+  cudaMemcpyToSymbol(sin_thetas, (void*)_polar_quad->getSinThetas(),
                      _num_polar * sizeof(FP_PRECISION), 0,
                      cudaMemcpyHostToDevice);
 }
@@ -1082,48 +994,19 @@ void GPUSolver::initializeExpEvaluator(){
 
   //FIXME
   /* Allocate array for the table */
-  if (_exp_evaluator != NULL) {
-    cudaFree(_exp_evaluator);
-    _exp_evaluator = NULL;
-  }
-    delete [] _exp_table;
+//  if (_exp_table != NULL)
+//    delete [] _exp_table;
 
-  ExpEvaluator* dev_exp_evaluator;
+  /* Allocate memory for a GPUExpEvaluator on the device */
+  GPUExpEvaluator* dev_exp_evaluator = new GPUExpEvaluator();
 
-  /* Allocate memory for the exponential evalutor on the device */
-  cudaMalloc((void**)&_dev_exp_evaluator, sizeof(ExpEvaluator));
+  /* Clone ExpEvaluator from the host into GPUExpEvaluator on the device */
+  clone_exp_evaluator(_exp_evaluator, dev_exp_evaluator);
 
-
-  /* Copy a boolean indicating whether or not to use the linear interpolation
-   * table or the exp intrinsic function */
-  cudaMemcpyToSymbol(interpolate_exponential,(void*)&_interpolate_exponential,
-                     sizeof(bool), 0, cudaMemcpyHostToDevice);
-
-  /* Allocate array for the table */
-  if (_exp_table != NULL)
-    delete [] _exp_table;
-
-  /* Allocate memory for the interpolation table on the device */
-  cudaMalloc((void**)&_exp_table, _exp_table_size * sizeof(FP_PRECISION));
-
-  /* Copy exponential interpolation table to the device */
-  cudaMemcpy((void*)_exp_table, (void*)exp_table,
-             _exp_table_size * sizeof(FP_PRECISION),
-             cudaMemcpyHostToDevice);
-
-  /* Copy table size and spacing to constant memory on the device */
-  cudaMemcpyToSymbol(exp_table_spacing, (void*)&_exp_table_spacing,
-                     sizeof(FP_PRECISION), 0, cudaMemcpyHostToDevice);
-
-  cudaMemcpyToSymbol(inverse_exp_table_spacing,
-                     (void*)&_inverse_exp_table_spacing,
-                     sizeof(FP_PRECISION), 0, cudaMemcpyHostToDevice);
-
-  cudaMemcpyToSymbol(exp_table_max_index, (void*)&_exp_table_max_index,
-                    sizeof(int), 0, cudaMemcpyHostToDevice);
-
-  free(exp_table);
-
+  /* Copy the GPUExpEvaluator into constant memory on the GPU */
+  cudaMemcpyToSymbol(exp_evaluator, (void*)&dev_exp_evaluator, 
+                     sizeof(GPUExpEvaluator), 0, cudaMemcpyHostToDevice);
+  
   return;
 }
 
@@ -1225,7 +1108,7 @@ void GPUSolver::initializeMaterials() {
      * on the device */
     cudaMalloc((void**)&_materials, _num_materials * sizeof(dev_material));
     for (iter=host_materials.begin(); iter != host_materials.end(); ++iter){
-      clone_material_on_gpu(iter->second, &_materials[material_index]);
+      clone_material(iter->second, &_materials[material_index]);
       _material_IDs_to_indices[iter->second->getId()] = material_index;
       material_index++;
     }
@@ -1259,7 +1142,7 @@ void GPUSolver::initializeTracks() {
 
     for (int i=0; i < _tot_num_tracks; i++) {
 
-      clone_track_on_gpu(_tracks[i], &_dev_tracks[i], _material_IDs_to_indices);
+      clone_track(_tracks[i], &_dev_tracks[i], _material_IDs_to_indices);
 
       /* Make Track reflective */
       index = computeScalarTrackIndex(_tracks[i]->getTrackInI(),
@@ -1273,11 +1156,6 @@ void GPUSolver::initializeTracks() {
                  (void*)&index, sizeof(int), cudaMemcpyHostToDevice);
     }
 
-    /* Copy the array of number of Tracks for each azimuthal angle into
-     * constant memory on GPU */
-    cudaMemcpyToSymbol(num_tracks, (void*)_num_tracks,
-                       _num_azim * sizeof(int), 0, cudaMemcpyHostToDevice);
-
     /* Copy the total number of Tracks into constant memory on GPU */
     cudaMemcpyToSymbol(tot_num_tracks, (void*)&_tot_num_tracks,
                        sizeof(int), 0, cudaMemcpyHostToDevice);
@@ -1285,15 +1163,6 @@ void GPUSolver::initializeTracks() {
     /* Copy the number of azimuthal angles into constant memory on GPU */
     cudaMemcpyToSymbol(num_azim, (void*)&_num_azim, sizeof(int), 0,
                        cudaMemcpyHostToDevice);
-
-    /* Copy the array of number of Tracks for each azimuthal angles into
-     * constant memory on GPU */
-    cudaMemcpyToSymbol(num_tracks, (void*)_num_tracks,
-                       _num_azim * sizeof(int), 0, cudaMemcpyHostToDevice);
-
-    /* Copy the total number of Tracks into constant memory on GPU */
-    cudaMemcpyToSymbol(tot_num_tracks, (void*)&_tot_num_tracks,
-                       sizeof(int), 0, cudaMemcpyHostToDevice);
   }
 
   catch(std::exception &e) {
@@ -1582,7 +1451,6 @@ void GPUSolver::transportSweep() {
   transportSweepOnDevice<<<_B, _T, shared_mem>>>(_scalar_flux, _boundary_flux,
                                                  _reduced_sources, _leakage,
                                                  _materials, _dev_tracks,
-                                                 _exp_table,
                                                  tid_offset, tid_max);
 
   /* Sweep the second halfspace of azimuthal angle space */
@@ -1592,7 +1460,6 @@ void GPUSolver::transportSweep() {
   transportSweepOnDevice<<<_B, _T, shared_mem>>>(_scalar_flux, _boundary_flux,
                                                  _reduced_sources, _leakage,
                                                  _materials, _dev_tracks,
-                                                 _exp_table,
                                                  tid_offset, tid_max);
 }
 

--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -9,6 +9,7 @@
 #define GPUSOLVER_H_
 
 #ifdef __cplusplus
+#include "../../constants.h"
 #include "../../Solver.h"
 #endif
 
@@ -17,6 +18,7 @@
 #include <sm_13_double_functions.h>
 #include <sm_20_atomic_functions.h>
 #include "clone.h"
+#include "GPUExpEvaluator.h"
 
 /** Indexing macro for the scalar flux in each FSR and energy group */
 #define scalar_flux(tid,e) (scalar_flux[(tid)*(*num_groups) + (e)])
@@ -31,12 +33,6 @@
 /** Indexing macro for the angular fluxes for each polar angle and energy
  *  group for a given Track */
 #define boundary_flux(t,pe2) (boundary_flux[2*(t)*(*polar_times_groups)+(pe2)])
-
-/** The value of 4pi: \f$ 4\pi \f$ */
-#define FOUR_PI 12.5663706143
-
-/** The values of 1 divided by 4pi: \f$ \frac{1}{4\pi} \f$ */
-#define ONE_OVER_FOUR_PI 0.0795774715
 
 /** The maximum number of polar angles to reserve constant memory on GPU */
 #define MAX_POLAR_ANGLES 10

--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -39,7 +39,7 @@
 #define ONE_OVER_FOUR_PI 0.0795774715
 
 /** The maximum number of polar angles to reserve constant memory on GPU */
-#define MAX_POLAR_ANGLES 3
+#define MAX_POLAR_ANGLES 10
 
 /** The maximum number of azimuthal angles to reserve constant memory on GPU */
 #define MAX_AZIM_ANGLES 256
@@ -108,13 +108,13 @@ private:
   std::map<int, int> _material_IDs_to_indices;
 
   void initializePolarQuadrature();
+  void initializeExpEvaluator();
   void initializeFSRs();
   void initializeMaterials();
   void initializeTracks();
   void initializeFluxArrays();
   void initializeSourceArrays();
   void initializeThrustVectors();
-  void buildExpInterpTable();
 
   void zeroTrackFluxes();
   void flattenFSRFluxes(FP_PRECISION value);

--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -126,15 +126,12 @@ public:
 
   /**
    * @brief Constructor initializes arrays for dev_tracks and dev_materials..
-   * @details The constructor retrieves the number of energy groups and FSRs
-   *          and azimuthal angles from the Geometry and TrackGenerator if
-   *          passed in as parameters by the user. The constructor initalizes
-   *          the number of CUDA threads and thread blocks each to a default
-   *          of 64.
+   * @details The constructor initalizes the number of CUDA threads and 
+   *          thread blocks each to a default of 64.
    * @param geometry an optional pointer to the Geometry
    * @param track_generator an optional pointer to the TrackjGenerator
    */
-  GPUSolver(Geometry* geometry=NULL, TrackGenerator* track_generator=NULL);
+  GPUSolver(TrackGenerator* track_generator=NULL);
   virtual ~GPUSolver();
 
   /**

--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -20,6 +20,7 @@
 #include "clone.h"
 #include "GPUExpEvaluator.h"
 
+
 /** Indexing macro for the scalar flux in each FSR and energy group */
 #define scalar_flux(tid,e) (scalar_flux[(tid)*(*num_groups) + (e)])
 

--- a/src/accel/cuda/clone.cu
+++ b/src/accel/cuda/clone.cu
@@ -10,7 +10,7 @@
  * @param material_h pointer to a Material on the host
  * @param material_d pointer to a dev_material on the GPU
  */
-void clone_material_on_gpu(Material* material_h, dev_material* material_d) {
+void clone_material(Material* material_h, dev_material* material_d) {
 
   /* Copy over the Material's ID */
   int id = material_h->getId();
@@ -80,8 +80,8 @@ void clone_material_on_gpu(Material* material_h, dev_material* material_d) {
  * @param material_IDs_to_indices map of material IDs to indices
  *        in the _materials array.
  */
-void clone_track_on_gpu(Track* track_h, dev_track* track_d, 
-     			std::map<int, int> &material_IDs_to_indices) {
+void clone_track(Track* track_h, dev_track* track_d, 
+     		 std::map<int, int> &material_IDs_to_indices) {
 
   dev_segment* dev_segments;
   dev_segment* host_segments = new dev_segment[track_h->getNumSegments()];

--- a/src/accel/cuda/clone.h
+++ b/src/accel/cuda/clone.h
@@ -10,6 +10,6 @@
 #include "../DeviceTrack.h"
 #include <map>
 
-void clone_material_on_gpu(Material* material_h, dev_material* material_d);
-void clone_track_on_gpu(Track* track_h, dev_track* track_d, 
+void clone_material(Material* material_h, dev_material* material_d);
+void clone_track(Track* track_h, dev_track* track_d, 
                         std::map<int, int> &material_IDs_to_indices);

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,0 +1,39 @@
+/**
+ * @file constants.h
+ * @brief Math constants and comparision tolerances.
+ * @date April 9, 2015.
+ * @author William Boyd, MIT, Course 22 (wboyd@mit.edu)
+ */
+
+#ifndef CONSTANTS_H_
+#define CONSTANTS_H_
+
+
+/** The value of 4pi: \f$ 4\pi \f$ */
+#define FOUR_PI 12.5663706143
+
+/** The values of 1 divided by 4pi: \f$ \frac{1}{4\pi} \f$ */
+#define ONE_OVER_FOUR_PI 0.0795774715
+
+/** A negligible cross-section value to over-ride user-defined
+ *  cross-sections very near zero (e.g., within (-1E-10, 1E-10)) */
+#define ZERO_SIGMA_T 1E-10
+
+/** Threshold to determine how close the sum of \f$ \Sigma_a \f$ and 
+ *  \f$ \Sigma_s \f$ must match \f$ \Sigma_t \f$ for each energy group */
+#define SIGMA_T_THRESH 1E-3
+
+/** Distance a Point is moved to cross over a Surface into a new Cell */
+#define TINY_MOVE 1E-10
+
+/** Threshold to determine if a Point is on the boundary of a Lattice cell */
+#define ON_LATTICE_CELL_THRESH 1E-12
+
+/** Error threshold to determine if a point is to be considered on a Surface */
+#define ON_SURFACE_THRESH 1E-12
+
+/** Tolerance for difference of the sum of polar weights with respect to 1.0 */
+#define POLAR_WEIGHT_SUM_TOL 1E-5
+
+
+#endif /* CONSTANTS_H_ */


### PR DESCRIPTION
This PR presents some modifications to the ``CPUSolver::scalarFluxTally(...)`` routine. In particular, the CMFD surface current calculation is completely abstracted away from the MOC ``Solver`` class/subclasses into the ``Cmfd`` class. This streamlines the code in the ``Solver``, building upon the changes made in PR #137.