### PR TITLE
Added logger message to print final keff as a RESULT message

### DIFF
--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1040,6 +1040,8 @@ void Solver::computeEigenvalue(int max_iters, solverMode mode,
   if (_num_iterations == max_iters-1)
     log_printf(WARNING, "Unable to converge the source distribution");
 
+  log_printf(RESULT, "Final k_eff = %1.6f", _k_eff);
+
   resetMaterials(mode);
 
   _timer->stopTimer();


### PR DESCRIPTION
This PR simply makes it such that the final keff value in an eigenvalue calculation is reported in a ``RESULT`` logger message. In an interactive environment like IPython Notebook, it can be helpful to throttle much of OpenMOC's output (*e.g.*, ``NORMAL`` messages showing eigenvalue convergence) and instead simply report the final converged eigenvalue. This one line PR makes it easy to do so by ensuring that the final eigenvalue (converged or unconverged) is reported to the screen as a ``RESULT`` message.