### PR TITLE
HOTFIX: Removing un-necessary comment lines from debugging

### DIFF
--- a/profile/models/c5g7/c5g7-cmfd.cpp
+++ b/profile/models/c5g7/c5g7-cmfd.cpp
@@ -476,20 +476,20 @@ int main() {
   root_cell->setFill(full_geometry);
   
   /* Create CMFD mesh */
-  log_printf(NORMAL, "Creating CMFD mesh..."); /////////////////////////////////////
+  log_printf(NORMAL, "Creating CMFD mesh...");
 
   Cmfd cmfd;
   cmfd.setMOCRelaxationFactor(0.6);
   cmfd.setSORRelaxationFactor(1.5);
   cmfd.setLatticeStructure(51, 51);
   int cmfd_group_structure[3] = {1,4,8};
-  cmfd.setGroupStructure(cmfd_group_structure, 3); ///////////////////////////////////////
+  cmfd.setGroupStructure(cmfd_group_structure, 3);
 
   /* Create the geometry */
   log_printf(NORMAL, "Creating geometry...");
   Geometry geometry;
   geometry.setRootUniverse(root_universe);
-  geometry.setCmfd(&cmfd); ////////////////////////////////////////////////////////////
+  geometry.setCmfd(&cmfd);
   geometry.initializeFlatSourceRegions();
 
   /* Generate tracks */


### PR DESCRIPTION
I don't see any need for anyone to review this. It just deletes some slash marks I put in earlier for debugging. Definitely does not conform to the style guide. I am merging this now.