### PR TITLE
Keff calculation based on successive fission sources

### DIFF
--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -28,10 +28,6 @@
  *  group for the outgoing reflective track from a given Track */
 #define track_out_flux(p,e) (track_out_flux[(p)*_num_groups + (e)])
 
-/** Indexing macro for the leakage for each polar angle and energy group
- *  for either the forward or reverse direction for a given Track */
-#define track_leakage(p,e) (track_leakage[(p)*_num_groups + (e)])
-
 
 /**
  * @class CPUSolver CPUSolver.h "src/CPUSolver.h"

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -935,7 +935,6 @@ void Solver::computeEigenvalue(int max_iters, residualType res_type) {
     transportSweep();
     addSourceToScalarFlux();
     residual = computeResidual(res_type);
-    storeFSRFluxes();
 
     /* Solve CMFD diffusion problem and update MOC flux */
     if (_cmfd != NULL && _cmfd->isFluxUpdateOn()) {
@@ -947,6 +946,8 @@ void Solver::computeEigenvalue(int max_iters, residualType res_type) {
 
     log_printf(NORMAL, "Iteration %d:\tk_eff = %1.6f"
                "\tres = %1.3E", i, _k_eff, residual);
+
+    storeFSRFluxes();
 
     /* Check for convergence of the fission source distribution */
     if (i > 1 && residual < _converge_thresh) {

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -24,7 +24,6 @@ Solver::Solver(TrackGenerator* track_generator) {
   _tracks = NULL;
   _polar_weights = NULL;
   _boundary_flux = NULL;
-  _boundary_leakage = NULL;
 
   _scalar_flux = NULL;
   _old_scalar_flux = NULL;

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -43,11 +43,6 @@
                                                 + (j)*_polar_times_groups \
                                                 + (p)*_num_groups + (e)])
 
-/** Indexing macro for the leakage for each polar angle and energy group
- *  for both the forward and reverse direction for each track */
-#define _boundary_leakage(i,pe2) (_boundary_leakage[2*(i)*_polar_times_groups \
-                                                    +(pe2)])
-
 /** Indexing scheme for fixed sources for each FSR and energy group */
 #define _fixed_sources(r,e) (_fixed_sources[(r)*_num_groups + (e)])
 
@@ -139,11 +134,6 @@ protected:
    *  a Track along both "forward" and "reverse" directions. */
   FP_PRECISION* _boundary_flux;
 
-  /** The angular leakages for each Track for all energy groups, polar angles,
-   *  and azimuthal angles. This array stores the weighted outgoing fluxes
-   *  for a Track along both "forward" and "reverse" directions. */
-  FP_PRECISION* _boundary_leakage;
-
   /** The scalar flux for each energy group in each FSR */
   FP_PRECISION* _scalar_flux;
 
@@ -175,8 +165,7 @@ protected:
   Cmfd* _cmfd;
 
   /**
-   * @brief Initializes Track boundary angular flux and leakage and
-   *        FSR scalar flux arrays.
+   * @brief Initializes Track boundary angular and FSR scalar flux arrays.
    */
   virtual void initializeFluxArrays() =0;
 

--- a/src/VectorizedSolver.cpp
+++ b/src/VectorizedSolver.cpp
@@ -33,11 +33,6 @@ VectorizedSolver::~VectorizedSolver() {
     _boundary_flux = NULL;
   }
 
