### PR TITLE
Hot fixes for Cell initialization

### DIFF
--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -51,6 +51,9 @@ Cell::Cell(int id, const char* name) {
   _name = NULL;
   setName(name);
 
+  _cell_type = UNFILLED;
+  _fill = NULL;
+
   _num_rings = 0;
   _num_sectors = 0;
 

--- a/src/Cell.h
+++ b/src/Cell.h
@@ -52,7 +52,10 @@ enum cellType {
   MATERIAL,
 
   /** A cell filled by a Universe */
-  FILL
+  FILL,
+
+  /** A cell not yet filled by anything */
+  UNFILLED
 };
 
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -773,8 +773,8 @@ void Geometry::segmentize(Track* track) {
 
   /* If starting Point was outside the bounds of the Geometry */
   if (curr == NULL)
-    log_printf(ERROR, "Could not find a Cell containing the start Point "
-               "of this Track: %s", track->toString().c_str());
+    log_printf(ERROR, "Could not find a material-filled Cell containing the "
+               "start Point of this Track: %s", track->toString().c_str());
 
   /* While the end of the segment's LocalCoords is still within the Geometry,
    * move it to the next Cell, create a new segment, and add it to the

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -274,7 +274,9 @@ std::map<int, Material*> Geometry::getAllMaterials() {
 
       if (cell->getType() == MATERIAL) {
         material = cell->getFillMaterial();
-        all_materials[material->getId()] = material;
+
+        if (material != NULL)
+          all_materials[material->getId()] = material;
       }
     }
   }

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -732,8 +732,8 @@ Lattice::Lattice(const int id, const char* name): Universe(id, name) {
   _offset.setCoords(0.0, 0.0);
 
   /* Default width and number of Lattice cells along each dimension */
-  _num_y = 0;
-  _num_x = 0;
+  _num_y = -1;
+  _num_x = -1;
   _width_x = 0;
   _width_y = 0;
 }


### PR DESCRIPTION
This PR fixes a few bugs which led to segmentation faults for certain use cases when initializing new ``Cells``. I ran into these situations while updating the online docs and executing the inline code examples. In particular, the elimination of ``CellBasic`` (filled by ``Materials``) and ``CellFill`` (filled by ``Universes``) in lieu of a single ``Cell`` class filled by either a ``Material`` or ``Universe`` in PR #142.