### PR TITLE
Added surface metadata to Cell->toString.

### DIFF
--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -946,11 +946,11 @@ std::string Cell::toString() {
 
   string << ", # surfaces = " << getNumSurfaces();
 
-  /** Add the IDs for the Surfaces in this Cell */
+  /** Add string data for the Surfaces in this Cell */
   std::map<int, surface_halfspace*>::iterator iter;
-  string << ", surface ids = ";
+  string << ", Surfaces: ";
   for (iter = _surfaces.begin(); iter != _surfaces.end(); ++iter)
-    string <<  iter->second->_halfspace * iter->first << ", ";
+    string <<  iter->second->_surface->toString() << ", ";
 
   return string.str();
 }


### PR DESCRIPTION
This is a simple PR that adds `Surface` metadata to the `Cell->toString()` string.  This fixes a bug I discovered that if you change `Surface` parameters between runs, OpenMOC will still read a now-incorrect track file.  With this change, OpenMOC can detect the change and will re-track the geometry.