### PR TITLE
Fixed Memory Deallocation in Geometry::findCellContainingFSR(...)`

### DIFF
--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1196,6 +1196,7 @@ Cell* Geometry::findCellContainingFSR(int fsr_id) {
   coords->setUniverse(_root_universe);
   Cell* cell = findCellContainingCoords(coords);
 
+  coods->prune();
   delete coords;
 
   return cell;


### PR DESCRIPTION
Recently, I've run into an issue when running large scale problems with the SPH calculator in #219. In particular, I was running out of memory (10+ GB) when setting up fixed source problems with hundreds or thousands of domains and ~100 energy groups. I discovered that this was caused by a one line bug in the memory deallocation of `LocalCoords` objects in the `Geometry::findCellContainingFSR(...)`. By fixing this bug here, it is now possible to solve such large fixed source problems. In addition, this bug will reduce the memory footprint consumed by the `openmoc.plotter` module which also made extensive use of this routine in the `Geometry`.