### PR TITLE
Fixed errors caused by improper logger initialization

### DIFF
--- a/openmoc/__init__.py
+++ b/openmoc/__init__.py
@@ -19,6 +19,7 @@ now = datetime.datetime.now()
 current_time = str(now.month).zfill(2) + '-' + str(now.day).zfill(2) + '-' + str(now.year) + '--'
 current_time = current_time + str(now.hour).zfill(2) + ':' + str(now.minute).zfill(2)
 current_time = current_time + ':' + str(now.second).zfill(2)
+initialize_logger()
 set_log_filename('log/openmoc-' + current_time + '.log');
 
 Timer = Timer()

--- a/openmoc/__init__.py
+++ b/openmoc/__init__.py
@@ -20,6 +20,6 @@ current_time = str(now.month).zfill(2) + '-' + str(now.day).zfill(2) + '-' + str
 current_time = current_time + str(now.hour).zfill(2) + ':' + str(now.minute).zfill(2)
 current_time = current_time + ':' + str(now.second).zfill(2)
 initialize_logger()
-set_log_filename('log/openmoc-' + current_time + '.log');
+set_log_filename('openmoc-' + current_time + '.log');
 
 Timer = Timer()

--- a/openmoc/materialize.py
+++ b/openmoc/materialize.py
@@ -71,12 +71,11 @@ def materialize(filename):
   if filename.endswith('.h5') or filename.endswith('.hdf5'):
 
     import h5py
-    import numpy as np
 
     # Create a h5py file handle for the file
     try:
       f = h5py.File(filename,'r')
-    except:
+    except IOError:
       py_printf('ERROR', 'Unable to materialize file %s because it ' + \
                   'cannot be opened.  Check the file path.',filename)
 
@@ -86,8 +85,6 @@ def materialize(filename):
                   'not contain an \'Energy Groups\' attribute', filename)
 
     num_groups = f.attrs['Energy Groups']
-
-
 
     # Check that the number of energy groups is an integer
     if not is_integer(num_groups):

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -102,7 +102,7 @@ void set_output_directory(char* directory) {
 
   /* Check to see if directory exists - if not, create it */
   struct stat st;
-  if ((stat(directory, &st)) == 0)
+  if ((stat(directory, &st)) == 0) {
     log_directory = std::string("") + directory + std::string("/log");
     mkdir(log_directory.c_str(), S_IRWXU);
   }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -98,11 +98,14 @@ void initialize_logger() {
 void set_output_directory(char* directory) {
 
   output_directory = std::string(directory);
+  std::string log_directory;
 
   /* Check to see if directory exists - if not, create it */
   struct stat st;
-  if ((!stat(directory, &st)) == 0)
-    mkdir(directory, S_IRWXU);
+  if ((stat(directory, &st)) == 0)
+    log_directory = std::string("") + directory + std::string("/log");
+    mkdir(log_directory.c_str(), S_IRWXU);
+  }
 }
 
 
@@ -445,11 +448,11 @@ void log_printf(logLevel level, const char* format, ...) {
       /* If output directory was not defined by user, then log file is
        * written to a "log" subdirectory. Create it if it doesn't exist */
       if (output_directory.compare(".") == 0)
-        set_output_directory((char*)"log");
+        set_output_directory((char*)".");
 
       /* Write the message to the output file */
       std::ofstream log_file;
-      log_file.open((output_directory + "/" + log_filename).c_str(),
+      log_file.open((output_directory + "/log/" + log_filename).c_str(),
                    std::ios::app);
 
       /* Append date, time to the top of log output file */
@@ -465,7 +468,7 @@ void log_printf(logLevel level, const char* format, ...) {
 
     /* Write the log message to the log_file */
     std::ofstream log_file;
-    log_file.open((output_directory + "/" + log_filename).c_str(),
+    log_file.open((output_directory + "/log/" + log_filename).c_str(),
                   std::ios::app);
     log_file << msg_string;
     log_file.close();

--- a/src/log.h
+++ b/src/log.h
@@ -89,6 +89,7 @@ typedef enum logLevels {
  */
 extern void set_err(const char *msg);
 
+void initialize_logger();
 void set_output_directory(char* directory);
 const char* get_output_directory();
 void set_log_filename(char* filename);


### PR DESCRIPTION
This PR fixes an issue I noticed when accidentally trying to ``materialize`` a material data file that was non-existent (*i.e.*, the path to it was incorrect). In this case, instead of reporting an error message, the code simply segfault'ed. After tracing this error down, I found that was *not* an issue with the ``materialize`` module but rather a bug introduced by PR #140 with improper initialization of the logger module's OpenMP ``log_error_lock`` static variable. Fortunately the code changes necessary to fix this are minimal.

Previously, ``log_error_lock`` was initialized in the ``set_output_directory(...)`` routine which was *only* called by the user and not internally by OpenMOC. If the user never called ``set_output_directory(...)``, the logger module would instead create a "log" directory to store all of its log files. The creation of the "log" directory was explicitly done in the ``log_printf(...)`` routine rather than by correctly calling the ``set_output_directory(...)`` routine. 

I modifed ``log_printf(...)`` to call ``set_output_directory(...)`` to initialize the output directory. In addition, I added a new ``initialize_logger(...)`` routine which explicitly initializes the ``log_error_lock`` OMP variable. The ``initialize_logger(...)`` is called when OpenMOC is imported into Python (as can now be see in the "openmoc/\_\_init\_\_.py" file) to ensure that the lock is always ready to go if and when an "ERROR" message is channeled through the logger.

It should be noted that this bug occurs only when compiling with Intel's rather than GNU's C++ compiler. The reason (I think) is that ``g++`` implicitly calls ``omp_init_lock(...)`` for all variables of data type ``omp_lock_t`` while ``icpc`` requires explicit initialization in the source code. But this bug was never an issue when compiled with Intel *if* there was not an "ERROR" message to report. Oh so subtle...

This PR also slightly improves the ``try-catch`` exception handling for the ``openmoc.materialize`` module.