### PR TITLE
Auto ID Maximization

### DIFF
--- a/openmoc/compatible/opencg_compatible.py
+++ b/openmoc/compatible/opencg_compatible.py
@@ -866,4 +866,21 @@ def get_openmoc_geometry(opencg_geometry):
   openmoc_geometry = openmoc.Geometry()
   openmoc_geometry.setRootUniverse(openmoc_root_universe)
 
+  # Update OpenMOC's auto-generated object IDs (e.g., Surface, Material)
+  # with the maximum of those created from the OpenCG objects
+  all_materials = openmoc_geometry.getAllMaterials()
+  all_surfaces = openmoc_geometry.getAllSurfaces()
+  all_cells = openmoc_geometry.getAllCells()
+  all_universes = openmoc_geometry.getAllUniverses()
+
+  max_material_id = max(all_materials.keys())
+  max_surface_id = max(all_surfaces.keys())
+  max_cell_id = max(all_cells.keys())
+  max_universe_id = max(all_universes.keys())
+
+  openmoc.maximize_material_id(max_material_id+1)
+  openmoc.maximize_surface_id(max_surface_id+1)
+  openmoc.maximize_cell_id(max_cell_id+1)
+  openmoc.maximize_universe_id(max_universe_id+1)
+
   return openmoc_geometry

--- a/openmoc/map_to_dict.i
+++ b/openmoc/map_to_dict.i
@@ -26,6 +26,30 @@
 }
 
 
+/* Typemap for all methods which return a std::map<int, Surface*>. This
+ * includes the Geometry::getAllSurfaces() method, which is useful for 
+ * OpenCG compatibility. */
+%clear std::map<int, Surface*>;
+%typemap(out) std::map<int, Surface*> {
+
+  $result = PyDict_New();
+  int size = $1.size();
+
+  std::map<int, Surface*>::iterator iter;
+  Surface* surf;
+  int surf_id;
+
+  for (iter = $1.begin(); iter != $1.end(); ++iter) {
+    surf_id = iter->first;
+    surf = iter->second;
+    PyObject* value =
+         SWIG_NewPointerObj(SWIG_as_voidptr(surf),
+                            $descriptor(Surface*), 0);
+    PyDict_SetItem($result, PyInt_FromLong(surf_id), value);
+  }
+}
+
+
 /* Typemap for all methods which return a std::map<int, surface_halfspace>.
  * This includes the Cell::getSurfaces() method, which is useful for OpenCG
  * compatibility. */

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -3,7 +3,7 @@
 
 int Cell::_n = 0;
 