-  if (_boundary_leakage != NULL) {
-    MM_FREE(_boundary_leakage);
-    _boundary_leakage = NULL;
-  }
-
   if (_scalar_flux != NULL) {
     MM_FREE(_scalar_flux);
     _scalar_flux = NULL;
@@ -165,8 +160,7 @@ void VectorizedSolver::initializeExpEvaluator() {
 
 
 /**
- * @brief Allocates memory for Track boundary angular flux and leakage and
- *        FSR scalar flux arrays.
+ * @brief Allocates memory for Track boundary angular and FSR scalar fluxes.
  * @details Deletes memory for old flux arrays if they were allocated for a
  *          previous simulation.
  */
@@ -175,9 +169,6 @@ void VectorizedSolver::initializeFluxArrays() {
   /* Delete old flux arrays if they exist */
   if (_boundary_flux != NULL)
     MM_FREE(_boundary_flux);
-
-  if (_boundary_leakage != NULL)
-    MM_FREE(_boundary_leakage);
 
   if (_scalar_flux != NULL)
     MM_FREE(_scalar_flux);
@@ -199,7 +190,6 @@ void VectorizedSolver::initializeFluxArrays() {
     size = 2 * _tot_num_tracks * _num_groups * _num_polar;
     size *= sizeof(FP_PRECISION);
     _boundary_flux = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
-    _boundary_leakage = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
     size = _num_FSRs * _num_groups * sizeof(FP_PRECISION);
     _scalar_flux = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
@@ -305,8 +295,10 @@ void VectorizedSolver::normalizeFluxes() {
   /* Normalize the FSR scalar fluxes */
   #ifdef SINGLE
   cblas_sscal(size, norm_factor, _scalar_flux, 1);
+  cblas_sscal(size, norm_factor, _old_scalar_flux, 1);
   #else
   cblas_dscal(size, norm_factor, _scalar_flux, 1);
+  cblas_dscal(size, norm_factor, _old_scalar_flux, 1);
   #endif
 
   /* Normalize the Track angular boundary fluxes */
@@ -450,15 +442,7 @@ void VectorizedSolver::addSourceToScalarFlux() {
 
 
 /**
- * @brief Compute \f$ k_{eff} \f$ from the total, fission and scattering
- *        reaction rates and leakage.
- * @details This method computes the current approximation to the
- *          multiplication factor on this iteration as follows:
- *          \f$ k_{eff} = \frac{\displaystyle\sum_{i \in I}
- *                        \displaystyle\sum_{g \in G} \nu \Sigma^F_g \Phi V_{i}}
- *                        {\displaystyle\sum_{i \in I}
- *                        \displaystyle\sum_{g \in G} (\Sigma^T_g \Phi V_{i} -
- *                        \Sigma^S_g \Phi V_{i} - L_{i,g})} \f$
+ * @brief Compute \f$ k_{eff} \f$ from successive fission sources.
  */
 void VectorizedSolver::computeKeff() {
 
@@ -466,7 +450,7 @@ void VectorizedSolver::computeKeff() {
   Material* material;
   FP_PRECISION* sigma;
   FP_PRECISION volume;
-  FP_PRECISION total, fission, scatter, leakage;
+  FP_PRECISION old_fission, new_fission;
 
   int size = _num_FSRs * sizeof(FP_PRECISION);
   FP_PRECISION* FSR_rates = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
@@ -474,7 +458,7 @@ void VectorizedSolver::computeKeff() {
   size = _num_threads * _num_groups * sizeof(FP_PRECISION);
   FP_PRECISION* group_rates = (FP_PRECISION*)MM_MALLOC(size, VEC_ALIGNMENT);
 
-  /* Loop over all FSRs and compute the volume-weighted total rates */
+  /* Compute the old nu-fission rates in each FSR */
   #pragma omp parallel for private(tid, volume, \
     material, sigma) schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
@@ -482,7 +466,7 @@ void VectorizedSolver::computeKeff() {
     tid = omp_get_thread_num() * _num_groups;
     volume = _FSR_volumes[r];
     material = _FSR_materials[r];
-    sigma = material->getSigmaT();
+    sigma = material->getNuSigmaF();
 
     /* Loop over each energy group vector length */
     for (int v=0; v < _num_vector_lengths; v++) {
@@ -490,7 +474,7 @@ void VectorizedSolver::computeKeff() {
       /* Loop over energy groups within this vector */
       #pragma simd vectorlength(VEC_LENGTH)
       for (int e=v*VEC_LENGTH; e < (v+1)*VEC_LENGTH; e++)
-        group_rates[tid+e] = sigma[e] * _scalar_flux(r,e);
+        group_rates[tid+e] = sigma[e] * _old_scalar_flux(r,e);
     }
 
     #ifdef SINGLE
@@ -500,14 +484,14 @@ void VectorizedSolver::computeKeff() {
     #endif
   }
 
-  /* Reduce total rates across FSRs, energy groups */
+  /* Reduce old fission rates across FSRs */
   #ifdef SINGLE
-  total = cblas_sasum(_num_FSRs, FSR_rates, 1);
+  old_fission = cblas_sasum(_num_FSRs, FSR_rates, 1);
   #else
-  total = cblas_dasum(_num_FSRs, FSR_rates, 1);
+  old_fission = cblas_dasum(_num_FSRs, FSR_rates, 1);
   #endif
 
-  /* Loop over all FSRs and compute the volume-weighted nu-fission rates */
+  /* Compute the new nu-fission rates in each FSR */
   #pragma omp parallel for private(tid, volume, \
     material, sigma) schedule(guided)
   for (int r=0; r < _num_FSRs; r++) {
@@ -533,64 +517,14 @@ void VectorizedSolver::computeKeff() {
     #endif
   }
 
-  /* Reduce nu-fission rates across FSRs */
+  /* Reduce new fission rates across FSRs */
   #ifdef SINGLE
-  fission = cblas_sasum(_num_FSRs, FSR_rates, 1);
+  new_fission = cblas_sasum(_num_FSRs, FSR_rates, 1);
   #else
-  fission = cblas_dasum(_num_FSRs, FSR_rates, 1);
+  new_fission = cblas_dasum(_num_FSRs, FSR_rates, 1);
   #endif
 
-  /* Loop over all FSRs and compute the volume-weighted scatter rates */
-  #pragma omp parallel for private(tid, volume, \
-    material, sigma) schedule(guided)
-  for (int r=0; r < _num_FSRs; r++) {
-
-    tid = omp_get_thread_num() * _num_groups;
-    volume = _FSR_volumes[r];
-    material = _FSR_materials[r];
-    sigma = material->getSigmaS();
-
-    FSR_rates[r] = 0.;
-
-    for (int G=0; G < _num_groups; G++) {
-
-      /* Loop over each energy group vector length */
-      for (int v=0; v < _num_vector_lengths; v++) {
-
-        /* Loop over energy groups within this vector */
-        #pragma simd vectorlength(VEC_LENGTH)
-        for (int g=v*VEC_LENGTH; g < (v+1)*VEC_LENGTH; g++)
-          group_rates[tid+g] = sigma[G*_num_groups+g] * _scalar_flux(r,g);
-      }
-
-      #ifdef SINGLE
-      FSR_rates[r] += cblas_sasum(_num_groups, &group_rates[tid], 1) * volume;
-      #else
-      FSR_rates[r] += cblas_dasum(_num_groups, &group_rates[tid], 1) * volume;
-      #endif
-    }
-  }
-
-  /* Reduce scatter rates across FSRs */
-  #ifdef SINGLE
-  scatter = cblas_sasum(_num_FSRs, FSR_rates, 1);
-  #else
-  scatter = cblas_dasum(_num_FSRs, FSR_rates, 1);
-  #endif
-
-  /** Reduce leakage array across tracks, energy groups, polar angles */
-  size = 2 * _tot_num_tracks * _polar_times_groups;
-
-  #ifdef SINGLE
-  leakage = cblas_sasum(size, _boundary_leakage, 1) * 0.5;
-  #else
-  leakage = cblas_dasum(size, _boundary_leakage, 1) * 0.5;
-  #endif
-
-  _k_eff = fission / (total - scatter + leakage);
-
-  log_printf(DEBUG, "tot = %f, fiss = %f, scatt = %f, leak = %f,"
-             "k_eff = %f", total, fission, scatter, leakage, _k_eff);
+  _k_eff *= new_fission / old_fission;
 
   MM_FREE(FSR_rates);
   MM_FREE(group_rates);
@@ -737,8 +671,7 @@ void VectorizedSolver::computeExponentials(segment* curr_segment,
 /**
  * @brief Updates the boundary flux for a Track given boundary conditions.
  * @details For reflective boundary conditions, the outgoing boundary flux
- *          for the Track is given to the reflecting Track. For vacuum
- *          boundary conditions, the outgoing flux tallied as leakage.
+ *          for the Track is given to the reflecting Track.
  * @param track_id the ID number for the Track of interest
  * @param azim_index a pointer to the azimuthal angle index for this segment
  * @param direction the Track direction (forward - true, reverse - false)
@@ -749,16 +682,13 @@ void VectorizedSolver::transferBoundaryFlux(int track_id, int azim_index,
                                             FP_PRECISION* track_flux) {
   int start;
   bool bc;
-  FP_PRECISION* track_leakage;
   int track_out_id;
 
-  /* Extract boundary conditions for this Track and the pointer to the
-   * outgoing reflective Track, and index into the leakage array */
+  /* Extract boundary conditions for this Track */
 
   /* For the "forward" direction */
   if (direction) {
     start = _tracks[track_id]->isReflOut() * _polar_times_groups;
-    track_leakage = &_boundary_leakage(track_id,0);
     track_out_id = _tracks[track_id]->getTrackOut()->getUid();
     bc = _tracks[track_id]->getBCOut();
   }
@@ -766,7 +696,6 @@ void VectorizedSolver::transferBoundaryFlux(int track_id, int azim_index,
   /* For the "reverse" direction */
   else {
     start = _tracks[track_id]->isReflIn() * _polar_times_groups;
-    track_leakage = &_boundary_leakage(track_id,_polar_times_groups);
     track_out_id = _tracks[track_id]->getTrackIn()->getUid();
     bc = _tracks[track_id]->getBCIn();
   }
@@ -783,16 +712,6 @@ void VectorizedSolver::transferBoundaryFlux(int track_id, int azim_index,
       #pragma simd vectorlength(VEC_LENGTH)
       for (int e=v*VEC_LENGTH; e < (v+1)*VEC_LENGTH; e++)
         track_out_flux(p,e) = track_flux(p,e) * bc;
-
-      /* Loop over energy groups within this vector */
-      #pragma simd vectorlength(VEC_LENGTH)
-      for (int e=v*VEC_LENGTH; e < (v+1)*VEC_LENGTH; e++)
-        track_leakage(p,e) = track_flux(p,e);
-
-      /* Loop over energy groups within this vector */
-      #pragma simd vectorlength(VEC_LENGTH)
-      for (int e=v*VEC_LENGTH; e < (v+1)*VEC_LENGTH; e++)
-        track_leakage(p,e) *= _polar_weights(azim_index,p) * (1-bc);
     }
   }
 }

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -205,67 +205,44 @@ __global__ void computeFSRSourcesOnDevice(int* FSR_materials,
  * @param FSR_materials an array of the FSR Material indices
  * @param materials an array of the dev_material pointers
  * @param scalar_flux an array of FSR scalar fluxes
- * @param total array of FSR total reaction rates
  * @param fission an array of FSR nu-fission rates
- * @param scatter an array of FSR scattering rates
  */
 __global__ void computeKeffReactionRates(FP_PRECISION* FSR_volumes,
                                          int* FSR_materials,
                                          dev_material* materials,
                                          FP_PRECISION* scalar_flux,
-                                         FP_PRECISION* total,
-                                         FP_PRECISION* fission,
-                                         FP_PRECISION* scatter) {
+                                         FP_PRECISION* fission) {
 
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
 
   dev_material* curr_material;
-  FP_PRECISION* sigma_t;
   FP_PRECISION* nu_sigma_f;
-  FP_PRECISION* sigma_s;
   FP_PRECISION volume;
 
-  FP_PRECISION tot = 0., fiss = 0., scatt = 0.;
+  FP_PRECISION fiss = 0.;
 
   /* Iterate over all FSRs */
   while (tid < *num_FSRs) {
 
     curr_material = &materials[FSR_materials[tid]];
-    sigma_t = curr_material->_sigma_t;
     nu_sigma_f = curr_material->_nu_sigma_f;
-    sigma_s = curr_material->_sigma_s;
     volume = FSR_volumes[tid];
 
-    FP_PRECISION curr_tot = 0., curr_fiss = 0., curr_scatt = 0.;
+    FP_PRECISION curr_fiss = 0.;
 
-    /* Iterate over all energy groups and update total and fission
-     * rates for this thread block */
-    for (int e=0; e < *num_groups; e++) {
-      curr_tot += sigma_t[e] * scalar_flux(tid,e);
+    /* Compute nu-fission rates rates for this thread block */
+    for (int e=0; e < *num_groups; e++)
       curr_fiss += nu_sigma_f[e] * scalar_flux(tid,e);
-    }
 
-    tot += curr_tot * volume;
     fiss += curr_fiss * volume;
-
-    /* Iterate over all energy groups and update scattering
-     * rates for this thread block */
-    for (int G=0; G < *num_groups; G++) {
-      for (int g=0; g < *num_groups; g++)
-        curr_scatt += sigma_s[G*(*num_groups)+g] * scalar_flux(tid,g);
-    }
-
-    scatt += curr_scatt * volume;
 
     /* Increment thread id */
     tid += blockDim.x * gridDim.x;
   }
 
-  /* Copy this thread's total and scatter rates to global memory */
+  /* Copy this thread's fission to global memory */
   tid = threadIdx.x + blockIdx.x * blockDim.x;
-  total[tid] = tot;
   fission[tid] = fiss;
-  scatter[tid] = scatt;
 }
 
 
@@ -345,14 +322,12 @@ __device__ void tallyScalarFlux(dev_segment* curr_segment,
 /**
  * @brief Updates the boundary flux for a Track given boundary conditions.
  * @details For reflective boundary conditions, the outgoing boundary flux
- *          for the Track is given to the reflecting track. For vacuum
- *          boundary conditions, the outgoing flux tallied as leakage.
+ *          for the Track is given to the reflecting track.
  *          Note: Only one energy group is transferred by this routine.
  * @param curr_track a pointer to the Track of interest
  * @param azim_index a pointer to the azimuthal angle index for this segment
  * @param track_flux an array of the outgoing Track flux
  * @param boundary_flux an array of all angular fluxes
- * @param leakage an array of leakages for each CUDA thread
  * @param polar_weights an array of polar Quadrature weights
  * @param energy_angle_index the energy group index
  * @param direction the Track direction (forward - true, reverse - false)
@@ -361,7 +336,6 @@ __device__ void transferBoundaryFlux(dev_track* curr_track,
                                      int azim_index,
                                      FP_PRECISION* track_flux,
                                      FP_PRECISION* boundary_flux,
-                                     FP_PRECISION* leakage,
                                      FP_PRECISION* polar_weights,
                                      int energy_angle_index,
                                      bool direction) {
@@ -370,8 +344,7 @@ __device__ void transferBoundaryFlux(dev_track* curr_track,
   bool bc;
   int track_out_id;
 
-  /* Extract boundary conditions for this Track and the pointer to the
-   * outgoing reflective Track, and index into the leakage array */
+  /* Extract boundary conditions for this Track */
 
   /* For the "forward" direction */
   if (direction) {
@@ -390,10 +363,8 @@ __device__ void transferBoundaryFlux(dev_track* curr_track,
   FP_PRECISION* track_out_flux = &boundary_flux(track_out_id,start);
 
   /* Put Track's flux in the shared memory temporary flux array */
-  for (int p=0; p < *num_polar; p++) {
+  for (int p=0; p < *num_polar; p++)
     track_out_flux[p] = track_flux[p] * bc;
-    leakage[0] += track_flux[p] * polar_weights(azim_index,p) * (1-bc);
-  }
 }
 
 
@@ -406,7 +377,6 @@ __device__ void transferBoundaryFlux(dev_track* curr_track,
  * @param scalar_flux an array of FSR scalar fluxes
  * @param boundary_flux an array of Track boundary fluxes
  * @param reduced_sources an array of FSR sources / total xs
- * @param leakage an array of angular flux leakaages
  * @param materials an array of dev_material pointers
  * @param tracks an array of Tracks
  * @param tid_offset the Track offset for azimuthal angle halfspace
@@ -416,7 +386,6 @@ __device__ void transferBoundaryFlux(dev_track* curr_track,
 __global__ void transportSweepOnDevice(FP_PRECISION* scalar_flux,
                                        FP_PRECISION* boundary_flux,
                                        FP_PRECISION* reduced_sources,
-                                       FP_PRECISION* leakage,
                                        dev_material* materials,
                                        dev_track* tracks,
                                        int tid_offset,
@@ -468,7 +437,6 @@ __global__ void transportSweepOnDevice(FP_PRECISION* scalar_flux,
 
     /* Transfer boundary angular flux to outgoing Track */
     transferBoundaryFlux(curr_track, azim_index, track_flux, boundary_flux,
-                         &leakage[threadIdx.x + blockIdx.x * blockDim.x],
                          polar_weights, energy_angle_index, true);
 
     /* Loop over each Track segment in reverse direction */
@@ -482,7 +450,6 @@ __global__ void transportSweepOnDevice(FP_PRECISION* scalar_flux,
 
     /* Transfer boundary angular flux to outgoing Track */
     transferBoundaryFlux(curr_track, azim_index, track_flux, boundary_flux,
-                         &leakage[threadIdx.x + blockIdx.x * blockDim.x],
                          polar_weights, energy_angle_index, false);
 
     /* Update the indices for this thread to the next Track, energy group */
@@ -625,7 +592,6 @@ GPUSolver::~GPUSolver() {
 
   /* Clear Thrust vectors's memory on the device */
   _boundary_flux.clear();
-  _boundary_leakage.clear();
   _scalar_flux.clear();
   _old_scalar_flux.clear();
   _fixed_sources.clear();
@@ -1074,8 +1040,7 @@ void GPUSolver::initializeTracks() {
 
 
 /**
- * @brief Allocates memory for Track boundary angular fluxes and leakages
- *        and FSR scalar fluxes on the GPU.
+ * @brief Allocates memory for Track boundary angular and FSR scalar fluxes.
  * @details Deletes memory for old flux vectors if they were allocated for a
  *          previous simulation.
  */
@@ -1085,7 +1050,6 @@ void GPUSolver::initializeFluxArrays() {
 
   /* Clear Thrust vectors' memory if previously allocated */
   _boundary_flux.clear();
-  _boundary_leakage.clear();
   _scalar_flux.clear();
   _old_scalar_flux.clear();
 
@@ -1093,7 +1057,6 @@ void GPUSolver::initializeFluxArrays() {
   try{
     int size = 2 * _tot_num_tracks * _polar_times_groups;
     _boundary_flux.resize(size);
-    _boundary_leakage.resize(_B * _T);
 
     size = _num_FSRs * _num_groups;
     _scalar_flux.resize(size);
@@ -1220,6 +1183,10 @@ void GPUSolver::normalizeFluxes() {
   thrust::transform(_scalar_flux.begin(), _scalar_flux.end(),
                     thrust::constant_iterator<FP_PRECISION>(norm_factor),
                     _scalar_flux.begin(), thrust::multiplies<FP_PRECISION>());
+  thrust::transform(_old_scalar_flux.begin(), _old_scalar_flux.end(),
+                    thrust::constant_iterator<FP_PRECISION>(norm_factor),
+                    _old_scalar_flux.begin(), 
+                    thrust::multiplies<FP_PRECISION>());
   thrust::transform(_boundary_flux.begin(), _boundary_flux.end(),
                     thrust::constant_iterator<FP_PRECISION>(norm_factor),
                     _boundary_flux.begin(), thrust::multiplies<FP_PRECISION>());
@@ -1270,14 +1237,11 @@ void GPUSolver::transportSweep() {
   log_printf(DEBUG, "Transport sweep on device with %d blocks and %d threads",
              _B, _T);
 
-  /* Initialize leakage to zero and get device pointer to the leakage array */
-  thrust::fill(_boundary_leakage.begin(), _boundary_leakage.end(), 0.0);
+  /* Get device pointer to the Thrust vectors */
   FP_PRECISION* scalar_flux = 
        thrust::raw_pointer_cast(&_scalar_flux[0]);
   FP_PRECISION* boundary_flux = 
        thrust::raw_pointer_cast(&_boundary_flux[0]);
-  FP_PRECISION* boundary_leakage = 
-       thrust::raw_pointer_cast(&_boundary_leakage[0]);
   FP_PRECISION* reduced_sources = 
        thrust::raw_pointer_cast(&_reduced_sources[0]);
 
@@ -1289,8 +1253,7 @@ void GPUSolver::transportSweep() {
   tid_max = (_tot_num_tracks / 2);
 
   transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
-                                                 reduced_sources, 
-                                                 boundary_leakage,
+                                                 reduced_sources,
                                                  _materials, _dev_tracks,
                                                  tid_offset, tid_max);
 
@@ -1299,8 +1262,7 @@ void GPUSolver::transportSweep() {
   tid_max = _tot_num_tracks;
 
   transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
-                                                 reduced_sources, 
-                                                 boundary_leakage,
+                                                 reduced_sources,
                                                  _materials, _dev_tracks,
                                                  tid_offset, tid_max);
 }
@@ -1323,8 +1285,7 @@ void GPUSolver::addSourceToScalarFlux() {
 
 
 /**
- * @brief Compute \f$ k_{eff} \f$ from the total, fission and scattering
- *        reaction rates and leakage.
+ * @brief Compute \f$ k_{eff} \f$ from successive fission sources.
  * @details This method computes the current approximation to the
  *          multiplication factor on this iteration as follows:
  *          \f$ k_{eff} = \frac{\displaystyle\sum_{i \in I}
@@ -1335,49 +1296,36 @@ void GPUSolver::addSourceToScalarFlux() {
  */
 void GPUSolver::computeKeff() {
 
-  FP_PRECISION total, fission, scatter, leakage;
+  FP_PRECISION old_fission, new_fission;
 
-  thrust::device_vector<FP_PRECISION> total_vec;
-  thrust::device_vector<FP_PRECISION> fission_vec;
-  thrust::device_vector<FP_PRECISION> scatter_vec;
-  total_vec.resize(_B * _T);
-  fission_vec.resize(_B * _T);
-  scatter_vec.resize(_B * _T);
+  thrust::device_vector<FP_PRECISION> old_fission_vec;
+  thrust::device_vector<FP_PRECISION> new_fission_vec;
+  old_fission_vec.resize(_B * _T);
+  new_fission_vec.resize(_B * _T);
 
-  FP_PRECISION* total_ptr = thrust::raw_pointer_cast(&total_vec[0]);
-  FP_PRECISION* fission_ptr = thrust::raw_pointer_cast(&fission_vec[0]);
-  FP_PRECISION* scatter_ptr = thrust::raw_pointer_cast(&scatter_vec[0]);
-  FP_PRECISION* scalar_flux = thrust::raw_pointer_cast(&_scalar_flux[0]);
+  FP_PRECISION* old_fiss_ptr = thrust::raw_pointer_cast(&old_fission_vec[0]);
+  FP_PRECISION* new_fiss_ptr = thrust::raw_pointer_cast(&new_fission_vec[0]);
+  FP_PRECISION* old_flux = thrust::raw_pointer_cast(&_old_scalar_flux[0]);
+  FP_PRECISION* new_flux = thrust::raw_pointer_cast(&_scalar_flux[0]);
 
   /* Compute the total, fission and scattering reaction rates on device.
    * This kernel stores partial rates in a Thrust vector with as many
    * entries as CUDAthreads executed by the kernel */
   computeKeffReactionRates<<<_B, _T>>>(_FSR_volumes, _FSR_materials,
-                                       _materials, scalar_flux,
-                                       total_ptr, fission_ptr, scatter_ptr);
+                                       _materials, old_flux, old_fiss_ptr);
+  computeKeffReactionRates<<<_B, _T>>>(_FSR_volumes, _FSR_materials,
+                                       _materials, new_flux, new_fiss_ptr);
 
   cudaDeviceSynchronize();
 
-  /* Compute the total, fission and scatter reaction rates by 
-   * reducing the partial rates compiled in the Thrust vectors */
-  total = thrust::reduce(total_vec.begin(), total_vec.end());
-  fission = thrust::reduce(fission_vec.begin(), fission_vec.end());
-  scatter = thrust::reduce(scatter_vec.begin(), scatter_vec.end());
+  /* Compute the old and new fission sources */
+  old_fission = thrust::reduce(old_fission_vec.begin(), old_fission_vec.end());
+  new_fission = thrust::reduce(new_fission_vec.begin(), new_fission_vec.end());
 
-  /* Compute the total leakage by reducing the partial leakage
-   * rates compiled in the Thrust vector */
-  leakage = 0.5 * thrust::reduce(_boundary_leakage.begin(),
-                                 _boundary_leakage.end());
+  _k_eff *= new_fission / old_fission;
 
-  /* Compute the new keff from the total, fission, scatter and leakage */
-  _k_eff = fission / (total - scatter + leakage);
-
-  log_printf(DEBUG, "tot = %f, fiss = %f, scatt = %f, leak = %f,"
-             " keff = %f", total, fission, scatter, leakage, _k_eff);
-
-  total_vec.clear();
-  fission_vec.clear();
-  scatter_vec.clear();
+  old_fission_vec.clear();
+  new_fission_vec.clear();
 }
 
 

--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -82,9 +82,6 @@ private:
   /** Thrust vector of angular fluxes for each track */
   thrust::device_vector<FP_PRECISION> _boundary_flux;
 
-  /** Thrust vector of leakages for each track */
-  thrust::device_vector<FP_PRECISION> _boundary_leakage;
-
   /** Thrust vector of FSR scalar fluxes */
   thrust::device_vector<FP_PRECISION> _scalar_flux;
 


### PR DESCRIPTION
This PR revises the way that the eigenvalue is computed to use fission sources from successive MOC iterations. In the current formulation from PR #115, the eigenvalue is computed directly based on the total, fission, scattering and leakage rates to account for multiplication from both nu-fission and (n,xn) reactions. Although this is sound, it does lead to some odd convergence behavior, such as that noted in #131. This likely the result of the boundary flux lagging the FSR scalar flux and hence oscillations in the convergence of the leakage (just my postulation). The new successive source formulation avoids this behavior since it does not need the leakage in the calculation. 

The switch to using successive fission sources has allowed all code related to the leakage to be removed which (marginally) improves both performance and the overall memory footprint. These changes have been implemented and verified for the ``CPUSolver``, ``GPUSolver`` and ``VectorizedSolver``. The new methodology has *only* been implemented for pure MOC eigenvalue calculations and is not included in CMFD. (@samuelshaner, how difficult would this be to translate over to CMFD, perhaps in #182?)

The successive fission source methodology for the eigenvalues will also be consistent for adjoint calculations, which I will provide in a separate PR later today. The direct methodology would *not* have been consistent as it would have required transposing both the scattering and fission source calculation routines. Rather than having two different modes to compute the forward/adjoint eigenvalues, it will be best to have a single streamlined calculation that will work for both.