### PR TITLE
Made openmoc.compatible module Python 3 compatible

### DIFF
--- a/openmoc/compatible/__init__.py
+++ b/openmoc/compatible/__init__.py
@@ -1,2 +1,2 @@
-from casmo import *
-from opencg_compatible import *
+from openmoc.compatible.casmo import *
+from openmoc.compatible.opencg_compatible import *


### PR DESCRIPTION
This PR just makes a few trivial changes to the "__init__.py" file for the `openmoc.compatible` submodule such that it is Python 3 compatible.