### PR TITLE
Hotfix for Solver::flattenFSRFluxes(...) routine

### DIFF
--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -198,10 +198,8 @@ void CPUSolver::flattenFSRFluxes(FP_PRECISION value) {
 
   #pragma omp parallel for schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
-    for (int e=0; e < _num_groups; e++) {
+    for (int e=0; e < _num_groups; e++)
       _scalar_flux(r,e) = value;
-      _old_scalar_flux(r,e) = value;
-    }
   }
 }
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -734,6 +734,7 @@ void Solver::computeFlux(int max_iters, bool only_fixed_source) {
   if (only_fixed_source || _num_iterations == 0) {
     initializeFluxArrays();
     flattenFSRFluxes(0.0);
+    storeFSRFluxes();
   }
 
   initializeSourceArrays();
@@ -837,6 +838,7 @@ void Solver::computeSource(int max_iters, double k_eff, residualType res_type) {
 
   /* Guess unity scalar flux for each region */
   flattenFSRFluxes(1.0);
+  storeFSRFluxes();
   zeroTrackFluxes();
 
   /* Source iteration loop */
@@ -922,6 +924,7 @@ void Solver::computeEigenvalue(int max_iters, residualType res_type) {
 
   /* Set scalar flux to unity for each region */
   flattenFSRFluxes(1.0);
+  storeFSRFluxes();
   zeroTrackFluxes();
 
   /* Source iteration loop */

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1179,7 +1179,6 @@ void GPUSolver::zeroTrackFluxes() {
  */
 void GPUSolver::flattenFSRFluxes(FP_PRECISION value) {
   thrust::fill(_scalar_flux.begin(), _scalar_flux.end(), value);
-  thrust::fill(_old_scalar_flux.begin(), _old_scalar_flux.end(), value);
 }
 
 


### PR DESCRIPTION
This PR fixes an issue introduced by PR #179. In a conversation I had with @cjosey earlier today, I recommended that he initialize the ``_old_scalar_flux`` array in ``Solver::flattenFSRFluxes(...)`` without fully considering the consequences. Since this PR was merged, the "develop" branch will now give erroneous results since other parts of the code assume that this routine *only* sets the ``_scalar_flux`` array in the ``Solver`` class. This PR fixes this issue by calling ``Solver::storeFluxes(...)`` routine when guessing the initial flux distribution to copy this initial guess from ``_scalar_flux`` to ``_old_scalar_flux``. 