### PR TITLE
Ring radius extension

### DIFF
--- a/openmoc/openmoc.i
+++ b/openmoc/openmoc.i
@@ -21,6 +21,7 @@
   #include "../src/Solver.h"
   #include "../src/CPUSolver.h"
   #include "../src/boundary_type.h"
+  #include "../src/ringify_type.h"
   #include "../src/Surface.h"
   #include "../src/Timer.h"
   #include "../src/Track.h"
@@ -106,6 +107,7 @@
 %include ../src/Solver.h
 %include ../src/CPUSolver.h
 %include ../src/boundary_type.h
+%include ../src/ringify_type.h
 %include ../src/Surface.h
 %include ../src/Timer.h
 %include ../src/Track.h

--- a/sample-input/simple-lattice/simple-lattice.py
+++ b/sample-input/simple-lattice/simple-lattice.py
@@ -56,7 +56,7 @@ large_fuel.setFill(materials['UO2'])
 large_fuel.addSurface(halfspace=-1, surface=large_zcylinder)
 
 large_moderator = openmoc.Cell(name='large pin moderator')
-large_fuel.setNumSectors(8)
+large_moderator.setNumSectors(8)
 large_moderator.setFill(materials['Water'])
 large_moderator.addSurface(halfspace=+1, surface=large_zcylinder)
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -780,7 +780,7 @@ void Geometry::subdivideCells() {
   }
 
   /* Recursively subdivide Cells into rings and sectors */
-  _root_universe->subdivideCells(max_radius);
+  _root_universe->subdivideCells(max_radius, _ringify_type);
 }
 
 
