### PR TITLE
Hotfix for Intel compiler

### DIFF
--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1080,12 +1080,14 @@ void Lattice::setUniverses(int num_y, int num_x, Universe** universes) {
  */
 void Lattice::removeUniverse(Universe* universe) {
 
+  Universe* null = NULL;
+
   /* Set all locations in the array of universes array to NULL */
   for (int j=0; j < _num_y; j++) {
     for (int i = 0; i < _num_x; i++) {
       if (universe->getId() == getUniverse(i,j)->getId())
         _universes.at(j).push_back(std::pair<int, Universe*>
-                                 (-1, NULL));
+                                 (-1, null));
     }
   }
 }

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1080,8 +1080,6 @@ void Lattice::setUniverses(int num_y, int num_x, Universe** universes) {
  */
 void Lattice::removeUniverse(Universe* universe) {
 
-  Universe* null = NULL;
-
   /* Set all locations in the array of universes array to NULL */
   for (int j=0; j < _num_y; j++) {
     for (int i = 0; i < _num_x; i++) {

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1084,7 +1084,7 @@ void Lattice::removeUniverse(Universe* universe) {
   for (int j=0; j < _num_y; j++) {
     for (int i = 0; i < _num_x; i++) {
       if (universe->getId() == getUniverse(i,j)->getId())
-        _universes.at(j)[i] = std::pair<int,Universe*>(-1,null);
+        _universes.at(j)[i] = std::pair<int,Universe*>(-1,NULL);
     }
   }
 }

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1086,8 +1086,7 @@ void Lattice::removeUniverse(Universe* universe) {
   for (int j=0; j < _num_y; j++) {
     for (int i = 0; i < _num_x; i++) {
       if (universe->getId() == getUniverse(i,j)->getId())
-        _universes.at(j).push_back(std::pair<int, Universe*>
-                                 (-1, null));
+        _universes.at(j)[i] = std::pair<int,Universe*>(-1,null);
     }
   }
 }

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -918,11 +918,13 @@ std::map<int, Universe*> Lattice::getUniqueUniverses() {
 
   std::map<int, Universe*> unique_universes;
   Universe* universe;
+  int univ_id;
 
   for (int i = _num_y-1; i > -1;  i--) {
     for (int j = 0; j < _num_x; j++) {
+      univ_id = _universes.at(i).at(j).first;
       universe = _universes.at(i).at(j).second;
-      unique_universes[universe->getId()] = universe;
+      unique_universes[univ_id] = universe;
     }
   }
 

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1080,11 +1080,13 @@ void Lattice::setUniverses(int num_y, int num_x, Universe** universes) {
  */
 void Lattice::removeUniverse(Universe* universe) {
 
+  Universe* null = NULL;
+
   /* Set all locations in the array of universes array to NULL */
   for (int j=0; j < _num_y; j++) {
     for (int i = 0; i < _num_x; i++) {
       if (universe->getId() == getUniverse(i,j)->getId())
-        _universes.at(j)[i] = std::pair<int,Universe*>(-1,NULL);
+        _universes.at(j)[i] = std::pair<int,Universe*>(-1, null);
     }
   }
 }


### PR DESCRIPTION
This PR fixes a bug which was preventing me from building the code using the Intel compiler (v0.13.1 on nsecluster). This was introduced by me in d35e0ca16b66c6f89a7d83550f4b6b4d01df4b33 in PR #161 in the ``Universe::removeUniverse(...)`` routine. Although this routine compiled just fine with GNU, the Intel compiler can be more strict sometimes and it caused it to fail.