### PR TITLE
Hotfix for advanced OpenCG compatibility

### DIFF
--- a/openmoc/compatible/opencg_compatible.py
+++ b/openmoc/compatible/opencg_compatible.py
@@ -744,6 +744,8 @@ def get_opencg_geometry(openmoc_geometry):
     raise ValueError(msg)
 
   # Clear dictionaries and auto-generated IDs
+  OPENMOC_MATERIALS.clear()
+  OPENCG_MATERIALS.clear()
   OPENMOC_SURFACES.clear()
   OPENCG_SURFACES.clear()
   OPENMOC_CELLS.clear()
@@ -778,7 +780,9 @@ def get_openmoc_geometry(opencg_geometry):
   # Update Cell bounding boxes in Geometry
   opencg_geometry.updateBoundingBoxes()
 
-  # Clear dictionaries and auto-generated ID
+  # Clear dictionaries and auto-generated IDs
+  OPENMOC_MATERIALS.clear()
+  OPENCG_MATERIALS.clear()
   OPENMOC_SURFACES.clear()
   OPENCG_SURFACES.clear()
   OPENMOC_CELLS.clear()

--- a/openmoc/thisown.i
+++ b/openmoc/thisown.i
@@ -50,7 +50,7 @@
   else:
     fill = locals()['args'][0]
 
-  fill.thisown = 1
+  fill.thisown = 0
 %}
 
 /* A Universe owns the memory for each Cell it contains */

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -268,7 +268,7 @@ FP_PRECISION* Material::getFissionMatrix() {
                "since it has not yet been built", _id);
 
   return _fiss_matrix;
-  }
+}
 
 
 /**
@@ -683,7 +683,6 @@ void Material::setNumEnergyGroups(const int num_groups) {
   _nu_sigma_f = new FP_PRECISION[_num_groups];
   _chi = new FP_PRECISION[_num_groups];
   _sigma_s = new FP_PRECISION[_num_groups*_num_groups];
-
 
   /* Assign the null vector to each data array */
   memset(_sigma_t, 0.0, sizeof(FP_PRECISION) * _num_groups);


### PR DESCRIPTION
This PR fixes a few issues I encountered when trying to interactively run multiple OpenMOC simulations in the same IPython Notebook with different multi-group cross sections defined on some OpenCG mesh (from OpenMC). This fixes a bug such that the ``thisown`` attribute for SWIG-wrapped ``Material`` Python objects is set to zero when a ``Material`` is added to a ``Cell`` (effectively delegating responsibility to the underlying C++ ``Cell`` object to delete the ``Material``). For some odd reason this bug crept in my PR #161. The second bug that this PR fixes is the deletion of ``Material`` objects for distinct calls of the ``opencg_compatible.get_openmoc_geometry(...)`` routine.