### PR TITLE
Hotfix for OpenCG/OpenMC compatibility

### DIFF
--- a/openmoc/compatible/opencg_compatible.py
+++ b/openmoc/compatible/opencg_compatible.py
@@ -110,9 +110,6 @@ def get_openmoc_material(opencg_material):
   # Add the OpenCG Material to the global collection of all OpenCG Materials
   OPENCG_MATERIALS[material_id] = opencg_material
 
-  # FIXME
-  openmoc_material.thisown = 0
-
   return openmoc_material
 
 
@@ -261,9 +258,6 @@ def get_openmoc_surface(opencg_surface):
 
   # Add the OpenCG Surface to the global collection of all OpenCG Surfaces
   OPENCG_SURFACES[surface_id] = opencg_surface
-
-  # FIXME
-  openmoc_surface.thisown = 0
 
   return openmoc_surface
 
@@ -560,9 +554,6 @@ def get_openmoc_cell(opencg_cell):
   # Add the OpenCG Cell to the global collection of all OpenCG Cells
   OPENCG_CELLS[cell_id] = opencg_cell
 
-  # FIXME
-  openmoc_cell.thisown = 0
-
   return openmoc_cell
 
 
@@ -633,9 +624,6 @@ def get_openmoc_universe(opencg_universe):
 
   # Add the OpenCG Universe to the global collection of all OpenCG Universes
   OPENCG_UNIVERSES[universe_id] = opencg_universe
-
-  # FIXME
-  openmoc_universe.thisown = 0
 
   return openmoc_universe
 
@@ -745,9 +733,6 @@ def get_openmoc_lattice(opencg_lattice):
   # Add the OpenCG Lattice to the global collection of all OpenCG Lattices
   OPENCG_LATTICES[lattice_id] = opencg_lattice
 
-  # FIXME
-  openmoc_lattice.thisown = 0
-
   return openmoc_lattice
 
 
@@ -815,8 +800,5 @@ def get_openmoc_geometry(opencg_geometry):
 
   openmoc_geometry = openmoc.Geometry()
   openmoc_geometry.setRootUniverse(openmoc_root_universe)
-
-  # FIXME
-  openmoc_geometry.thisown = 0
 
   return openmoc_geometry

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -37,7 +37,7 @@ void reset_universe_id() {
 Universe::Universe(const int id, const char* name) {
 
   /* If the user did not define an optional ID, create one */
-  if (id == 0)
+  if (id == -1)
     _id = cell_id();
 
   /* Use the user-defined ID */

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -155,7 +155,7 @@ private:
 
 public:
 
-  Lattice(const int id=0, const char* name="");
+  Lattice(const int id=-1, const char* name="");
   virtual ~Lattice();
 
   void setOffset(double x, double y);

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -83,7 +83,7 @@ protected:
 
 public:
 
-  Universe(const int id=0, const char* name="");
+  Universe(const int id=-1, const char* name="");
   virtual ~Universe();
   int getUid() const;
   int getId() const;


### PR DESCRIPTION
This PR makes the default ``Universe`` ID=-1 rather than 0 to support OpenCG compatibility with OpenMC geometries which must have a universe with ID=0 (at the root). In addition, this PR removes some elements of ``openmoc.compatible.opencg_compatible`` for memory management of geometric primitives (*e.g.*, setting the SWIG ``thisown`` attributes) which was resolved in #176 and #160.