### PR TITLE
Fixed OpenCG compability module installation

### DIFF
--- a/config.py
+++ b/config.py
@@ -92,7 +92,7 @@ class configuration:
   extensions = list()
 
   # List of the possible packages to install based on runtime options
-  packages = ['openmoc', 'openmoc.cuda']
+  packages = ['openmoc', 'openmoc.cuda', 'openmoc.compatible']
 
 
   #############################################################################


### PR DESCRIPTION
It looks like the installation of the OpenCG compability module somehow was removed when I refactored much of the build system earlier this summer.