-static int auto_id = 10000;
+static int auto_id = DEFAULT_INIT_ID;
 
 
 /**
@@ -26,7 +26,7 @@ int cell_id() {
  * @brief Resets the auto-generated unique Cell ID counter to 10000.
  */
 void reset_cell_id() {
-  auto_id = 10000;
+  auto_id = DEFAULT_INIT_ID;
 }
 
 

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -31,6 +31,21 @@ void reset_cell_id() {
 
 
 /**
+ * @brief Maximize the auto-generated unique Cell ID counter.
+ * @details This method updates the auto-generated unique Cell ID
+ *          counter if the input parameter is greater than the present
+ *          value. This is useful for the OpenCG compatibility module
+ *          to ensure that the auto-generated Cell IDs do not
+ *          collide with those created in OpenCG.
+ * @param material_id the id assigned to the auto-generated counter
+ */
+void maximize_cell_id(int cell_id) {
+  if (cell_id > auto_id)
+    auto_id = cell_id;
+}
+
+
+/**
  * @brief Constructor sets the unique and user-specifed IDs for this Cell.
  * @param id the user-specified optional Cell ID
  * @param name the user-specified optional Cell name

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -37,7 +37,7 @@ void reset_cell_id() {
  *          value. This is useful for the OpenCG compatibility module
  *          to ensure that the auto-generated Cell IDs do not
  *          collide with those created in OpenCG.
- * @param material_id the id assigned to the auto-generated counter
+ * @param cell_id the id assigned to the auto-generated counter
  */
 void maximize_cell_id(int cell_id) {
   if (cell_id > auto_id)

--- a/src/Cell.h
+++ b/src/Cell.h
@@ -26,6 +26,7 @@ class Surface;
 
 int cell_id();
 void reset_cell_id();
+void maximize_cell_id(int cell_id);
 
 
 /**

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -7,7 +7,7 @@
  */
 void reset_auto_ids() {
   reset_material_id();
-  reset_surf_id();
+  reset_surface_id();
   reset_cell_id();
   reset_universe_id();
 }
@@ -246,18 +246,65 @@ int Geometry::getNumCells() {
 
 
 /**
- * @brief Return a std::map container of Universe IDs (keys) with Unierses
+ * @brief Return a std::map container of Surface IDs (keys) with Surfaces
  *        pointers (values).
- * @return a std::map of Universes indexed by Universe ID in the geometry
+ * @return a std::map of Surfaces indexed by Surface ID in the geometry
  */
-std::map<int, Universe*> Geometry::getAllUniverses() {
+std::map<int, Surface*> Geometry::getAllSurfaces() {
 
-  std::map<int, Universe*> all_universes;
+  Cell* cell;
+  Surface* surf;
+  std::map<int, Surface*> all_surfs;
+  std::map<int, surface_halfspace*> surfs;
+  std::map<int, Cell*>::iterator c_iter;
+  std::map<int, surface_halfspace*>::iterator s_iter;
 
-  if (_root_universe != NULL)
-    all_universes = _root_universe->getAllUniverses();
+  if (_root_universe != NULL) {
+    std::map<int, Cell*> all_cells = getAllCells();
 
-  return all_universes;
+    for (c_iter = all_cells.begin(); c_iter != all_cells.end(); ++c_iter) {
+      cell = (*c_iter).second;
+      surfs = cell->getSurfaces();
+
+      for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
+	surf = (*s_iter).second->_surface;
+	all_surfs[surf->getId()] = surf;
+      }
+    }
+  }
+
+  return all_surfs;
+}
+
+
+/**
+ * @brief Return a std::map container of Material IDs (keys) with Materials
+ *        pointers (values).
+ * @return a std::map of Materials indexed by Material ID in the geometry
+ */
+std::map<int, Material*> Geometry::getAllMaterials() {
+
+  std::map<int, Material*> all_materials;
+  Cell* cell;
+  Material* material;
+
+  if (_root_universe != NULL) {
+    std::map<int, Cell*> all_cells = getAllMaterialCells();
+    std::map<int, Cell*>::iterator iter;
+
+    for (iter = all_cells.begin(); iter != all_cells.end(); ++iter) {
+      cell = (*iter).second;
+
+      if (cell->getType() == MATERIAL) {
+        material = cell->getFillMaterial();
+
+        if (material != NULL)
+          all_materials[material->getId()] = material;
+      }
+    }
+  }
+
+  return all_materials;
 }
 
 
@@ -304,33 +351,18 @@ std::map<int, Cell*> Geometry::getAllMaterialCells() {
 
 
 /**
- * @brief Return a std::map container of Material IDs (keys) with Materials
+ * @brief Return a std::map container of Universe IDs (keys) with Unierses
  *        pointers (values).
- * @return a std::map of Materials indexed by Material ID in the geometry
+ * @return a std::map of Universes indexed by Universe ID in the geometry
  */
-std::map<int, Material*> Geometry::getAllMaterials() {
+std::map<int, Universe*> Geometry::getAllUniverses() {
 
-  std::map<int, Material*> all_materials;
-  Cell* cell;
-  Material* material;
+  std::map<int, Universe*> all_universes;
 
-  if (_root_universe != NULL) {
-    std::map<int, Cell*> all_cells = getAllMaterialCells();
-    std::map<int, Cell*>::iterator iter;
+  if (_root_universe != NULL)
+    all_universes = _root_universe->getAllUniverses();
 
-    for (iter = all_cells.begin(); iter != all_cells.end(); ++iter) {
-      cell = (*iter).second;
-
-      if (cell->getType() == MATERIAL) {
-        material = cell->getFillMaterial();
-
-        if (material != NULL)
-          all_materials[material->getId()] = material;
-      }
-    }
-  }
-
-  return all_materials;
+  return all_universes;
 }
 
 

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -134,10 +134,11 @@ public:
   int getNumEnergyGroups();
   int getNumMaterials();
   int getNumCells();
-  std::map<int, Universe*> getAllUniverses();
+  std::map<int, Material*> getAllMaterials();
+  std::map<int, Surface*> getAllSurfaces();
   std::map<int, Cell*> getAllCells();
   std::map<int, Cell*> getAllMaterialCells();
-  std::map<int, Material*> getAllMaterials();
+  std::map<int, Universe*> getAllUniverses();
   void setRootUniverse(Universe* root_universe);
 
   Cmfd* getCmfd();

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -28,6 +28,21 @@ void reset_material_id() {
 
 
 /**
+ * @brief Maximize the auto-generated unique Material ID counter.
+ * @details This method updates the auto-generated unique Material ID
+ *          counter if the input parameter is greater than the present
+ *          value. This is useful for the OpenCG compatibility module
+ *          to ensure that the auto-generated Material IDs do not
+ *          collide with those created in OpenCG.
+ * @param material_id the id assigned to the auto-generated counter
+ */
+void maximize_material_id(int material_id) {
+  if (material_id > auto_id)
+    auto_id = material_id;
+}
+
+
+/**
  * @brief Constructor sets the ID and unique ID for the Material.
  * @param id the user-specified optional Material ID
  * @param name the user-specified optional Material name

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -1,6 +1,6 @@
 #include "Material.h"
 
-static int auto_id = 10000;
+static int auto_id = DEFAULT_INIT_ID;
 
 
 /**
@@ -23,7 +23,7 @@ int material_id() {
  * @brief Resets the auto-generated unique Material ID counter to 10000.
  */
 void reset_material_id() {
-  auto_id = 10000;
+  auto_id = DEFAULT_INIT_ID;
 }
 
 

--- a/src/Material.h
+++ b/src/Material.h
@@ -41,6 +41,7 @@
 
 int material_id();
 void reset_material_id();
+void maximize_material_id(int material_id);
 
 
 /**

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -2,7 +2,7 @@
 
 int Surface::_n = 0;
 
-static int auto_id = 10000;
+static int auto_id = DEFAULT_INIT_ID;
 
 /**
  * @brief Returns an auto-generated unique surface ID.
@@ -24,7 +24,7 @@ int surface_id() {
  * @brief Resets the auto-generated unique Surface ID counter to 10000.
  */
 void reset_surface_id() {
-  auto_id = 10000;
+  auto_id = DEFAULT_INIT_ID;
 }
 
 

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -13,7 +13,7 @@ static int auto_id = 10000;
  *          first ID begins at 10000. Hence, user-defined surface IDs greater
  *          than or equal to 10000 are prohibited.
  */
-int surf_id() {
+int surface_id() {
   int id = auto_id;
   auto_id++;
   return id;
@@ -23,8 +23,23 @@ int surf_id() {
 /**
  * @brief Resets the auto-generated unique Surface ID counter to 10000.
  */
-void reset_surf_id() {
+void reset_surface_id() {
   auto_id = 10000;
+}
+
+
+/**
+ * @brief Maximize the auto-generated unique Surface ID counter.
+ * @details This method updates the auto-generated unique Surface ID
+ *          counter if the input parameter is greater than the present
+ *          value. This is useful for the OpenCG compatibility module
+ *          to ensure that the auto-generated Surface IDs do not
+ *          collide with those created in OpenCG.
+ * @param surface_id the id assigned to the auto-generated counter
+ */
+void maximize_surface_id(int surface_id) {
+  if (surface_id > auto_id)
+    auto_id = surface_id;
 }
 
 
@@ -39,7 +54,7 @@ Surface::Surface(const int id, const char* name) {
 
   /* If the user did not define an optional ID, create one */
   if (id == 0)
-    _id = surf_id();
+    _id = surface_id();
 
   /* Use the user-defined ID */
   else

--- a/src/Surface.h
+++ b/src/Surface.h
@@ -28,8 +28,9 @@ class LocalCoords;
 class Cell;
 
 
-int surf_id();
-void reset_surf_id();
+int surface_id();
+void reset_surface_id();
+void maximize_surface_id(int surface_id);
 
 
 /**

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -30,6 +30,21 @@ void reset_universe_id() {
 
 
 /**
+ * @brief Maximize the auto-generated unique Universe ID counter.
+ * @details This method updates the auto-generated unique Universe ID
+ *          counter if the input parameter is greater than the present
+ *          value. This is useful for the OpenCG compatibility module
+ *          to ensure that the auto-generated Universe IDs do not
+ *          collide with those created in OpenCG.
+ * @param universe_id the id assigned to the auto-generated counter
+ */
+void maximize_universe_id(int universe_id) {
+  if (universe_id > auto_id)
+    auto_id = universe_id;
+}
+
+
+/**
  * @brief Constructor assigns a unique and user-specified ID for the Universe.
  * @param id the user-specified optional Universe ID
  * @param name the user-specified optional Universe ID

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -3,7 +3,7 @@
 
 int Universe::_n = 0;
 
-static int auto_id = 10000;
+static int auto_id = DEFAULT_INIT_ID;
 
 /**
  * @brief Returns an auto-generated unique Universe ID.
@@ -25,7 +25,7 @@ int universe_id() {
  * @brief Resets the auto-generated unique Universe ID counter to 10000.
  */
 void reset_universe_id() {
-  auto_id = 10000;
+  auto_id = DEFAULT_INIT_ID;
 }
 
 

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -31,6 +31,7 @@ struct surface_halfspace;
 
 int universe_id();
 void reset_universe_id();
+void maximize_universe_id(int universe_id);
 
 
 /**

--- a/src/constants.h
+++ b/src/constants.h
@@ -9,6 +9,9 @@
 #define CONSTANTS_H_
 
 
+/** The minimum auto ID used for Surfaces, Cells, Materials and Universes */
+#define DEFAULT_INIT_ID 10000
+
 /** The value of 4pi: \f$ 4\pi \f$ */
 #define FOUR_PI 12.5663706143
 


### PR DESCRIPTION
This PR adds new routines to maximize auto-generated IDs for `Surfaces`, `Materials`, `Cells` and `Universes`. These new routines include the following:

* `maximize_surface_id()`
* `maximize_material_id()`
* `maximize_cell_id()`
* `maximize_universe_id()`

Our auto-generated ID streams start at 10000 by default. In the event that a user creates an OpenMOC `Geometry` from an OpenCG `Geometry` which has its own IDs, the auto-generated ID streams are not updated (or "maximized"). This PR changes that so that after an `opencg.Geometry` is transformed into an equivalent `openmoc.Geometry` the auto ID streams are updated to the max IDs of the `opencg.Surface`, `opencg.Material`, `opencg.Cell` and `opencg.Universe` objects. This prevents IDs from overlapping if a user decides to 1) create an OpenMOC `Geometry` from an OpenCG `Geometry` and 2) interchange some `Materials`, `Cells`, etc. with new OpenMOC ones.