### PR TITLE
Normed plots

### DIFF
--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -696,7 +696,7 @@ def plot_cmfd_cells(geometry, cmfd, gridsize=250, xlim=None, ylim=None):
 #
 # @param solver a Solver object that has converged the source for the Geometry
 # @param energy_groups a Python list of integer energy groups to plot
-# @param norm normalize the fission rates to unity (default is False)
+# @param norm normalize the fluxes to the maximum flux
 # @param gridsize an optional number of grid cells for the plot
 # @param xlim optional list/tuple of the minimim/maximum x-coordinates
 # @param ylim optional list/tuple of the minimim/maximum y-coordinates
@@ -781,7 +781,7 @@ def plot_spatial_fluxes(solver, energy_groups=[1], norm=False,
   # Loop over all energy group and create a plot
   for index, group in enumerate(energy_groups):
 
-    # Normalize fluxes to maximum flux if requested
+    # Normalize to maximum flux if requested
     if norm:
       fluxes[index,:,:] /= np.max(fluxes[index,:,:])
 
@@ -820,7 +820,7 @@ def plot_spatial_fluxes(solver, energy_groups=[1], norm=False,
 # @param solver a Solver object that has converged the source for the Geometry
 # @param fsrs the flat source region IDs of interest
 # @param group_bounds an optional Python list of the energy group bounds (eV)
-# @param norm a boolean indicating whether to normalize the flux
+# @param norm normalize the fluxes to the total energy-integrated flux
 # @param loglog boolean indicating whether to plot use a log-log scale
 def plot_energy_fluxes(solver, fsrs, group_bounds=None, norm=True, loglog=True):
 
@@ -952,7 +952,7 @@ def plot_energy_fluxes(solver, fsrs, group_bounds=None, norm=True, loglog=True):
 # @endcode
 #
 # @param solver a Solver object that has converged the source for the Geometry
-# @param norm normalize the fission rates to unity (default is False)
+# @param norm normalize the fission rates to the maximum fission rate
 # @param transparent_zeros make regions without fission transparent
 # @param gridsize an optional number of grid cells for the plot
 # @param xlim optional list/tuple of the minimim/maximum x-coordinates
@@ -1016,7 +1016,7 @@ def plot_fission_rates(solver, norm=False, transparent_zeros=True,
       else:
        surface[j][i] = fission_rates[fsr_id]
 
-  # Normalize to maximum rate if requested
+  # Normalize to maximum fission rate if requested
   if norm:
     surface /= np.max(surface)
 
@@ -1053,7 +1053,7 @@ def plot_fission_rates(solver, norm=False, transparent_zeros=True,
 # @param iramsolver an IRAMSolver object that has computed the eigenmodes
 # @param eigenmodes a Python list of integer eigenmodes to plot
 # @param energy_groups a Python list of integer energy groups to plot
-# @param norm normalize the fission rates to unity (default is False)
+# @param norm normalize the fluxes to the maximum flux
 # @param gridsize an optional number of grid cells for the plot
 # @param xlim optional list/tuple of the minimim/maximum x-coordinates
 # @param ylim optional list/tuple of the minimim/maximum y-coordinates

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -696,10 +696,11 @@ def plot_cmfd_cells(geometry, cmfd, gridsize=250, xlim=None, ylim=None):
 #
 # @param solver a Solver object that has converged the source for the Geometry
 # @param energy_groups a Python list of integer energy groups to plot
+# @param norm normalize the fission rates to unity (default is False)
 # @param gridsize an optional number of grid cells for the plot
 # @param xlim optional list/tuple of the minimim/maximum x-coordinates
 # @param ylim optional list/tuple of the minimim/maximum y-coordinates
-def plot_spatial_fluxes(solver, energy_groups=[1],
+def plot_spatial_fluxes(solver, energy_groups=[1], norm=False,
                         gridsize=250, xlim=None, ylim=None):
 
   global subdirectory
@@ -779,6 +780,10 @@ def plot_spatial_fluxes(solver, energy_groups=[1],
 
   # Loop over all energy group and create a plot
   for index, group in enumerate(energy_groups):
+
+    # Normalize fluxes to maximum flux if requested
+    if norm:
+      fluxes[index,:,:] /= np.max(fluxes[index,:,:])
 
     # Plot a 2D color map of the flat source regions
     fig = plt.figure(index)
@@ -947,12 +952,12 @@ def plot_energy_fluxes(solver, fsrs, group_bounds=None, norm=True, loglog=True):
 # @endcode
 #
 # @param solver a Solver object that has converged the source for the Geometry
-# @param normed normalize the fission rates to unity (default is False)
+# @param norm normalize the fission rates to unity (default is False)
 # @param transparent_zeros make regions without fission transparent
 # @param gridsize an optional number of grid cells for the plot
 # @param xlim optional list/tuple of the minimim/maximum x-coordinates
 # @param ylim optional list/tuple of the minimim/maximum y-coordinates
-def plot_fission_rates(solver, normed=False, transparent_zeros=True,
+def plot_fission_rates(solver, norm=False, transparent_zeros=True,
                        gridsize=250, xlim=None, ylim=None):
 
   global subdirectory
@@ -1011,8 +1016,8 @@ def plot_fission_rates(solver, normed=False, transparent_zeros=True,
       else:
        surface[j][i] = fission_rates[fsr_id]
 
-  # Normalize the plot if needed
-  if normed:
+  # Normalize to maximum rate if requested
+  if norm:
     surface /= np.max(surface)
 
   # Set zero fission rates to NaN so Matplotlib will make them transparent
@@ -1048,11 +1053,12 @@ def plot_fission_rates(solver, normed=False, transparent_zeros=True,
 # @param iramsolver an IRAMSolver object that has computed the eigenmodes
 # @param eigenmodes a Python list of integer eigenmodes to plot
 # @param energy_groups a Python list of integer energy groups to plot
+# @param norm normalize the fission rates to unity (default is False)
 # @param gridsize an optional number of grid cells for the plot
 # @param xlim optional list/tuple of the minimim/maximum x-coordinates
 # @param ylim optional list/tuple of the minimim/maximum y-coordinates
-def plot_eigenmode_fluxes(iramsolver, eigenmodes=[], energy_groups=[1],
-                          gridsize=250, xlim=None, ylim=None):
+def plot_eigenmode_fluxes(iramsolver, eigenmodes=[], norm=False,
+                          energy_groups=[1], gridsize=250, xlim=None, ylim=None):
 
   global subdirectory
 
@@ -1117,7 +1123,7 @@ def plot_eigenmode_fluxes(iramsolver, eigenmodes=[], energy_groups=[1],
     subdirectory = '/plots/eig-{0}-flux/'.format(str(mode).zfill(num_digits))
 
     # Plot this eigenmode's spatial fluxes
-    plot_spatial_fluxes(moc_solver, energy_groups, gridsize, xlim, ylim)
+    plot_spatial_fluxes(moc_solver, energy_groups, norm, gridsize, xlim, ylim)
 
   # Reset global subdirectory
   subdirectory = '/plots/'

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -950,7 +950,9 @@ def plot_energy_fluxes(solver, fsrs, group_bounds=None, norm=True, loglog=True):
 # @param gridsize an optional number of grid cells for the plot
 # @param xlim optional list/tuple of the minimim/maximum x-coordinates
 # @param ylim optional list/tuple of the minimim/maximum y-coordinates
-def plot_fission_rates(solver, gridsize=250, xlim=None, ylim=None):
+# @param normed normalize the fission rates to unity (default is False)
+def plot_fission_rates(solver, normed=False, gridsize=250, 
+                       xlim=None, ylim=None):
 
   global subdirectory
 
@@ -1007,6 +1009,10 @@ def plot_fission_rates(solver, gridsize=250, xlim=None, ylim=None):
       # Get the fission rate in this FSR
       else:
        surface[j][i] = fission_rates[fsr_id]
+
+  # Normalize the plot if needed
+  if normed:
+    surface /= np.max(surface)
 
   # Plot a 2D color map of the flat source regions fission rates
   fig = plt.figure()

--- a/sample-input/benchmarks/c5g7/c5g7-cmfd.py
+++ b/sample-input/benchmarks/c5g7/c5g7-cmfd.py
@@ -67,6 +67,6 @@ openmoc.plotter.plot_cells(geometry, gridsize=250)
 openmoc.plotter.plot_cmfd_cells(geometry, cmfd, gridsize=250)
 openmoc.plotter.plot_flat_source_regions(geometry, gridsize=250)
 openmoc.plotter.plot_spatial_fluxes(solver, energy_groups=[1,2,3,4,5,6,7])
-openmoc.plotter.plot_fission_rates(solver, normed=True, gridsize=250)
+openmoc.plotter.plot_fission_rates(solver, gridsize=250)
 
 openmoc.log.py_printf('TITLE', 'Finished')

--- a/sample-input/benchmarks/c5g7/c5g7-cmfd.py
+++ b/sample-input/benchmarks/c5g7/c5g7-cmfd.py
@@ -67,6 +67,6 @@ openmoc.plotter.plot_cells(geometry, gridsize=250)
 openmoc.plotter.plot_cmfd_cells(geometry, cmfd, gridsize=250)
 openmoc.plotter.plot_flat_source_regions(geometry, gridsize=250)
 openmoc.plotter.plot_spatial_fluxes(solver, energy_groups=[1,2,3,4,5,6,7])
-openmoc.plotter.plot_fission_rates(solver, gridsize=250)
+openmoc.plotter.plot_fission_rates(solver, normed=True, gridsize=250)
 
 openmoc.log.py_printf('TITLE', 'Finished')


### PR DESCRIPTION
This PR adds a new `norm` parameter to the scalar flux and fission rate plotting routines in `openmoc.plotter`. The current behavior is preserved when `norm` is equal to `False` (default); when `norm` is set to `True` the flux / fission rate is normalized to the maximum of value in the spatial domain of interest (*e.g.*, the max value within the [min_x, max_x], [min_y, max_y] in the plot).