### PR TITLE
Fix Geometry::toString() method for improved importation of tracking files

### DIFF
--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1005,7 +1005,7 @@ std::string Geometry::toString() {
   string << "\n\tUniverses:\n\t\t";
   for (univ_iter = all_universes.begin();
        univ_iter != all_universes.end(); ++univ_iter)
-      string << univ_iter->second->toString() << "\n\t\t";
+    string << univ_iter->second->toString() << "\n\t\t";
 
   std::string formatted_string = string.str();
   formatted_string.erase(formatted_string.end()-3);

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1004,16 +1004,8 @@ std::string Geometry::toString() {
 
   string << "\n\tUniverses:\n\t\t";
   for (univ_iter = all_universes.begin();
-       univ_iter != all_universes.end(); ++univ_iter) {
-    if (univ_iter->second->getType() == UNIV) {
-      Universe* universe = static_cast<Universe*>(univ_iter->second);
-      string << universe->toString() << "\n\t\t";
-    }
-    else {
-      Lattice* lattice = static_cast<Lattice*>(univ_iter->second);
-      string << lattice->toString() << "\n\t\t";
-    }
-  }
+       univ_iter != all_universes.end(); ++univ_iter)
+      string << univ_iter->second->toString() << "\n\t\t";
 
   std::string formatted_string = string.str();
   formatted_string.erase(formatted_string.end()-3);

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1004,8 +1004,16 @@ std::string Geometry::toString() {
 
   string << "\n\tUniverses:\n\t\t";
   for (univ_iter = all_universes.begin();
-       univ_iter != all_universes.end(); ++univ_iter)
-    string << univ_iter->second->toString() << "\n\t\t";
+       univ_iter != all_universes.end(); ++univ_iter) {
+    if (univ_iter->second->getType() == UNIV) {
+      Universe* universe = static_cast<Universe*>(univ_iter->second);
+      string << universe->toString() << "\n\t\t";
+    }
+    else {
+      Lattice* lattice = static_cast<Lattice*>(univ_iter->second);
+      string << lattice->toString() << "\n\t\t";
+    }
+  }
 
   std::string formatted_string = string.str();
   formatted_string.erase(formatted_string.end()-3);

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -118,7 +118,7 @@ public:
   void subdivideCells();
   void buildNeighbors();
 
-  std::string toString();
+  virtual std::string toString();
   void printString();
 
   Universe* clone();


### PR DESCRIPTION
This PR fixes a bug that is the culprit behind Issue #168. The bug related to the way the ``Geometry::toString()`` routine assumed all ``Universes`` in a ``Geometry`` were indeed ``Universes`` and not the ``Lattice`` subclass. As a result, when building a string representation of the ``Geometry``, the ``Universe::toString()`` routine was called in place of the ``Lattice::toString()`` method, leaving out important information such as the ``Lattice`` dimensions and ``Universe`` IDs. Now, the routine calls ``Lattice::toString()`` explicitly when necessary, embedding the relevant geometric information needed to avoid perturbed geometries such as the examples discussed in #168.