### PR TITLE
Cmfd shared memory optimization

### DIFF
--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -2155,7 +2155,7 @@ void Cmfd::tallySurfaceCurrent(segment* curr_segment, FP_PRECISION* track_flux,
 
     surf_id = curr_segment->_cmfd_surface_fwd;
 
-    /* Prepare surface current */
+    /* Prepare Cmfd Mesh surface current */
     for (int e=0; e < _num_moc_groups; e++) {
       surf_current[e] = 0.f;
 
@@ -2165,7 +2165,7 @@ void Cmfd::tallySurfaceCurrent(segment* curr_segment, FP_PRECISION* track_flux,
       surf_current[e] = surf_current[e] / 2.f;
     }
 
-    /* SHM write surface current */
+    /* SHM write Cmfd Mesh surface current */
     omp_set_lock(&_surface_locks[surf_id]);
     #pragma omp simd
     for (int e=0; e < _num_moc_groups; e++)
@@ -2177,7 +2177,7 @@ void Cmfd::tallySurfaceCurrent(segment* curr_segment, FP_PRECISION* track_flux,
 
     surf_id = curr_segment->_cmfd_surface_bwd;
 
-    /* Prepare surface current */
+    /* Prepare Cmfd Mesh surface current */
     for (int e=0; e < _num_moc_groups; e++) {
       surf_current[e] = 0.f;
 
@@ -2187,7 +2187,7 @@ void Cmfd::tallySurfaceCurrent(segment* curr_segment, FP_PRECISION* track_flux,
       surf_current[e] = surf_current[e] / 2.f;
     }
 
-    /* SHM write surface current */
+    /* SHM write Cmfd Mesh surface current */
     omp_set_lock(&_surface_locks[surf_id]);
     #pragma omp simd
     for (int e=0; e < _num_moc_groups; e++) 

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -2165,7 +2165,7 @@ void Cmfd::tallySurfaceCurrent(segment* curr_segment, FP_PRECISION* track_flux,
       surf_current[e] = surf_current[e] / 2.f;
     }
 
-	/* SHM write surface current */
+    /* SHM write surface current */
     omp_set_lock(&_surface_locks[surf_id]);
     #pragma omp simd
     for (int e=0; e < _num_moc_groups; e++)
@@ -2187,7 +2187,7 @@ void Cmfd::tallySurfaceCurrent(segment* curr_segment, FP_PRECISION* track_flux,
       surf_current[e] = surf_current[e] / 2.f;
     }
 
-	/* SHM write surface current */
+    /* SHM write surface current */
     omp_set_lock(&_surface_locks[surf_id]);
 	#pragma omp simd
     for (int e=0; e < _num_moc_groups; e++) 

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -2189,7 +2189,7 @@ void Cmfd::tallySurfaceCurrent(segment* curr_segment, FP_PRECISION* track_flux,
 
     /* SHM write surface current */
     omp_set_lock(&_surface_locks[surf_id]);
-	#pragma omp simd
+    #pragma omp simd
     for (int e=0; e < _num_moc_groups; e++) 
       _surface_currents(surf_id, e) += surf_current[e];
     omp_unset_lock(&_surface_locks[surf_id]);


### PR DESCRIPTION
In this PR I've optimized the shared memory locking implementation for CMFD. When using many threads, I observe performance improvements of 1.2x - 2x on c5g7-cmfd depending on machine and problem size.

The optimization is the result of reducing the number of times the locks are accessed. Rather than preparing data and locking in the same step for each energy group and polar angle, we now prepare our contributions in advance for all energy groups, then lock once and write all data in one transaction.

I've also added simd pragmas inside the update loop, which don't offer much improvement for low group numbers, but should speed things up for larger problem sizes. I chose the "omp simd" flavor as this is a little more portable.