### PR TITLE
Hotfix for CMFD Re-initialization

### DIFF
--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -905,11 +905,11 @@ void Cmfd::initializeCurrents() {
 
   /* Delete old Cmfd surface currents array it it exists */
   if (_surface_currents != NULL)
-    delete [] _surface_currents;
+    delete _surface_currents;
 
   /* Delete old Cmfd corner currents array it it exists */
   if (_corner_currents != NULL)
-    delete [] _corner_currents;
+    delete _corner_currents;
 
   /* Allocate memory for the Cmfd Mesh surface and corner currents Vectors */
   _surface_currents = new Vector(_num_x, _num_y,
@@ -1306,11 +1306,6 @@ void Cmfd::setSourceConvergenceThreshold(FP_PRECISION source_thresh) {
  * @param polar_quad A PolarQuad object pointer from the Solver
  */
 void Cmfd::setPolarQuadrature(PolarQuad* polar_quad) {
-
-  /* Deletes the old Quadrature if one existed */
-  if (_polar_quad != NULL)
-    delete _polar_quad;
-
   _polar_quad = polar_quad;
   _num_polar = polar_quad->getNumPolarAngles();
 }

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -903,11 +903,11 @@ void Cmfd::initializeMaterials() {
  */
 void Cmfd::initializeCurrents() {
 
-  /* Delete old Cmfd surface currents array it it exists */
+  /* Delete old Cmfd surface currents vector if it exists */
   if (_surface_currents != NULL)
     delete _surface_currents;
 
-  /* Delete old Cmfd corner currents array it it exists */
+  /* Delete old Cmfd corner currents vector if it exists */
   if (_corner_currents != NULL)
     delete _corner_currents;
 


### PR DESCRIPTION
This very minor PR fixes two issues in CMFD related to re-initialization. In particular, a user will currently observe a segmentation when using same `CMFD`, `Geometry`, `TrackGenerator` and `Solver` objects for two simulations. This is due to the way a few of `CMFD's` attributes are deleted during re-initialization. This PR fixes these issues and makes it possible to run as many simulations as one wishes to with a single `CMFD` object (*e.g.*, with different MGXS libraries).