@@ -1164,8 +1164,7 @@ void Geometry::setFSRsToKeys(std::vector<std::string>* FSRs_to_keys) {
  * @brief Sets the method for selection of the maximum ring radius for subdivision
  * @param ringify_type The method to use for selection of maximum ring radius
  */
-void Geometry::setRingifyType(ringifyType ringify_type)
-{
+void Geometry::setRingifyType(ringifyType ringify_type) {
   _ringify_type = ringify_type;
 }
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -765,9 +765,11 @@ std::string Geometry::getFSRKey(LocalCoords* coords) {
  */
 void Geometry::subdivideCells() {
 
-  /* Compute equivalent radius with the same area as the Geometry */
+  double x_rad = getWidthX()/2.0;
+  double y_rad = getWidthY()/2.0;
+
   /* This is used as the maximum radius for all ringified Cells */
-  double max_radius = sqrt(getWidthX() * getWidthY() / M_PI);
+  double max_radius = sqrt(x_rad*x_rad + y_rad*y_rad);
 
   /* Recursively subdivide Cells into rings and sectors */
   _root_universe->subdivideCells(max_radius);

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -20,6 +20,9 @@ Geometry::Geometry() {
 
   /* Initialize CMFD object to NULL */
   _cmfd = NULL;
+
+  /* Default value for ringify type */
+  _ringify_type = EQUIVALENT_AREA;
 }
 
 
@@ -765,11 +768,16 @@ std::string Geometry::getFSRKey(LocalCoords* coords) {
  */
 void Geometry::subdivideCells() {
 
-  double x_rad = getWidthX()/2.0;
-  double y_rad = getWidthY()/2.0;
+  double max_radius = 0;
 
-  /* This is used as the maximum radius for all ringified Cells */
-  double max_radius = sqrt(x_rad*x_rad + y_rad*y_rad);
+  if (_ringify_type == EQUIVALENT_AREA)
+    max_radius = sqrt(getWidthX() * getWidthY() / M_PI);
+  else {
+    double x_rad = getWidthX()/2.0;
+    double y_rad = getWidthY()/2.0;
+
+    max_radius = sqrt(x_rad*x_rad + y_rad*y_rad);
+  }
 
   /* Recursively subdivide Cells into rings and sectors */
   _root_universe->subdivideCells(max_radius);
@@ -1149,6 +1157,16 @@ void Geometry::setFSRKeysMap(ParallelHashMap<std::string, fsr_data*>*
  */
 void Geometry::setFSRsToKeys(std::vector<std::string>* FSRs_to_keys) {
   _FSRs_to_keys = *FSRs_to_keys;
+}
+
+
+/**
+ * @brief Sets the method for selection of the maximum ring radius for subdivision
+ * @param ringify_type The method to use for selection of maximum ring radius
+ */
+void Geometry::setRingifyType(ringifyType ringify_type)
+{
+  _ringify_type = ringify_type;
 }
 
 

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -13,6 +13,7 @@
 #include "Python.h"
 #endif
 #include "Cmfd.h"
+#include "ringify_type.h"
 #include <limits>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -25,19 +26,6 @@
 
 /** Forward declaration of Cmfd class */
 class Cmfd;
-
-/**
- * @enum ringifyType
- * @brief The method to use when subdividing cells into rings
- */
-enum ringifyType{
-
-  /** Max ring radius chosen such that it has the same area as the total geometry */
-  EQUIVALENT_AREA,
-
-  /** Max ring radius chosen to be the distance from the center to a corner of the geometry */
-  MAX_DISTANCE
-};
 
 /**
  * @struct fsr_data

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -27,6 +27,19 @@
 class Cmfd;
 
 /**
+ * @enum ringifyType
+ * @brief The method to use when subdividing cells into rings
+ */
+enum ringifyType{
+
+  /** Max ring radius chosen such that it has the same area as the total geometry */
+  EQUIVALENT_AREA,
+
+  /** Max ring radius chosen to be the distance from the center to a corner of the geometry */
+  MAX_DISTANCE
+};
+
+/**
  * @struct fsr_data
  * @brief A fsr_data struct represents an FSR with a unique FSR ID
  *        and a characteristic point that lies within the FSR that
@@ -104,6 +117,9 @@ private:
   /** An vector of FSR key hashes indexed by FSR ID */
   std::vector<std::string> _FSRs_to_keys;
 
+  /** The method to use when subdividing cells into rings */
+  ringifyType _ringify_type;
+
   /* The Universe at the root node in the CSG tree */
   Universe* _root_universe;
 
@@ -160,6 +176,7 @@ public:
   void setCmfd(Cmfd* cmfd);
   void setFSRCentroid(int fsr, Point* centroid);
   void setFSRKeysMap(ParallelHashMap<std::string, fsr_data*>* FSR_keys_map);
+  void setRingifyType(ringifyType ringify_type);
 
   /* Find methods */
   Cell* findCellContainingCoords(LocalCoords* coords);

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -15,6 +15,7 @@
 #include "constants.h"
 #include "LocalCoords.h"
 #include "boundary_type.h"
+#include "ringify_type.h"
 #include <limits>
 #include <map>
 #include <vector>
@@ -28,7 +29,6 @@ class Surface;
 class Material;
 struct surface_halfspace;
 
-
 int universe_id();
 void reset_universe_id();
 void maximize_universe_id(int universe_id);
@@ -38,7 +38,7 @@ void maximize_universe_id(int universe_id);
  * @enum universeType
  * @brief The type of universe
  */
-enum universeType{
+enum universeType {
 
   /** A simple non-repeating Universe */
   SIMPLE,
@@ -116,7 +116,7 @@ public:
 
   Cell* findCell(LocalCoords* coords);
   void setFissionability(bool fissionable);
-  void subdivideCells(double max_radius=INFINITY);
+  void subdivideCells(double max_radius=INFINITY, ringifyType ringify_type=EQUIVALENT_AREA);
   void buildNeighbors();
 
   virtual std::string toString();
@@ -193,7 +193,7 @@ public:
                 double width_z=std::numeric_limits<double>::infinity());
   void setUniverses(int num_z, int num_y, int num_x, Universe** universes);
   void removeUniverse(Universe* universe);
-  void subdivideCells(double max_radius=INFINITY);
+  void subdivideCells(double max_radius=INFINITY, ringifyType ringify_type=EQUIVALENT_AREA);
   void buildNeighbors();
 
   bool withinBounds(Point* point);

--- a/src/ringify_type.h
+++ b/src/ringify_type.h
@@ -1,0 +1,25 @@
+/**
+ * @file ringify_type.h
+ * @details The ringifyType enum.
+ * @date February 16, 2016
+ * @author Derek Gaston, MIT, Course 22 (gastdr@mit.edu)
+ */
+
+#ifndef RINGIFY_TYPE_H_
+#define RINGIFY_TYPE_H_
+
+/**
+ * @enum ringifyType
+ * @brief The method to use when subdividing cells into rings
+ */
+enum ringifyType {
+  /** Max ring radius chosen such that it has the same area as the
+   * bounding box of the universe it lies in */
+  EQUIVALENT_AREA,
+
+  /** Max ring radius chosen to be the distance from the center to
+   * a corner of the bounding box for the universe it lies in */
+  MAX_DISTANCE
+};
+
+#endif /* RINGIFY_TYPE_H_ */


### PR DESCRIPTION
When using rings to subdivide the moderator the rings won't reach all the way to the outer corners like so:

![pasted image at 2016_02_15 07_07 pm](https://cloud.githubusercontent.com/assets/870705/13082935/c6e3ba66-d4a0-11e5-8dc4-dd3f448985ee.png)

I've modified the selection of the maximum ring radius to allow for reaching the corners like so:

![flat-source-regions-z-0 0](https://cloud.githubusercontent.com/assets/870705/13083030/4217184a-d4a1-11e5-9bb1-0eb2e343702a.png)
