### PR TITLE
Quick fix for Intel compiler

### DIFF
--- a/src/VectorizedSolver.cpp
+++ b/src/VectorizedSolver.cpp
@@ -58,11 +58,6 @@ VectorizedSolver::~VectorizedSolver() {
     _fixed_sources = NULL;
   }
 
-  if (_source_residuals != NULL) {
-    MM_FREE(_source_residuals);
-    _source_residuals = NULL;
-  }
-
   if (_delta_psi != NULL) {
     MM_FREE(_delta_psi);
     _delta_psi = NULL;


### PR DESCRIPTION
This PR fixes an issue that was introduced in the recent spate of PRs with the Intel compiler. I'm honestly unsure how this slipped through the cracks since I did extensive testing with each PR individually, but this bug still slipped by even after all of them were merged. I noticed this bug since OpenMOC will only compile with icpc on nsecluster (the version of gcc is *very* old and does not support some necessary C++11 features).