### PR TITLE
Fixed FSR keys to be unique

### DIFF
--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -565,22 +565,21 @@ int Geometry::findFSRId(LocalCoords* coords) {
   int fsr_id;
   LocalCoords* curr = coords;
   curr = coords->getLowestLevel();
-  std::hash<std::string> key_hash_function;
 
   /* Generate unique FSR key */
-  std::size_t fsr_key_hash = key_hash_function(getFSRKey(coords));
+  std::string fsr_key = getFSRKey(coords);
 
   /* If FSR has not been encountered, update FSR maps and vectors */
-  if (!_FSR_keys_map.contains(fsr_key_hash)) {
+  if (!_FSR_keys_map.contains(fsr_key)) {
 
     /* Try to get a clean copy of the fsr_id, adding the FSR data 
        if necessary where -1 indicates the key was already added */
-    fsr_id = _FSR_keys_map.insert_and_get_count(fsr_key_hash, NULL);
+    fsr_id = _FSR_keys_map.insert_and_get_count(fsr_key, NULL);
     if (fsr_id == -1)
     {
       fsr_data volatile* fsr;
       do {
-        fsr = _FSR_keys_map.at(fsr_key_hash);
+        fsr = _FSR_keys_map.at(fsr_key);
       } while (fsr == NULL);
       fsr_id = fsr->_fsr_id;
     }
@@ -589,7 +588,7 @@ int Geometry::findFSRId(LocalCoords* coords) {
       /* Add FSR information to FSR key map and FSR_to vectors */
       fsr_data* fsr = new fsr_data;
       fsr->_fsr_id = fsr_id;
-      _FSR_keys_map.at(fsr_key_hash) = fsr;
+      _FSR_keys_map.at(fsr_key) = fsr;
       Point* point = new Point();
       point->setCoords(coords->getHighestLevel()->getX(), 
                        coords->getHighestLevel()->getY());
@@ -609,7 +608,7 @@ int Geometry::findFSRId(LocalCoords* coords) {
   else {
     fsr_data volatile* fsr;
     do {
-      fsr = _FSR_keys_map.at(fsr_key_hash);
+      fsr = _FSR_keys_map.at(fsr_key);
     } while (fsr == NULL);
 
     fsr_id = fsr->_fsr_id;
@@ -629,11 +628,10 @@ int Geometry::getFSRId(LocalCoords* coords) {
 
   int fsr_id = 0;
   std::string fsr_key;
-  std::hash<std::string> key_hash_function;
 
   try{
     fsr_key = getFSRKey(coords);
-    fsr_id = _FSR_keys_map.at(key_hash_function(fsr_key))->_fsr_id;
+    fsr_id = _FSR_keys_map.at(fsr_key)->_fsr_id;
   }
   catch(std::exception &e) {
     log_printf(ERROR, "Could not find FSR ID with key: %s. Try creating "
@@ -912,19 +910,19 @@ void Geometry::segmentize(Track* track) {
 void Geometry::initializeFSRVectors() {
   
   /* get keys and values from map */
-  std::size_t *key_list = _FSR_keys_map.keys();
+  std::string *key_list = _FSR_keys_map.keys();
   fsr_data **value_list = _FSR_keys_map.values();
 
   /* allocate vectors */
   int num_FSRs = _FSR_keys_map.size();
-  _FSRs_to_keys = std::vector<size_t>(num_FSRs);
+  _FSRs_to_keys = std::vector<std::string>(num_FSRs);
   _FSRs_to_material_IDs = std::vector<int>(num_FSRs);
 
   /* fill vectors key and material ID information */
   #pragma omp parallel for
   for (int i=0; i < num_FSRs; i++)
   {
-    std::size_t key = key_list[i];
+    std::string key = key_list[i];
     fsr_data* fsr = value_list[i];
     int fsr_id = fsr->_fsr_id;
     _FSRs_to_keys.at(fsr_id) = key;
@@ -1098,7 +1096,7 @@ void Geometry::initializeCmfd() {
  * @brief Returns a pointer to the map that maps FSR keys to FSR IDs
  * @return pointer to _FSR_keys_map map of FSR keys to FSR IDs
  */
-ParallelHashMap<std::size_t, fsr_data*>* Geometry::getFSRKeysMap() {
+ParallelHashMap<std::string, fsr_data*>* Geometry::getFSRKeysMap() {
   return &_FSR_keys_map;
 }
 
@@ -1107,7 +1105,7 @@ ParallelHashMap<std::size_t, fsr_data*>* Geometry::getFSRKeysMap() {
  * @brief Returns the vector that maps FSR IDs to FSR key hashes
  * @return _FSR_keys_map map of FSR keys to FSR IDs
  */
-std::vector<std::size_t>* Geometry::getFSRsToKeys() {
+std::vector<std::string>* Geometry::getFSRsToKeys() {
   return &_FSRs_to_keys;
 }
 
@@ -1134,7 +1132,7 @@ std::vector<int>* Geometry::getFSRsToMaterialIDs() {
  *          are read from file to avoid unnecessary segmentation.  
  * @param FSR_keys_map map of FSR keys to FSR data
  */
-void Geometry::setFSRKeysMap(ParallelHashMap<std::size_t, fsr_data*>* 
+void Geometry::setFSRKeysMap(ParallelHashMap<std::string, fsr_data*>* 
                              FSR_keys_map) {
   _FSR_keys_map = *FSR_keys_map;
 }
@@ -1143,7 +1141,7 @@ void Geometry::setFSRKeysMap(ParallelHashMap<std::size_t, fsr_data*>*
  * @brief Sets the _FSRs_to_keys vector
  * @param FSRs_to_keys vector of FSR key hashes indexed by FSR IDs
  */
-void Geometry::setFSRsToKeys(std::vector<std::size_t>* FSRs_to_keys) {
+void Geometry::setFSRsToKeys(std::vector<std::string>* FSRs_to_keys) {
   _FSRs_to_keys = *FSRs_to_keys;
 }
 

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -93,10 +93,10 @@ private:
   boundaryType _right_bc;
 
   /** An map of FSR key hashes to unique fsr_data structs */
-  ParallelHashMap<std::size_t, fsr_data*> _FSR_keys_map;
+  ParallelHashMap<std::string, fsr_data*> _FSR_keys_map;
 
   /** An vector of FSR key hashes indexed by FSR ID */
-  std::vector<std::size_t> _FSRs_to_keys;
+  std::vector<std::string> _FSRs_to_keys;
 
   /** A vector of Material IDs indexed by FSR IDs */
   std::vector<int> _FSRs_to_material_IDs;
@@ -145,20 +145,20 @@ public:
   void setRootUniverse(Universe* root_universe);
 
   Cmfd* getCmfd();
-  std::vector<std::size_t>* getFSRsToKeys();
+  std::vector<std::string>* getFSRsToKeys();
   std::vector<int>* getFSRsToMaterialIDs();
   int getFSRId(LocalCoords* coords);
   Point* getFSRPoint(int fsr_id);
   Point* getFSRCentroid(int fsr_id);
   std::string getFSRKey(LocalCoords* coords);
-  ParallelHashMap<std::size_t, fsr_data*>* getFSRKeysMap();
+  ParallelHashMap<std::string, fsr_data*>* getFSRKeysMap();
 
   /* Set parameters */
   void setFSRsToMaterialIDs(std::vector<int>* FSRs_to_material_IDs);
-  void setFSRsToKeys(std::vector<std::size_t>* FSRs_to_keys);
+  void setFSRsToKeys(std::vector<std::string>* FSRs_to_keys);
   void setCmfd(Cmfd* cmfd);
   void setFSRCentroid(int fsr, Point* centroid);
-  void setFSRKeysMap(ParallelHashMap<std::size_t, fsr_data*>* FSR_keys_map);
+  void setFSRKeysMap(ParallelHashMap<std::string, fsr_data*>* FSR_keys_map);
 
   /* Find methods */
   Cell* findCellContainingCoords(LocalCoords* coords);


### PR DESCRIPTION
This PR corrects for the potential bug of two unique ``fsr_key`` strings hashing to the same key. Currently OpenMOC converts an FSR region into a unique string identifier and then hashes that string to an integer (``size_t``). That integer is then used as the key to be inserted into the hash table. This is incorrect since the hash table already uses an internal hashing function. This leads to potentially loading the incorrect FSR.

This PR corrects this behavior to instead use the unique string identifiers as keys. In this way, we gain the benefit of hashing (present internally in the hash table) but also safeguard against inconsistency by directly comparing the unique string identifiers.