### PR TITLE
Fix issue with exponential evaluations on GPU

### DIFF
--- a/src/ExpEvaluator.cpp
+++ b/src/ExpEvaluator.cpp
@@ -171,6 +171,10 @@ void ExpEvaluator::initialize() {
   int num_array_values = _max_optical_length * sqrt(1. / (8. * _exp_precision));
   FP_PRECISION exp_table_spacing = _max_optical_length / num_array_values;
 
+  /* Increment the number of vaues in the array to ensure that a tau equal to
+   * max_optical_length resides as the final entry in the table */
+  num_array_values += 1;
+
   /* Compute the reciprocal of the table entry spacing */
   _inverse_exp_table_spacing = 1.0 / exp_table_spacing;
 

--- a/src/ExpEvaluator.cpp
+++ b/src/ExpEvaluator.cpp
@@ -166,9 +166,6 @@ void ExpEvaluator::initialize() {
 
   log_printf(INFO, "Initializing exponential interpolation table...");
 
-  /* Expand max tau slightly to avoid roundoff error approximation */
-  _max_optical_length *= 1.00001;
-
   /* Set size of interpolation table */
   int num_polar = _polar_quad->getNumPolarAngles();
   int num_array_values = _max_optical_length * sqrt(1. / (8. * _exp_precision));
@@ -219,8 +216,8 @@ FP_PRECISION ExpEvaluator::computeExponential(FP_PRECISION tau, int polar) {
 
   /* Evaluate the exponential using the lookup table - linear interpolation */
   if (_interpolate) {
-    int index;
-    index = floor(tau * _inverse_exp_table_spacing);
+    tau = std::min(tau, (_max_optical_length));
+    int index = floor(tau * _inverse_exp_table_spacing);
     index *= _two_times_num_polar;
     exponential = (1. - (_exp_table[index + 2 * polar] * tau +
                   _exp_table[index + 2 * polar + 1]));

--- a/src/accel/cuda/GPUExpEvaluator.h
+++ b/src/accel/cuda/GPUExpEvaluator.h
@@ -31,7 +31,6 @@ private:
 
 public:
 
-  //FIXME: Put in shared memory!!
   /** The exponential linear interpolation table */
   FP_PRECISION* _exp_table;
 


### PR DESCRIPTION
In the process of debugging the adjoint eigenmode calculations on the GPU for #187, I happened to try to run the "homogeneous-one-group" and "homogeneous-two-group" benchmarks with the ``GPUSolver`` and noted that they failed. In particular, the ``GPUSolver`` will produce "inf" for k-infinity for each of these cases for certain azimuthal angle counts when using the exp table, but *not* when using an exp intrinsic. After a little digging, I believe the issue is that CUDA bends the IEEE math rules (when using "-ffast-math") which leads to a slightly different outcome for the arithmetic operations used to compute the optical path length (tau). In certain rare scenarios, tau is just every so slightly larger than the maximum allowable tau, which results in the table index to overflow the table. Of course this will lead to errant results for the exponential calculation. Based on my analysis, this should *not* occur if IEEE math is adhered to as *should* be the case for the solvers written in C++. In any case, this PR uses a ``std::min`` to ensure that the tau used to compute the exponential table index is never larger than the maximum allowable tau. For consistency, I implemented this in both the ``ExpEvaluator`` and ``GPUExpEvaluator`` classes.