### PR TITLE
Exaggerated Fission Rate Color Scheme

### DIFF
--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -1,4 +1,4 @@
-#
+##
 # @file plotter.py
 # @package openmoc.plotter
 # @brief The plotter module provides utility functions to plot data from
@@ -941,10 +941,12 @@ def plot_energy_fluxes(solver, fsrs, group_bounds=None, norm=True, loglog=True):
 # @endcode
 #
 # @param solver a Solver object that has converged the source for the Geometry
+# @param transparent_zeros make regions without fission transparent
 # @param gridsize an optional number of grid cells for the plot
 # @param xlim optional list/tuple of the minimim/maximum x-coordinates
 # @param ylim optional list/tuple of the minimim/maximum y-coordinates
-def plot_fission_rates(solver, gridsize=250, xlim=None, ylim=None):
+def plot_fission_rates(solver, transparent_zeros=False, gridsize=250,
+                       xlim=None, ylim=None):
 
   global subdirectory
 
@@ -1002,9 +1004,17 @@ def plot_fission_rates(solver, gridsize=250, xlim=None, ylim=None):
       else:
        surface[j][i] = fission_rates[fsr_id]
 
+  # Set zero fission rates to NaN so Matplotlib will make them transparent
+  if transparent_zeros:
+    surface[surface == 0.0] = np.nan
+
+  # Make Matplotlib color "bad" numbers (ie, NaN, INF) with transparent pixels
+  cmap = plt.get_cmap()
+  cmap.set_bad(alpha=0.0)
+
   # Plot a 2D color map of the flat source regions fission rates
   fig = plt.figure()
-  plt.imshow(np.flipud(surface), extent=coords['bounds'])
+  plt.imshow(np.flipud(surface), extent=coords['bounds'], cmap=cmap)
   plt.colorbar()
   plt.suptitle('Flat Source Region Fission Rates')
   plt.title('z = ' + str(zcoord))

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -775,7 +775,7 @@ def plot_spatial_fluxes(solver, energy_groups=[1],
   for index, group in enumerate(energy_groups):
 
     # Plot a 2D color map of the flat source regions
-    fig = plt.figure()
+    fig = plt.figure(index)
     plt.imshow(np.flipud(fluxes[index,:,:]), extent=coords['bounds'])
     plt.colorbar()
     plt.suptitle('FSR Scalar Flux (Group {0})'.format(group))
@@ -1006,7 +1006,8 @@ def plot_fission_rates(solver, transparent_zeros=True, gridsize=250,
 
   # Set zero fission rates to NaN so Matplotlib will make them transparent
   if transparent_zeros:
-    surface[surface == 0.0] = np.nan
+    indices = np.where(surface == 0.0)
+    surface[indices] = np.nan
 
   # Make Matplotlib color "bad" numbers (ie, NaN, INF) with transparent pixels
   cmap = plt.get_cmap()

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -945,7 +945,7 @@ def plot_energy_fluxes(solver, fsrs, group_bounds=None, norm=True, loglog=True):
 # @param gridsize an optional number of grid cells for the plot
 # @param xlim optional list/tuple of the minimim/maximum x-coordinates
 # @param ylim optional list/tuple of the minimim/maximum y-coordinates
-def plot_fission_rates(solver, transparent_zeros=False, gridsize=250,
+def plot_fission_rates(solver, transparent_zeros=True, gridsize=250,
                        xlim=None, ylim=None):
 
   global subdirectory


### PR DESCRIPTION
This PR adds a new boolean `transparent_zeros` parameter to the `openmoc.plotter.plot_fission_rates(...)` routine. This can be used to make all regions with a zero fission rate (*e.g.*, gap, clad, moderator) transparent in the plot (and excluded from the colorbar). This can make it easier to compare the relative fission rates between different fuel pins in an assembly.

For example, let's say we have the following fuel assembly of cells:

<img src="https://cloud.githubusercontent.com/assets/209492/11614538/a2ae3542-9c13-11e5-884b-db8677978e42.png" width="250">

The current code would plot the fission rates with dark blue for those regions without fission as follows:

<img src="https://cloud.githubusercontent.com/assets/209492/11614561/482aee8e-9c14-11e5-8fff-c1d8bf7579c6.png" width="300">

The above plot may still be generated with the new code introduced here when `transparent_zeros=False` (the default). If instead the user sets `transparent_zeros=True` one will obtain the following more useful plot:

<img src="https://cloud.githubusercontent.com/assets/209492/11614554/15e9ff6e-9c14-11e5-801b-b283bebc0fe1.png" width="300">

@geogunow - you want to review this easy PR and take the load off of @samuelshaner?