### PR TITLE
Recompute cell min/max values and boundary conditions when queried

### DIFF
--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -161,6 +161,7 @@ int Cell::getNumSectors() {
  * @return the minimum x-coordinate
  */
 double Cell::getMinX() {
+  findBoundingBox();
   return _min_x;
 }
 
@@ -170,6 +171,7 @@ double Cell::getMinX() {
  * @return the maximum x-coordinate
  */
 double Cell::getMaxX() {
+  findBoundingBox();
   return _max_x;
 }
 
@@ -179,6 +181,7 @@ double Cell::getMaxX() {
  * @return the minimum y-coordinate
  */
 double Cell::getMinY() {
+  findBoundingBox();
   return _min_y;
 }
 
@@ -188,6 +191,7 @@ double Cell::getMinY() {
  * @return the maximum y-coordinate
  */
 double Cell::getMaxY() {
+  findBoundingBox();
   return _max_y;
 }
 
@@ -197,6 +201,7 @@ double Cell::getMaxY() {
  * @return the minimum z-coordinate
  */
 double Cell::getMinZ() {
+  findBoundingBox();
   return _min_z;
 }
 
@@ -206,6 +211,7 @@ double Cell::getMinZ() {
  * @return the maximum z-coordinate
  */
 double Cell::getMaxZ() {
+  findBoundingBox();
   return _max_z;
 }
 
@@ -216,6 +222,7 @@ double Cell::getMaxZ() {
  * @return the boundary condition at the minimum x-coordinate
  */
 boundaryType Cell::getMinXBoundaryType() {
+  findBoundingBox();
   return _min_x_bc;
 }
 
@@ -226,6 +233,7 @@ boundaryType Cell::getMinXBoundaryType() {
  * @return the boundary condition at the maximum x-coordinate
  */
 boundaryType Cell::getMaxXBoundaryType() {
+  findBoundingBox();
   return _max_x_bc;
 }
 
@@ -236,6 +244,7 @@ boundaryType Cell::getMaxXBoundaryType() {
  * @return the boundary condition at the minimum y-coordinate
  */
 boundaryType Cell::getMinYBoundaryType() {
+  findBoundingBox();
   return _min_y_bc;
 }
 
@@ -246,6 +255,7 @@ boundaryType Cell::getMinYBoundaryType() {
  * @return the boundary condition at the maximum y-coordinate
  */
 boundaryType Cell::getMaxYBoundaryType() {
+  findBoundingBox();
   return _max_y_bc;
 }
 
@@ -256,6 +266,7 @@ boundaryType Cell::getMaxYBoundaryType() {
  * @return the boundary condition at the minimum z-coordinate
  */
 boundaryType Cell::getMinZBoundaryType() {
+  findBoundingBox();
   return _min_z_bc;
 }
 
@@ -266,6 +277,7 @@ boundaryType Cell::getMinZBoundaryType() {
  * @return the boundary condition at the maximum z-coordinate
  */
 boundaryType Cell::getMaxZBoundaryType() {
+  findBoundingBox();
   return _max_z_bc;
 }
 
@@ -434,8 +446,6 @@ void Cell::addSurface(int halfspace, Surface* surface) {
   new_surf_half->_halfspace = halfspace;
 
   _surfaces[surface->getId()] = *new_surf_half;
-
-  findBoundingBox();
 }
 
 
@@ -447,8 +457,6 @@ void Cell::removeSurface(Surface* surface) {
 
   if (_surfaces.find(surface->getId()) != _surfaces.end())
     _surfaces.erase(surface->getId());
-
-  findBoundingBox();
 }
 
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -760,10 +760,6 @@ void Geometry::initializeFlatSourceRegions() {
 
   /* Create map of Material IDs to Material pointers */
   _all_materials = getAllMaterials();
-
-  /* Initialize CMFD */
-  if (_cmfd != NULL)
-    initializeCmfd();
 }
 
 

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -479,6 +479,10 @@ void TrackGenerator::generateTracks() {
     delete [] _tracks;
   }
 
+  /* Initialize the CMFD object */
+  if (_geometry->getCmfd() != NULL)
+    _geometry->initializeCmfd();
+
   initializeTrackFileDirectory();
 
   /* If not Tracks input file exists, generate Tracks */


### PR DESCRIPTION
This PR addresses issue 171 by recomputing the Cell's min/max values and boundary conditions when these values are queried. To avoid code reuse and because these evaluations are often quick, the `Cell::findBoundingBox()` method is called during each call to `Cell::getMin_()`, `Cell::getMax_()`, and `Cell::get____BoundaryType()` and all bounding box properties are updated instead of just the value being queried. This PR builds on PR #172 and should merged after that one.