### PR TITLE
changed eigenvalueSolve to normalize new source instead of old source

### DIFF
--- a/src/linalg.cpp
+++ b/src/linalg.cpp
@@ -64,14 +64,13 @@ FP_PRECISION eigenvalueSolve(Matrix* A, Matrix* M, Vector* X, FP_PRECISION tol,
     /* Compute and set keff */
     _k_eff = new_source.getSum() / num_rows;
 
-    /* Scale the old source by keff */
-    old_source.scaleByValue(_k_eff);
+    /* Scale the new source by 1 / k_eff */
+    new_source.scaleByValue(1.0 / _k_eff);
 
     /* Compute the residual */
     residual = computeRMSE(&new_source, &old_source, true);
 
-    /* Normalize the new source to have an average value of 1.0 */
-    new_source.scaleByValue(num_rows / new_source.getSum());
+    /* Copy the new source to the old source */
     new_source.copyTo(&old_source);
 
     log_printf(INFO, "Matrix-Vector eigenvalue iter: %d, keff: %f, residual: "


### PR DESCRIPTION
This PR makes a small, but significant change to the `eigenvalueSolve()` function in `linalg.cpp`. While, this would seemingly not have an effect on the residual computed during the eigenvalue solve, in practice the residual is affected by this change. Additionally, this slightly reduces the amount of computation in the eigenvalue solve.