### PR TITLE
Fixed bug in handling horizontal tracks

### DIFF
--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -50,6 +50,12 @@ struct fsr_data {
   /** Global numerical centroid in Root Universe */
   Point* _centroid;
 
+  /** Constructor for FSR data initializes centroids and points to NULL */
+  fsr_data() {
+    _centroid = NULL;
+    _point = NULL;
+  }
+
   /** Destructor for fsr_data */
   ~fsr_data() {
     if (_point != NULL)

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -842,7 +842,8 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
     /* Solve for where the line x = x0 and the Surface F(x,y) intersect
      * Find the y where F(x0, y) = 0
      * Substitute x0 into F(x,y) and rearrange to put in
-     * the form of the quadratic formula: ay^2 + by + c = 0 */
+     * the form of the quadratic formula: ay^2 + by + c = 0 
+     * This is simplified for a z-cylinder with a vertical axis */
     a = 1.;
     b = _D;
     c = _A * x0 * x0 + _C * x0 + _E;

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -843,11 +843,11 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
      * Find the y where F(x0, y) = 0
      * Substitute x0 into F(x,y) and rearrange to put in
      * the form of the quadratic formula: ay^2 + by + c = 0 */
-    a = _B * _B;
+    a = 1.;
     b = _D;
     c = _A * x0 * x0 + _C * x0 + _E;
 
-    discr = b*b - 4*a*c;
+    discr = b*b - 4*c;
 
     /* There are no intersections */
     if (discr < 0)
@@ -856,7 +856,7 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
     /* There is one intersection (ie on the Surface) */
     else if (discr == 0) {
       xcurr = x0;
-      ycurr = -b / (2*a);
+      ycurr = -b / 2;
       zcurr = z0;
       points[num].setCoords(xcurr, ycurr, zcurr);
 
@@ -872,7 +872,7 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
     /* There are two intersections */
     else {
       xcurr = x0;
-      ycurr = (-b + sqrt(discr)) / (2 * a);
+      ycurr = (-b + sqrt(discr)) / 2;
       zcurr = z0;
       points[num].setCoords(xcurr, ycurr, zcurr);
       if (angle < M_PI && ycurr > y0)
@@ -881,7 +881,7 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
         num++;
 
       xcurr = x0;
-      ycurr = (-b - sqrt(discr)) / (2 * a);
+      ycurr = (-b - sqrt(discr)) / 2;
       zcurr = z0;
       points[num].setCoords(xcurr, ycurr, zcurr);
       if (angle < M_PI && ycurr > y0)
@@ -901,11 +901,12 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
      * rearrange to put in the form of the quadratic formula:
      * ax^2 + bx + c = 0
      */
-    double m = sin(angle) / cos(angle);
+    bool right = angle < M_PI || angle > 3. * M_PI / 2.;
+    double m = tan(angle);
     q = y0 - m * x0;
-    a = _A + _B * _B * m * m;
-    b = 2 * _B * m * q + _C + _D * m;
-    c = _B * q * q + _D * q + _E;
+    a = 1. + m * m;
+    b = 2 * m * q + _C + _D * m;
+    c = q * q + _D * q + _E;
 
     discr = b*b - 4*a*c;
 
@@ -919,9 +920,9 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
       ycurr = y0 + m * (points[num].getX() - x0);
       zcurr = z0;
       points[num].setCoords(xcurr, ycurr, zcurr);
-      if (angle < M_PI && ycurr > y0)
+      if (right && xcurr > x0)
         num++;
-      else if (angle > M_PI && ycurr < y0)
+      else if (!right && xcurr < x0)
         num++;
 
       return num;
@@ -933,18 +934,18 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
       ycurr = y0 + m * (xcurr - x0);
       zcurr = z0;
       points[num].setCoords(xcurr, ycurr, zcurr);
-      if (angle < M_PI && ycurr > y0)
+      if (right && xcurr > x0)
         num++;
-      else if (angle > M_PI && ycurr < y0)
+      else if (!right && xcurr < x0)
         num++;
 
       xcurr = (-b - sqrt(discr)) / (2*a);
       ycurr = y0 + m * (xcurr - x0);
       zcurr = z0;
       points[num].setCoords(xcurr, ycurr, zcurr);
-      if (angle < M_PI && ycurr > y0)
+      if (right && xcurr > x0)
         num++;
-      else if (angle > M_PI && ycurr < y0)
+      else if (!right && xcurr < x0)
         num++;
 
       return num;

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -902,7 +902,7 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
      * rearrange to put in the form of the quadratic formula:
      * ax^2 + bx + c = 0
      */
-    bool right = angle < M_PI || angle > 3. * M_PI / 2.;
+    bool right = angle < M_PI / 2. || angle > 3. * M_PI / 2.;
     double m = tan(angle);
     q = y0 - m * x0;
     a = 1. + m * m;

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -919,10 +919,15 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
 
     /* There is one intersection (ie on the Surface) */
     else if (discr == 0) {
+
+      /* Determine the point of intersection */
       xcurr = -b / (2*a);
       ycurr = y0 + m * (points[num].getX() - x0);
       zcurr = z0;
       points[num].setCoords(xcurr, ycurr, zcurr);
+
+      /* Increase the number of intersections if the intersection is in the
+       * direction of the track is heading */
       if (right && xcurr > x0)
         num++;
       else if (!right && xcurr < x0)

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -902,14 +902,16 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
      * rearrange to put in the form of the quadratic formula:
      * ax^2 + bx + c = 0
      */
-    bool right = angle < M_PI / 2. || angle > 3. * M_PI / 2.;
     double m = tan(angle);
     q = y0 - m * x0;
-    a = 1. + m * m;
+    a = 1 + m * m;
     b = 2 * m * q + _C + _D * m;
     c = q * q + _D * q + _E;
 
     discr = b*b - 4*a*c;
+
+    /* Boolean value describing whether the track is traveling to the right */
+    bool right = angle < M_PI / 2. || angle > 3. * M_PI / 2.;
 
     /* There are no intersections */
     if (discr < 0)
@@ -931,19 +933,28 @@ int ZCylinder::intersection(Point* point, double angle, Point* points) {
 
     /* There are two intersections */
     else {
+
+      /* Determine the point of intersection */
       xcurr = (-b + sqrt(discr)) / (2*a);
       ycurr = y0 + m * (xcurr - x0);
       zcurr = z0;
       points[num].setCoords(xcurr, ycurr, zcurr);
+
+      /* Increase the number of intersections if the intersection is in the
+       * direction of the track is heading */
       if (right && xcurr > x0)
         num++;
       else if (!right && xcurr < x0)
         num++;
 
+      /* Determine the point of intersection */
       xcurr = (-b - sqrt(discr)) / (2*a);
       ycurr = y0 + m * (xcurr - x0);
       zcurr = z0;
       points[num].setCoords(xcurr, ycurr, zcurr);
+
+      /* Increase the number of intersections if the intersection is in the
+       * direction of the track is heading */
       if (right && xcurr > x0)
         num++;
       else if (!right && xcurr < x0)


### PR DESCRIPTION
This PR fixes a bug in our tracking. Currently, ``ZCylinder::intersection`` does not work for tracks that travel horizontally. This is because the change in the ``y`` coordinate is used to determine whether a point is inside or outside of a ``ZCylinder``. This PR changes the routine to check the ``x`` coordinate for non-vertical tracks. In addition, a simple constructor for ``fsr_data`` was added to ensure that pointers are initialized as ``NULL`` (this is not guaranteed otherwise).