### PR TITLE
Initialize keff in fixed source calculations

### DIFF
--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -719,6 +719,9 @@ void Solver::computeFlux(int max_iters, bool only_fixed_source) {
   /* Start the timer to record the total time to converge the flux */
   _timer->startTimer();
 
+  /* Initialize keff to 1 for FSR source calculations */
+  _k_eff = 1.;
+
   FP_PRECISION residual;
 
   /* Initialize data structures */
@@ -797,7 +800,7 @@ void Solver::computeFlux(int max_iters, bool only_fixed_source) {
  *          // ...
  * 
  *          // Find the flux distribution resulting from the fixed sources
- *          solver.computeFlux(max_iters=100, k_eff=0.981)
+ *          solver.computeSource(max_iters=100, k_eff=0.981)
  * @endcode
  *
  * @param max_iters the maximum number of source iterations to allow


### PR DESCRIPTION
This PR addresses #177 by initializing the ``_k_eff`` member variable of the ``Solver`` class to 1.0 for fixed source calculations (*e.g.*, ``Solver::computeFlux()``). Although fixed source calculations do not update ``_k_eff``, they do (re-)use the ``Solver::computeFSRSources()`` routine which uses ``_k_eff`` to scale the fission source. Although ``computeFlux()`` is intended to be used for problems without fissionable material and hence with a zero fission source, this zero fission source was being divided by ``_k_eff`` which was randomly initialized (in some cases to zero) which led to a NaN total source and flux. Now ``_k_eff`` is initialized to 1.0 in ``Solver::computeFlux()`` to avoid this issue entirely.