### PR TITLE
Removing unnecessary Makefile flags from C++ alternative build

### DIFF
--- a/profile/Makefile
+++ b/profile/Makefile
@@ -3,14 +3,11 @@
 #===============================================================================
 
 COMPILER    = gnu
-MPI         = no
 OPENMP      = yes
 OPTIMIZE    = yes
 DEBUG       = no
 PROFILE     = no
-PAPI        = no
-BENCHMARK   = no
-PRECISION   = double
+PRECISION   = single
 
 #===============================================================================
 # Source Code List
@@ -122,20 +119,6 @@ endif
 ifeq ($(COMPILER),clang)
   CFLAGS += -O3 -ffast-math -fvectorize -fpic
 endif
-endif
-
-# PAPI source (you may need to provide -I and -L pointing
-# to PAPI depending on your installation
-ifeq ($(PAPI),yes)
-  CFLAGS += -DPAPI
-  LDFLAGS += -lpapi
-  OPENMP = yes
-endif
-
-# MPI
-ifeq ($(MPI),yes)
-  CC = mpic++
-  CFLAGS += -DMPI
 endif
 
 # OpenMP


### PR DESCRIPTION
This is a simple PR to remove un-needed Makefile options from the alternative C++ build system such as MPI and PAPI (not used currently in OpenMOC). This should be merged soon, barring any objections.