### PR TITLE
Update to Periodic Boundary Conditions PR

### DIFF
--- a/config.py
+++ b/config.py
@@ -165,7 +165,7 @@ class configuration:
                      'src/Cmfd.cpp',
                      'src/Vector.cpp',
                      'src/Matrix.cpp',
-                     'src/linalg/cpp']
+                     'src/linalg.cpp']
 
 
   sources['bgxlc'] = ['openmoc/openmoc_wrap.cpp',

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -666,12 +666,13 @@ void CPUSolver::computeKeff() {
 void CPUSolver::transportSweep() {
 
   int tid;
-  int min_track, max_track;
   int azim_index, num_segments;
   Track* curr_track;
   segment* curr_segment;
   segment* segments;
   FP_PRECISION* track_flux;
+  int min_track = 0;
+  int max_track = 0;
 
   log_printf(DEBUG, "Transport sweep with %d OpenMP threads", _num_threads);
 
@@ -686,8 +687,8 @@ void CPUSolver::transportSweep() {
 
     /* Compute the minimum and maximum Track IDs corresponding to
      * this parallel track group */
-    min_track = _num_tracks_by_parallel_group[i];
-    max_track = _num_tracks_by_parallel_group[i+1];
+    min_track = max_track;
+    max_track += _track_generator->getNumTracksByParallelGroup(i);
 
     /* Loop over each thread within this azimuthal angle halfspace */
     #pragma omp parallel for private(curr_track, azim_index, num_segments, \
@@ -813,42 +814,20 @@ void CPUSolver::transferBoundaryFlux(int track_id,
                                      bool direction,
                                      FP_PRECISION* track_flux) {
   int start;
-  int bc;
+  bool transfer_flux;
   int track_out_id;
 
   /* For the "forward" direction */
   if (direction) {
     start = _tracks[track_id]->isNextOut() * _polar_times_groups;
-
-    /* If the outgoing boundary condition is vacuum, set bc to 0 indicating the
-     * track flux of the outgoing track will be zeroed out */
-    if (_tracks[track_id]->getBCOut() == VACUUM)
-      bc = 0;
-
-    /* If the outgoing boundary condition is anything other than vacuum, set
-     * bc to 1 indicating the flux passed to the outgoing track should be the
-     * current track's flux */
-    else
-      bc = 1;
-
+    transfer_flux = _tracks[track_id]->getTransferFluxOut();
     track_out_id = _tracks[track_id]->getTrackOut()->getUid();
   }
 
   /* For the "reverse" direction */
   else {
     start = _tracks[track_id]->isNextIn() * _polar_times_groups;
-
-    /* If the incoming boundary condition is vacuum, set bc to 0 indicating the
-     * track flux of the incoming track will be zeroed out */
-    if (_tracks[track_id]->getBCIn() == VACUUM)
-      bc = 0;
-
-    /* If the incoming boundary condition is anything other than vacuum, set
-     * bc to 1 indicating the flux passed to the incoming track should be the
-     * current track's flux. */
-    else
-      bc = 1;
-
+    transfer_flux = _tracks[track_id]->getTransferFluxIn();
     track_out_id = _tracks[track_id]->getTrackIn()->getUid();
   }
 
@@ -857,7 +836,7 @@ void CPUSolver::transferBoundaryFlux(int track_id,
   /* Loop over polar angles and energy groups */
   for (int e=0; e < _num_groups; e++) {
     for (int p=0; p < _num_polar; p++)
-      track_out_flux(p,e) = track_flux(p,e) * bc;
+      track_out_flux(p,e) = track_flux(p,e) * transfer_flux;
   }
 }
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -87,9 +87,6 @@ Solver::~Solver() {
   if (_timer != NULL)
     delete _timer;
 
-  if (_tracks != NULL)
-    delete [] _tracks;
-
   if (_polar_quad != NULL && !_user_polar_quad)
     delete _polar_quad;
 }

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -11,7 +11,6 @@ Solver::Solver(TrackGenerator* track_generator) {
   _num_groups = 0;
   _num_azim = 0;
   _num_parallel_track_groups = 0;
-  _num_tracks_by_parallel_group = NULL;
 
   _num_FSRs = 0;
   _num_fissionable_FSRs = 0;
@@ -359,8 +358,6 @@ void Solver::setTrackGenerator(TrackGenerator* track_generator) {
   _track_generator = track_generator;
   _num_azim = _track_generator->getNumAzim() / 2;
   _num_parallel_track_groups = _track_generator->getNumParallelTrackGroups();
-  _num_tracks_by_parallel_group =
-    _track_generator->getNumTracksByParallelGroupArray();
   _tot_num_tracks = _track_generator->getNumTracks();
   _tracks = _track_generator->getTracksByParallelGroup();
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -10,6 +10,8 @@ Solver::Solver(TrackGenerator* track_generator) {
   _num_materials = 0;
   _num_groups = 0;
   _num_azim = 0;
+  _num_parallel_track_groups = 0;
+  _num_tracks_by_parallel_group = NULL;
 
   _num_FSRs = 0;
   _num_fissionable_FSRs = 0;
@@ -356,48 +358,11 @@ void Solver::setTrackGenerator(TrackGenerator* track_generator) {
 
   _track_generator = track_generator;
   _num_azim = _track_generator->getNumAzim() / 2;
-  int* num_tracks = _track_generator->getNumTracksArray();
-  _num_tracks_by_halfspace = _track_generator->getNumTracksByHalfspaceArray();
+  _num_parallel_track_groups = _track_generator->getNumParallelTrackGroups();
+  _num_tracks_by_parallel_group =
+    _track_generator->getNumTracksByParallelGroupArray();
   _tot_num_tracks = _track_generator->getNumTracks();
-  _tracks = new Track*[_tot_num_tracks];
-
-  /* Initialize the tracks array */
-  int counter = 0;
-  int num_x, num_y;
-  Track* track;
-  int index;
-
-  for (int azim_halfspace=0; azim_halfspace < 2; azim_halfspace++) {
-    for (int period_halfspace=0; period_halfspace < 3; period_halfspace++) {
-      for (int a=azim_halfspace*_num_azim/2;
-           a < (azim_halfspace+1)*_num_azim/2; a++) {
-
-        /* Get the number of tracks in x and y directions */
-        num_x = _track_generator->getNumX(a);
-        num_y = _track_generator->getNumY(a);
-
-        for (int i=0; i < num_tracks[a]; i++) {
-
-          track = &_track_generator->getTracks()[a][i];
-          index = track->getPeriodicTrackIndex();
-
-          /* Check if track UID should be set */
-          if (period_halfspace == 0 && index == 0) {
-            _tracks[counter] = track;
-            counter++;
-          }
-          else if (period_halfspace == 1 && index % 2 == 1) {
-            _tracks[counter] = track;
-            counter++;
-          }
-          else if (period_halfspace == 2 && index % 2 == 0 && index != 0) {
-            _tracks[counter] = track;
-            counter++;
-          }
-        }
-      }
-    }
-  }
+  _tracks = _track_generator->getTracksByParallelGroup();
 
   /* Retrieve and store the Geometry from the TrackGenerator */  
   setGeometry(_track_generator->getGeometry());

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -126,9 +126,9 @@ protected:
   /** The total number of Tracks */
   int _tot_num_tracks;
 
-  /** An integer array with the Track uid separating the azimuthal and periodic
-   * halfspaces */
-  int* _num_tracks_by_halfspace;
+  /** An integer array with the Track uid separating the parallel track
+   *  groups */
+  int* _num_tracks_by_parallel_group;
 
   /** The weights for each polar angle in the polar angle quadrature */
   FP_PRECISION* _polar_weights;
@@ -170,6 +170,10 @@ protected:
 
   /** A pointer to a Coarse Mesh Finite Difference (CMFD) acceleration object */
   Cmfd* _cmfd;
+
+  /** The number of groups of tracks that can be looped over in parallel
+   *  without data races between threads */
+  int _num_parallel_track_groups;
 
   void clearTimerSplits();
 

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -126,10 +126,6 @@ protected:
   /** The total number of Tracks */
   int _tot_num_tracks;
 
-  /** An integer array with the Track uid separating the parallel track
-   *  groups */
-  int* _num_tracks_by_parallel_group;
-
   /** The weights for each polar angle in the polar angle quadrature */
   FP_PRECISION* _polar_weights;
 

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -9,6 +9,10 @@ Track::Track() {
   /* Initialize the periodic track index to -1, indicating it has not
    * been set */
   _periodic_track_index = -1;
+
+  /* Initialize the reflective track index to -1, indicating it has not
+   * been set */
+  _reflective_track_index = -1;
 }
 
 
@@ -78,6 +82,18 @@ void Track::setAzimAngleIndex(const int index) {
  */
 void Track::setPeriodicTrackIndex(const int index) {
   _periodic_track_index = index;
+}
+
+
+/**
+ * @brief Set the index of a track in a reflective cycle.
+ * @details Tracks form reflective track cycles as they traverse the geometry.
+ *          Tracks can be arbitrarily decomposed into reflective track cycles
+ *          and this index indicates the index in a particular cycle.
+ * @param index of the track in a reflective cycle
+ */
+void Track::setReflectiveTrackIndex(const int index) {
+  _reflective_track_index = index;
 }
 
 
@@ -246,6 +262,40 @@ boundaryType Track::getBCOut() const {
 
 
 /**
+ * @brief Returns a boolean to indicate whether the outgoing flux along this
+ *        Track's "forward" direction should be transferred to the outgoing
+ *        Track.
+ * @details The bool with be false for vacuum BCs and true for all other BCs.
+ * @return bool indicating whether the flux should be passed when tracking in
+ *         the "forward" direction.
+ */
+bool Track::getTransferFluxIn() const {
+
+  if (_bc_in == VACUUM)
+    return false;
+  else
+    return true;
+}
+
+
+/**
+ * @brief Returns a boolean to indicate whether the outgoing flux along this
+ *        Track's "reverse" direction should be transferred to the incoming
+ *        Track.
+ * @details The bool with be false for vacuum BCs and true for all other BCs.
+ * @return bool indicating whether the flux should be passed when tracking in
+ *         the "reverse" direction.
+ */
+bool Track::getTransferFluxOut() const {
+
+  if (_bc_out == VACUUM)
+    return false;
+  else
+    return true;
+}
+
+
+/**
  * @brief Returns a pointer to the Track's end Point.
  * @return a pointer to the Track's end Point
  */
@@ -288,6 +338,15 @@ int Track::getAzimAngleIndex() const {
  */
 int Track::getPeriodicTrackIndex() const {
   return _periodic_track_index;
+}
+
+
+/**
+ * @brief Get the index of a track in a reflective cycle.
+ * @return index of the track in a reflective cycle
+ */
+int Track::getReflectiveTrackIndex() const {
+  return _reflective_track_index;
 }
 
 

--- a/src/Track.h
+++ b/src/Track.h
@@ -84,6 +84,9 @@ private:
   /** The track index in the periodic cycle */
   int _periodic_track_index;
 
+  /** The track index in the reflective cycle */
+  int _reflective_track_index;
+
   /** A dynamically sized vector of segments making up this Track */
   std::vector<segment> _segments;
 
@@ -105,14 +108,10 @@ private:
    *  direction. */
   bool _next_out;
 
-  /** A boolean to indicate whether the outgoing angular flux along this
-   *  Track's "forward" direction should be zeroed out for vacuum boundary
-   *  conditions. */
+  /** An enum to indicate the boundary condition in the "forward" direction. */
   boundaryType _bc_in;
 
-  /** A boolean to indicate whether the outgoing angular flux along this
-   *  Track's "reverse" direction should be zeroed out for vacuum boundary
-   *  conditions. */
+  /** An enum to indicate the boundary condition in the "reverse" direction. */
   boundaryType  _bc_out;
 
 public:
@@ -124,6 +123,7 @@ public:
   void setPhi(const double phi);
   void setAzimAngleIndex(const int index);
   void setPeriodicTrackIndex(const int index);
+  void setReflectiveTrackIndex(const int index);
   void setNextIn(const bool next_in);
   void setNextOut(const bool next_out);
   void setBCIn(const boundaryType bc_in);
@@ -137,6 +137,7 @@ public:
   double getPhi() const;
   int getAzimAngleIndex() const;
   int getPeriodicTrackIndex() const;
+  int getReflectiveTrackIndex() const;
   segment* getSegment(int s);
   segment* getSegments();
   int getNumSegments();
@@ -146,6 +147,8 @@ public:
   bool isNextOut() const;
   boundaryType getBCIn() const;
   boundaryType getBCOut() const;
+  bool getTransferFluxIn() const;
+  bool getTransferFluxOut() const;
 
   bool contains(Point* point);
   void addSegment(segment* to_add);

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1022,7 +1022,7 @@ void TrackGenerator::initializeTrackUids() {
       }
     }
 
-    /* Set the track index boundary for this parallel group */
+    /* Set the number of tracks in this parallel group */
     _num_tracks_by_parallel_group[g] = num_tracks;
   }
 }

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -605,7 +605,7 @@ void TrackGenerator::generateTracks() {
     }
   }
 
-  /* Initialize the track bounadry conditions and set the track UIDs */
+  /* Initialize the track boundary conditions and set the track UIDs */
   initializeBoundaryConditions();
   initializeTrackPeriodicCycleIndices();
   initializeTrackUIDs();

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -821,11 +821,15 @@ void TrackGenerator::recalibrateTracksToOrigin() {
 
 
 /**
- * @brief Recalibrates Track start and end points to the origin of the Geometry.
- * @details The origin of the Geometry is designated at its center by
- *          convention, but for track initialization the origin is assumed to be
- *          at the bottom right corner for simplicity. This method corrects
- *          for this by re-assigning the start and end Point coordinates.
+ * @brief Set the periodic cycle index for each track.
+ * @details The tracks can be separated into parallel cycles as they
+ *          traverse the geometry. It is important to set the periodic cycle
+ *          indices for problems with periodic boundary conditions so transport
+ *          sweeps can be performed in parallel over groups of tracks that do
+ *          not transfer their flux into each other. In this method, all tracks
+ *          are looped over; if the track's periodic cycle index has not been
+ *          set, the periodic cycle index is incremented and the periodic cycle
+ *          index is set for that track and all tracks in its periodic cycle.
  */
 void TrackGenerator::initializeTrackPeriodicCycleIndices() {
 
@@ -873,11 +877,15 @@ void TrackGenerator::initializeTrackPeriodicCycleIndices() {
 
 
 /**
- * @brief Recalibrates Track start and end points to the origin of the Geometry.
- * @details The origin of the Geometry is designated at its center by
- *          convention, but for track initialization the origin is assumed to be
- *          at the bottom right corner for simplicity. This method corrects
- *          for this by re-assigning the start and end Point coordinates.
+ * @brief Set the Track UIDs for all tracks and generate the 1D array of
+ *        track pointers that separates the groups of tracks by parallel group.
+ * @details The Solver requires the tracks to be separated into groups of tracks
+ *          that can be looped over in parallel without data races. This method
+ *          creates a 1D array of Track pointers where the tracks are arranged
+ *          by parallel group. If the geometry has a periodic BC, 6 periodic
+ *          groups are created; otherwise, 2 periodic groups are created. The
+ *          Track UIDs are also set to their index in the tracks by periodic
+ *          group array.
  */
 void TrackGenerator::initializeTrackUIDs() {
 

--- a/src/TrackGenerator.h
+++ b/src/TrackGenerator.h
@@ -47,8 +47,7 @@ private:
   /** An integer array of the number of Tracks for each azimuthal angle */
   int* _num_tracks;
 
-  /** An integer array with the indices into the _tracks_by_parallel_group array
-   *  separating the parallel track groups */
+  /** An integer array with the number of Tracks in each parallel track group */
   int* _num_tracks_by_parallel_group;
 
   /** The number of the track groups needed to ensure data races don't occur

--- a/src/TrackGenerator.h
+++ b/src/TrackGenerator.h
@@ -47,7 +47,8 @@ private:
   /** An integer array of the number of Tracks for each azimuthal angle */
   int* _num_tracks;
 
-  /** An integer array with the Track uid separating the parallel groups */
+  /** An integer array with the indices into the _tracks_by_parallel_group array
+   *  separating the parallel track groups */
   int* _num_tracks_by_parallel_group;
 
   /** The number of the track groups needed to ensure data races don't occur
@@ -89,9 +90,9 @@ private:
   void initializeTrackFileDirectory();
   void initializeTracks();
   void recalibrateTracksToOrigin();
-  void initializeTrackUIDs();
+  void initializeTrackUids();
   void initializeBoundaryConditions();
-  void initializeTrackPeriodicCycleIndices();
+  void initializeTrackCycleIndices(boundaryType bc);
   void segmentize();
   void dumpTracksToFile();
   bool readTracksFromFile();
@@ -108,8 +109,7 @@ public:
   int getNumTracks();
   int getNumX(int azim);
   int getNumY(int azim);
-  int* getNumTracksArray();
-  int* getNumTracksByParallelGroupArray();
+  int getNumTracksByParallelGroup(int group);
   int getNumParallelTrackGroups();
   int getNumSegments();
   Track** getTracks();

--- a/src/TrackGenerator.h
+++ b/src/TrackGenerator.h
@@ -47,9 +47,12 @@ private:
   /** An integer array of the number of Tracks for each azimuthal angle */
   int* _num_tracks;
 
-  /** An integer array with the Track uid separating the azimuthal and periodic
-   * halfspaces */
-  int* _num_tracks_by_halfspace;
+  /** An integer array with the Track uid separating the parallel groups */
+  int* _num_tracks_by_parallel_group;
+
+  /** The number of the track groups needed to ensure data races don't occur
+   *  during the Solver's transportSweep */
+  int _num_parallel_track_groups;
 
   /** An integer array of the number of Tracks starting on the x-axis for each
    *  azimuthal angle */
@@ -64,6 +67,9 @@ private:
 
   /** A 2D ragged array of Tracks */
   Track** _tracks;
+
+  /** A 1D array of Track pointers arranged by parallel group */
+  Track** _tracks_by_parallel_group;
 
   /** Pointer to the Geometry */
   Geometry* _geometry;
@@ -85,6 +91,7 @@ private:
   void recalibrateTracksToOrigin();
   void initializeTrackUIDs();
   void initializeBoundaryConditions();
+  void initializeTrackPeriodicCycleIndices();
   void segmentize();
   void dumpTracksToFile();
   bool readTracksFromFile();
@@ -102,9 +109,11 @@ public:
   int getNumX(int azim);
   int getNumY(int azim);
   int* getNumTracksArray();
-  int* getNumTracksByHalfspaceArray();
+  int* getNumTracksByParallelGroupArray();
+  int getNumParallelTrackGroups();
   int getNumSegments();
   Track** getTracks();
+  Track** getTracksByParallelGroup();
   FP_PRECISION* getAzimWeights();
   int getNumThreads();
   FP_PRECISION* getFSRVolumes();

--- a/src/VectorizedSolver.cpp
+++ b/src/VectorizedSolver.cpp
@@ -675,14 +675,14 @@ void VectorizedSolver::transferBoundaryFlux(int track_id, int azim_index,
   /* For the "forward" direction */
   if (direction) {
     start = _tracks[track_id]->isNextOut() * _polar_times_groups;
-    transfer_flux = _tracks[track_id]->getTranferFluxOut();
+    transfer_flux = _tracks[track_id]->getTransferFluxOut();
     track_out_id = _tracks[track_id]->getTrackOut()->getUid();
   }
 
   /* For the "reverse" direction */
   else {
     start = _tracks[track_id]->isNextIn() * _polar_times_groups;
-    transfer_flux = _tracks[track_id]->getTranferFluxIn();
+    transfer_flux = _tracks[track_id]->getTransferFluxIn();
     track_out_id = _tracks[track_id]->getTrackIn()->getUid();
   }
 

--- a/src/VectorizedSolver.cpp
+++ b/src/VectorizedSolver.cpp
@@ -669,21 +669,21 @@ void VectorizedSolver::transferBoundaryFlux(int track_id, int azim_index,
                                             bool direction,
                                             FP_PRECISION* track_flux) {
   int start;
-  bool bc;
+  bool transfer_flux;
   int track_out_id;
 
   /* For the "forward" direction */
   if (direction) {
     start = _tracks[track_id]->isNextOut() * _polar_times_groups;
+    transfer_flux = _tracks[track_id]->getTranferFluxOut();
     track_out_id = _tracks[track_id]->getTrackOut()->getUid();
-    bc = std::min((int)_tracks[track_id]->getBCOut(), 1);
   }
 
   /* For the "reverse" direction */
   else {
     start = _tracks[track_id]->isNextIn() * _polar_times_groups;
+    transfer_flux = _tracks[track_id]->getTranferFluxIn();
     track_out_id = _tracks[track_id]->getTrackIn()->getUid();
-    bc = std::min((int)_tracks[track_id]->getBCIn(), 1);
   }
 
   FP_PRECISION* track_out_flux = &_boundary_flux(track_out_id,0,0,start);
@@ -697,7 +697,7 @@ void VectorizedSolver::transferBoundaryFlux(int track_id, int azim_index,
       /* Loop over energy groups within this vector */
       #pragma simd vectorlength(VEC_LENGTH)
       for (int e=v*VEC_LENGTH; e < (v+1)*VEC_LENGTH; e++)
-        track_out_flux(p,e) = track_flux(p,e) * bc;
+        track_out_flux(p,e) = track_flux(p,e) * transfer_flux;
     }
   }
 }

--- a/src/accel/DeviceTrack.h
+++ b/src/accel/DeviceTrack.h
@@ -73,14 +73,14 @@ struct dev_track {
   bool _next_out;
 
   /** A boolean to indicate whether the outgoing angular flux along this
-   *  Track's "forward" direction should be zeroed out for vacuum boundary
-   *  conditions. */
-  int _bc_in;
+   *  Track's "forward" direction should be transferred to the outgoing
+   *  Track. */
+  bool _transfer_flux_in;
 
   /** A boolean to indicate whether the outgoing angular flux along this
-   *  Track's "reverse" direction should be zeroed out for vacuum boundary
-   *  conditions. */
-  int _bc_out;
+   *  Track's "reverse" direction should be transferred to the incoming
+   *  Track. */
+  bool _transfer_flux_out;
 };
 
 

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -436,19 +436,19 @@ __device__ void transferBoundaryFlux(dev_track* curr_track,
                                      bool direction) {
 
   int start = energy_angle_index;
-  bool bc;
+  bool transfer_flux;
   int track_out_id;
 
   /* For the "forward" direction */
   if (direction) {
-    bc = curr_track->_bc_out;
+    transfer_flux = curr_track->_transfer_flux_out;
     track_out_id = curr_track->_track_out;
     start += curr_track->_next_out * (*polar_times_groups);
   }
 
   /* For the "reverse" direction */
   else {
-    bc = curr_track->_bc_in;
+    transfer_flux = curr_track->_transfer_flux_in;
     track_out_id = curr_track->_track_in;
     start += curr_track->_next_in * (*polar_times_groups);
   }
@@ -457,7 +457,7 @@ __device__ void transferBoundaryFlux(dev_track* curr_track,
 
   /* Put Track's flux in the shared memory temporary flux array */
   for (int p=0; p < *num_polar; p++)
-    track_out_flux[p] = track_flux[p] * bc;
+    track_out_flux[p] = track_flux[p] * transfer_flux;
 }
 
 
@@ -1275,34 +1275,6 @@ void GPUSolver::initializeSourceArrays() {
 
 
 /**
- * @brief This method computes the index for the Track j at azimuthal angle i.
- * @details This method is necessary since the array of dev_tracks on the device
- *          is a 1D array which needs a one-to-one mapping from the 2D jagged
- *          array of Tracks on the host.
- * @param i azimuthal angle number
- * @param j the jth track at angle i
- * @return an index into the device track array
- */
-int GPUSolver::computeScalarTrackIndex(int i, int j) {
-
-  int index = 0, p = 0;
-  int* num_tracks = _track_generator->getNumTracksArray();
-
-  /* Iterate over each azimuthal angle and increment index by the number of
-   * Tracks at each angle */
-  while (p < i) {
-    index += num_tracks[p];
-    p++;
-  }
-
-  /* Update index for this Track since it is the jth Track at angle i */
-  index += j;
-
-  return index;
-}
-
-
-/**
  * @brief Zero each Track's boundary fluxes for each energy group and polar
  *        angle in the "forward" and "reverse" directions.
  */
@@ -1436,7 +1408,8 @@ void GPUSolver::computeFSRScatterSources() {
 void GPUSolver::transportSweep() {
 
   int shared_mem = _T * _two_times_num_polar * sizeof(FP_PRECISION);
-  int tid_offset, tid_max;
+  int tid_offset = 0;
+  int tid_max = 0;
 
   log_printf(DEBUG, "Transport sweep on device with %d blocks and %d threads",
              _B, _T);
@@ -1456,13 +1429,15 @@ void GPUSolver::transportSweep() {
    * in that group */
   for (int g=0; g < _num_parallel_track_groups; g++) {
 
-    tid_offset = _num_tracks_by_parallel_group[g] * _num_groups;
-    tid_max = _num_tracks_by_parallel_group[g+1];
+    tid_offset = tid_max * _num_groups;
+    tid_max += _track_generator->getNumTracksByParallelGroup(g);
 
     transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
                                                    reduced_sources,
                                                    _materials, _dev_tracks,
                                                    tid_offset, tid_max);
+
+    cudaDeviceSynchronize();
   }
 }
 

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1456,7 +1456,7 @@ void GPUSolver::transportSweep() {
    * in that group */
   for (int g=0; g < _num_parallel_track_groups; g++) {
 
-    tid_offset = _num_tracks_by_parallel_group[g];
+    tid_offset = _num_tracks_by_parallel_group[g] * _num_groups;
     tid_max = _num_tracks_by_parallel_group[g+1];
 
     transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1452,59 +1452,18 @@ void GPUSolver::transportSweep() {
   /* Initialize flux in each FSR to zero */
   flattenFSRFluxes(0.0);
 
-  /* Sweep the first space of azimuthal angle and periodic track halfspaces */
-  tid_offset = _num_tracks_by_halfspace[0];
-  tid_max = _num_tracks_by_halfspace[1];
+  /* Loop over the parallel track groups and perform transport sweep on tracks
+   * in that group */
+  for (int g=0; g < _num_parallel_track_groups; g++) {
 
-  transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
-                                                 reduced_sources,
-                                                 _materials, _dev_tracks,
-                                                 tid_offset, tid_max);
+    tid_offset = _num_tracks_by_parallel_group[g];
+    tid_max = _num_tracks_by_parallel_group[g+1];
 
-  /* Sweep the second space of azimuthal angle and periodic track halfspaces */
-  tid_offset = _num_tracks_by_halfspace[1] * _num_groups;
-  tid_max = _num_tracks_by_halfspace[2];
-
-  transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
-                                                 reduced_sources,
-                                                 _materials, _dev_tracks,
-                                                 tid_offset, tid_max);
-
-  /* Sweep the third space of azimuthal angle and periodic track halfspaces */
-  tid_offset = _num_tracks_by_halfspace[2] * _num_groups;
-  tid_max = _num_tracks_by_halfspace[3];
-
-  transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
-                                                 reduced_sources,
-                                                 _materials, _dev_tracks,
-                                                 tid_offset, tid_max);
-
-  /* Sweep the fourth space of azimuthal angle and periodic track halfspaces */
-  tid_offset = _num_tracks_by_halfspace[3] * _num_groups;
-  tid_max = _num_tracks_by_halfspace[4];
-
-  transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
-                                                 reduced_sources,
-                                                 _materials, _dev_tracks,
-                                                 tid_offset, tid_max);
-
-  /* Sweep the fifth space of azimuthal angle and periodic track halfspaces */
-  tid_offset = _num_tracks_by_halfspace[4] * _num_groups;
-  tid_max = _num_tracks_by_halfspace[5];
-
-  transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
-                                                 reduced_sources,
-                                                 _materials, _dev_tracks,
-                                                 tid_offset, tid_max);
-
-  /* Sweep the fifth space of azimuthal angle and periodic track halfspaces */
-  tid_offset = _num_tracks_by_halfspace[5] * _num_groups;
-  tid_max = _num_tracks_by_halfspace[6];
-
-  transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
-                                                 reduced_sources,
-                                                 _materials, _dev_tracks,
-                                                 tid_offset, tid_max);
+    transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
+                                                   reduced_sources,
+                                                   _materials, _dev_tracks,
+                                                   tid_offset, tid_max);
+  }
 }
 
 

--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -97,8 +97,6 @@ private:
   /** Map of Material IDs to indices in _materials array */
   std::map<int, int> _material_IDs_to_indices;
 
-  int computeScalarTrackIndex(int i, int j);
-
 public:
 
   GPUSolver(TrackGenerator* track_generator=NULL);

--- a/src/accel/cuda/clone.cu
+++ b/src/accel/cuda/clone.cu
@@ -114,7 +114,7 @@ void clone_track(Track* track_h, dev_track* track_d,
 
   /* If the outgoing boundary condition is vacuum, set bc out to 0 indicating the
    * track flux of the outgoing track will be zeroed out */
-  if (_tracks[track_id]->getBCOut() == VACUUM)
+  if (track_h->getBCOut() == VACUUM)
     new_track._bc_out = 0;
 
   /* If the outgoing boundary condition is anything other than vacuum, set

--- a/src/accel/cuda/clone.cu
+++ b/src/accel/cuda/clone.cu
@@ -100,8 +100,8 @@ void clone_track(Track* track_h, dev_track* track_d,
   new_track._azim_angle_index = track_h->getAzimAngleIndex();
   new_track._next_in = track_h->isNextIn();
   new_track._next_out = track_h->isNextOut();
-  new_track._tranfer_flux_in = track_h->getTransferFluxIn();
-  new_track._tranfer_flux_out = track_h->getTransferFluxOut();
+  new_track._transfer_flux_in = track_h->getTransferFluxIn();
+  new_track._transfer_flux_out = track_h->getTransferFluxOut();
 
   cudaMalloc((void**)&dev_segments,
              track_h->getNumSegments() * sizeof(dev_segment));

--- a/src/accel/cuda/clone.cu
+++ b/src/accel/cuda/clone.cu
@@ -101,9 +101,28 @@ void clone_track(Track* track_h, dev_track* track_d,
   new_track._next_in = track_h->isNextIn();
   new_track._next_out = track_h->isNextOut();
 
-  new_track._bc_in = std::min((int)track_h->getBCIn(), 1);
-  new_track._bc_out = std::min((int)track_h->getBCOut(), 1);
-    
+  /* If the incoming boundary condition is vacuum, set bc in to 0 indicating the
+   * track flux of the incoming track will be zeroed out */
+  if (track_h->getBCIn() == VACUUM)
+    new_track._bc_in = 0;
+
+  /* If the incoming boundary condition is anything other than vacuum, set
+   * bc in to 1 indicating the flux passed to the incoming track should be the
+   * current track's flux. */
+  else
+    new_track._bc_in = 1;
+
+  /* If the outgoing boundary condition is vacuum, set bc out to 0 indicating the
+   * track flux of the outgoing track will be zeroed out */
+  if (_tracks[track_id]->getBCOut() == VACUUM)
+    new_track._bc_out = 0;
+
+  /* If the outgoing boundary condition is anything other than vacuum, set
+   * bc out to 1 indicating the flux passed to the outgoing track should be the
+   * current track's flux */
+  else
+    new_track._bc_out = 1;
+
   cudaMalloc((void**)&dev_segments,
              track_h->getNumSegments() * sizeof(dev_segment));
   new_track._segments = dev_segments;

--- a/src/accel/cuda/clone.cu
+++ b/src/accel/cuda/clone.cu
@@ -100,28 +100,8 @@ void clone_track(Track* track_h, dev_track* track_d,
   new_track._azim_angle_index = track_h->getAzimAngleIndex();
   new_track._next_in = track_h->isNextIn();
   new_track._next_out = track_h->isNextOut();
-
-  /* If the incoming boundary condition is vacuum, set bc in to 0 indicating the
-   * track flux of the incoming track will be zeroed out */
-  if (track_h->getBCIn() == VACUUM)
-    new_track._bc_in = 0;
-
-  /* If the incoming boundary condition is anything other than vacuum, set
-   * bc in to 1 indicating the flux passed to the incoming track should be the
-   * current track's flux. */
-  else
-    new_track._bc_in = 1;
-
-  /* If the outgoing boundary condition is vacuum, set bc out to 0 indicating the
-   * track flux of the outgoing track will be zeroed out */
-  if (track_h->getBCOut() == VACUUM)
-    new_track._bc_out = 0;
-
-  /* If the outgoing boundary condition is anything other than vacuum, set
-   * bc out to 1 indicating the flux passed to the outgoing track should be the
-   * current track's flux */
-  else
-    new_track._bc_out = 1;
+  new_track._tranfer_flux_in = track_h->getTransferFluxIn();
+  new_track._tranfer_flux_out = track_h->getTransferFluxOut();
 
   cudaMalloc((void**)&dev_segments,
              track_h->getNumSegments() * sizeof(dev_segment));


### PR DESCRIPTION
This PR updates PR #185 by cleaning up the additions to the TrackGenerator, Solver, GPUSolver, and clone. The changes in this PR include:
- Fixed typo in `config.py` for the icpc source files.
- Added `_num_tracks_by_parallel_group` array storing the track UIDs that separate the groups of tracks that can be looped over in parallel in the Solver's transportSweep method.
- Added `_num_parallel_track_groups` attribute to indicate the number of parallel track groups.
- Added `_tracks_by_parallel_groups` 1D array of track pointers that stores the tracks arranged by parallel track group. This array was created to avoid the redundant loops in the `TrackGenerator` and `Solver` that set the Track UIDs and form the 1D array of track pointers that stores the tracks arranged by parallel track group.
- Added method `TrackGenerator::initializeTrackPeriodicCycleIndices`. Formerly, the code in this method was included in the `TrackGenerator::initializeTrackUIDs` method.
- Shortened `GPUSolver::transportSweep` method by changing hard coded transport sweeps over parallel groups to a loop over the parallel groups.