### PR TITLE
Changed GPU compile flags to a generic one for newer machines

### DIFF
--- a/config.py
+++ b/config.py
@@ -206,8 +206,7 @@ class configuration:
   compiler_flags['nvcc'] =  ['--relocatable-device-code', 'true',
                              '-c', '-O3',  '-std=c++11', 
                              '--compiler-options', '-fpic',
-                             '-gencode=arch=compute_20,code=sm_20',
-                             '-gencode=arch=compute_30,code=sm_30']
+                             '-arch=compute_20']
 
 
   #############################################################################


### PR DESCRIPTION
This changes the compile flags for NVCC from ones that will only compile for ``sm_20`` and ``sm_30`` to one that will JIT compile based on the user's GPU.

This allows for higher shader model machines, and might slightly reduce compile time as fewer binaries are created.  Code was tested on 3 GPUs successfully, an ``sm_30`` device (Quadro K600), an ``sm_35`` device (Tesla K20), and an ``sm_52`` device (Titan X).  Prior to this patch, only the first one was supported.

In testing with C5G7 (with 32 angles), there was no performance difference between any ``compute_nn``, so ``compute_20``, which supports the most devices, was selected.

This also fixes issue #192.