### PR TITLE
moved call for CMFD initialization from Geometry to TrackGenerator

### DIFF
--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -760,10 +760,6 @@ void Geometry::initializeFlatSourceRegions() {
 
   /* Create map of Material IDs to Material pointers */
   _all_materials = getAllMaterials();
-
-  /* Initialize CMFD */
-  if (_cmfd != NULL)
-    initializeCmfd();
 }
 
 

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -479,6 +479,10 @@ void TrackGenerator::generateTracks() {
     delete [] _tracks;
   }
 
+  /* Initialize the CMFD object */
+  if (_geometry->getCmfd() != NULL)
+    _geometry->initializeCmfd();
+
   initializeTrackFileDirectory();
 
   /* If not Tracks input file exists, generate Tracks */


### PR DESCRIPTION
This PR address issue 170 by moving the call to initialize the CMFD object from the `Geometry::initializeFlatSourceRegions()` method to `TrackGenerator::generateTracks()` method so the CMFD object can be generated just prior to generation of the tracks.