### PR TITLE
Variable logger buffer length

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -258,8 +258,47 @@ void set_log_level(const char* new_level) {
  * @brief Return the minimum level for log messages printed to the screen.
  * @return the minimum level for log messages
  */
-int get_log_level() {
-  return log_level;
+const char* get_log_level() {
+
+  std::string level;
+
+  switch (log_level) {
+  case (DEBUG):
+    level = "DEBUG";
+    break;
+  case (INFO):
+    level = "INFO";
+    break;
+  case (NORMAL):
+    level = "NORMAL";
+    break;
+  case (SEPARATOR):
+    level = "SEPARATOR";
+    break;
+  case (HEADER):
+    level = "HEADER";
+    break;
+  case (TITLE):
+    level = "TITLE";
+    break;
+  case (WARNING):
+    level = "WARNING";
+    break;
+  case (CRITICAL):
+    level = "CRITICAL";
+    break;
+  case (RESULT):
+    level = "RESULT";
+    break;
+  case (UNITTEST):
+    level = "UNITTEST";
+    break;
+  case (ERROR):
+    level = "ERROR";
+    break;
+  }
+
+  return level.c_str();
 }
 
 
@@ -285,7 +324,7 @@ void log_printf(logLevel level, const char* format, ...) {
     if (size <= n) {
       delete [] buffer;
       buffer = new char[n+1];
-      n = vsnprintf(buffer, n, format, args);
+      n = vsnprintf(buffer, n+1, format, args);
     }
 
     std::string msg = std::string(buffer);
@@ -506,7 +545,7 @@ std::string create_multiline_msg(std::string level, std::string message) {
   std::string msg_string;
 
   /* Loop over msg creating substrings for each line */
-  while (end < size + line_length) {
+  while (end <= size + line_length) {
 
     /* Append log level to the beginning of each line */
     msg_string += level;
@@ -519,7 +558,7 @@ std::string create_multiline_msg(std::string level, std::string message) {
     substring = message.substr(start, line_length);
 
     /* Truncate substring to last complete word */
-    if (end < size-1) {
+    if (end <= size) {
       int endspace = substring.find_last_of(" ");
       if (message.at(endspace+1) != ' ' &&
           endspace != int(std::string::npos)) {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -272,20 +272,29 @@ int get_log_level() {
  */
 void log_printf(logLevel level, const char* format, ...) {
 
-  char message[1024];
-  std::string msg_string;
   if (level >= log_level) {
     va_list args;
-
     va_start(args, format);
-    vsprintf(message, format, args);
+
+    int size = 256;
+    char* buffer = new char[size];
+    std::string msg_string;
+    int n = vsnprintf(buffer, size, format, args);
+
+    /* Resize buffer as needed for strings longer than 256 characters */
+    if (size <= n) {
+      delete [] buffer;
+      buffer = new char[n+1];
+      n = vsnprintf(buffer, n, format, args);
+    }
+
+    std::string msg = std::string(buffer);
     va_end(args);
 
     /* Append the log level to the message */
     switch (level) {
     case (DEBUG):
       {
-        std::string msg = std::string(message);
         std::string level_prefix = "[  DEBUG  ]  ";
 
         /* If message is too long for a line, split into many lines */
@@ -300,7 +309,6 @@ void log_printf(logLevel level, const char* format, ...) {
       }
     case (INFO):
       {
-        std::string msg = std::string(message);
         std::string level_prefix = "[  INFO   ]  ";
 
         /* If message is too long for a line, split into many lines */
@@ -315,7 +323,6 @@ void log_printf(logLevel level, const char* format, ...) {
       }
     case (NORMAL):
       {
-        std::string msg = std::string(message);
         std::string level_prefix = "[  NORMAL ]  ";
 
         /* If message is too long for a line, split into many lines */
@@ -339,33 +346,32 @@ void log_printf(logLevel level, const char* format, ...) {
       }
     case (HEADER):
       {
-        int size = strlen(message);
+        int size = strlen(buffer);
         int halfpad = (line_length - 4 - size) / 2;
         std::string pad1 = std::string(halfpad, header_char);
         std::string pad2 = std::string(halfpad +
                            (line_length - 4 - size) % 2, header_char);
         std::string prefix = std::string("[  HEADER ]  ");
         std::stringstream ss;
-        ss << prefix << pad1 << "  " << message << "  " << pad2 << "\n";
+        ss << prefix << pad1 << "  " << buffer << "  " << pad2 << "\n";
         msg_string = ss.str();
         break;
       }
     case (TITLE):
       {
-        int size = strlen(message);
+        int size = strlen(buffer);
         int halfpad = (line_length - size) / 2;
         std::string pad = std::string(halfpad, ' ');
         std::string prefix = std::string("[  TITLE  ]  ");
         std::stringstream ss;
         ss << prefix << std::string(line_length, title_char) << "\n";
-        ss << prefix << pad << message << pad << "\n";
+        ss << prefix << pad << buffer << pad << "\n";
         ss << prefix << std::string(line_length, title_char) << "\n";
         msg_string = ss.str();
         break;
       }
     case (WARNING):
       {
-        std::string msg = std::string(message);
         std::string level_prefix = "[ WARNING ]  ";
 
         /* If message is too long for a line, split into many lines */
@@ -380,7 +386,6 @@ void log_printf(logLevel level, const char* format, ...) {
       }
     case (CRITICAL):
       {
-        std::string msg = std::string(message);
         std::string level_prefix = "[ CRITICAL]  ";
 
         /* If message is too long for a line, split into many lines */
@@ -395,7 +400,6 @@ void log_printf(logLevel level, const char* format, ...) {
       }
     case (RESULT):
       {
-        std::string msg = std::string(message);
         std::string level_prefix = "[  RESULT ]  ";
 
         /* If message is too long for a line, split into many lines */
@@ -410,7 +414,6 @@ void log_printf(logLevel level, const char* format, ...) {
       }
     case (UNITTEST):
       {
-        std::string msg = std::string(message);
         std::string level_prefix = "[   TEST  ]  ";
 
         /* If message is too long for a line, split into many lines */
@@ -426,10 +429,6 @@ void log_printf(logLevel level, const char* format, ...) {
     case (ERROR):
       {
         /* Create message based on runtime error stack */
-        va_start(args, format);
-        vsprintf(message, format, args);
-        va_end(args);
-        std::string msg = std::string(message);
         std::string level_prefix = "";
 
         /* If message is too long for a line, split into many lines */

--- a/src/log.h
+++ b/src/log.h
@@ -107,7 +107,7 @@ void set_title_character(char c);
 char get_title_character();
 void set_line_length(int length);
 void set_log_level(const char* new_level);
-int get_log_level();
+const char* get_log_level();
 
 void log_printf(logLevel level, const char *format, ...);
 std::string create_multiline_msg(std::string level, std::string message);


### PR DESCRIPTION
This PR addresses Issue #100 regarding the limited logger buffer length. I ran up against this issue recently with some log messages from the SPH calculator in PR #219 for very complex geometries. I found it was actually quite easy to resolve this issue through the use of [`vsnprintf`](http://www.cplusplus.com/reference/cstdio/vsnprintf/) to determine the necessary length for the logger buffer rather than fixing the size to 1024 or some other hard-coded value.

With this PR, one can now do the following (which breaks the current logger implementation):

```bash
$ ipython
Python 2.7.6 (default, Jun 22 2015, 17:58:13) 
Type "copyright", "credits" or "license" for more information.

IPython 3.2.0-dev -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import openmoc

In [2]: openmoc.log_printf(openmoc.NORMAL, '8'*2000)
[  NORMAL ]  8888888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888888888888888888888888888888888888888888888888888888
[  NORMAL ]  ... 888888888888
```