### PR TITLE
[Hotfix] Parallel Hash Map Concurrency

### DIFF
--- a/profile/Makefile
+++ b/profile/Makefile
@@ -5,7 +5,7 @@
 COMPILER    = gnu
 OPENMP      = yes
 OPTIMIZE    = yes
-DEBUG       = no
+DEBUG       = yes
 PROFILE     = no
 PRECISION   = single
 
@@ -13,7 +13,7 @@ PRECISION   = single
 # Source Code List
 #===============================================================================
 
-case = c5g7/c5g7-cmfd.cpp
+case = LRA/lra-cmfd.cpp
 
 source = \
 Cell.cpp \
@@ -41,7 +41,8 @@ gradients/one-directional/one-directional-gradient.cpp \
 gradients/two-directional/two-directional-gradient.cpp \
 homogeneous/homogeneous-one-group.cpp \
 c5g7/c5g7.cpp \
-c5g7/c5g7-cmfd.cpp
+c5g7/c5g7-cmfd.cpp \
+LRA/lra-cmfd.cpp
 
 #===============================================================================
 # Sets Flags

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -5,7 +5,7 @@
 COMPILER    = gnu
 OPENMP      = yes
 OPTIMIZE    = yes
-DEBUG       = yes
+DEBUG       = no
 PROFILE     = no
 PRECISION   = single
 
@@ -13,7 +13,7 @@ PRECISION   = single
 # Source Code List
 #===============================================================================
 
-case = LRA/lra-cmfd.cpp
+case = c5g7/c5g7-cmfd.cpp
 
 source = \
 Cell.cpp \
@@ -41,8 +41,7 @@ gradients/one-directional/one-directional-gradient.cpp \
 gradients/two-directional/two-directional-gradient.cpp \
 homogeneous/homogeneous-one-group.cpp \
 c5g7/c5g7.cpp \
-c5g7/c5g7-cmfd.cpp \
-LRA/lra-cmfd.cpp
+c5g7/c5g7-cmfd.cpp
 
 #===============================================================================
 # Sets Flags

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -585,7 +585,7 @@ int Geometry::findFSRId(LocalCoords* coords) {
       /* Add FSR information to FSR key map and FSR_to vectors */
       fsr_data* fsr = new fsr_data;
       fsr->_fsr_id = fsr_id;
-      _FSR_keys_map.at(fsr_key) = fsr;
+      _FSR_keys_map.update(fsr_key, fsr);
       Point* point = new Point();
       point->setCoords(coords->getHighestLevel()->getX(),
                        coords->getHighestLevel()->getY(),

--- a/src/ParallelHashMap.h
+++ b/src/ParallelHashMap.h
@@ -84,7 +84,7 @@ class ParallelHashMap {
     volatile long pad_L5;
     volatile long pad_L7;
     volatile long pad_L8;
-    FixedHashMap<K,V>* volatile value;
+    FixedHashMap<K,V> volatile* value;
     volatile long pad_R1;
     volatile long pad_R2;
     volatile long pad_R3;

--- a/src/ParallelHashMap.h
+++ b/src/ParallelHashMap.h
@@ -296,7 +296,7 @@ int FixedHashMap<K,V>::insert_and_get_count(K key, V value) {
   /* increment counter and return number */
   size_t N;
 #pragma omp critical (node_incr)
-      N = _N++;
+    N = _N++;
 
   return (int) N;
 }
@@ -414,11 +414,12 @@ void FixedHashMap<K,V>::clear() {
  */
 template <class K, class V>
 void FixedHashMap<K,V>::print_buckets() {
+  log_printf(NORMAL, "Printing all buckets in the hash map...");
   for (size_t i=0; i<_M; i++) {
     if (_buckets[i] == NULL)
-      log_printf(NORMAL, "%d -> NULL", i);
+      log_printf(NORMAL, "Bucket %d -> NULL", i);
     else
-      log_printf(NORMAL, "%d -> %p", i, _buckets[i]);
+      log_printf(NORMAL, "Bucket %d -> %p", i, _buckets[i]);
   }
 }
 

--- a/src/ParallelHashMap.h
+++ b/src/ParallelHashMap.h
@@ -845,4 +845,4 @@ void ParallelHashMap<K,V>::print_buckets() {
   _announce[tid].value = NULL;
 }
 
-
+#endif

--- a/src/ParallelHashMap.h
+++ b/src/ParallelHashMap.h
@@ -17,6 +17,7 @@
 #include<omp.h>
 #endif
 
+
 /**
  * @class FixedHashMap ParallelHashMap.h "src/ParallelHashMap.h"
  * @brief A fixed-size hash map supporting insertion and lookup operations
@@ -29,11 +30,9 @@
  *    class. This table guarantees O(1) insertions and lookups on average.
  */
 template <class K, class V>
-class FixedHashMap
-{
-  struct node
-  {
-    node(K k_in, V v_in) : next(NULL), key(k_in), value(v_in){}
+class FixedHashMap {
+  struct node {
+    node(K k_in, V v_in) : next(NULL), key(k_in), value(v_in) {}
     K key;
     V value;
     node *next;
@@ -60,6 +59,7 @@ class FixedHashMap
     void print_buckets();
 };
 
+
 /**
  * @class ParallelHashMap ParallelHashMap.h "src/ParallelHashMap.h"
  * @brief A thread-safe hash map supporting insertion and lookup operations
@@ -73,11 +73,10 @@ class FixedHashMap
  *    chosen to limit the number of resizing operations.
  */
 template <class K, class V>
-class ParallelHashMap
-{
+class ParallelHashMap {
+
   /* padded pointer to hash table to avoid false sharing */
-  struct paddedPointer
-  {
+  struct paddedPointer {
     volatile long pad_L1;
     volatile long pad_L2;
     volatile long pad_L3;
@@ -95,15 +94,16 @@ class ParallelHashMap
     volatile long pad_R7;
     volatile long pad_R8;
   };
+
   private:
     FixedHashMap<K,V> *_table;
     paddedPointer *_announce;
     size_t _num_threads;
     size_t _N;
-    #ifdef OPENMP
+#ifdef OPENMP
     omp_lock_t * _locks;
     size_t _num_locks;
-    #endif
+#endif
     void resize();
 
   public:
@@ -123,6 +123,7 @@ class ParallelHashMap
     void print_buckets();
 };
 
+
 /**
  * @brief Constructor initializes fixed-size table of buckets filled with empty
  *      linked lists.
@@ -133,11 +134,10 @@ class ParallelHashMap
  * @param M size of fixed hash map
  */
 template <class K, class V>
-FixedHashMap<K,V>::FixedHashMap(size_t M)
-{
+FixedHashMap<K,V>::FixedHashMap(size_t M) {
+
   /* ensure M is a power of 2 */
-  if ((M & (M-1)) != 0)
-  {
+  if ((M & (M-1)) != 0) {
     /* if not, round up to nearest power of 2 */
     M--;
     for (size_t i = 1; i < 8 * sizeof(size_t); i*=2)
@@ -151,19 +151,17 @@ FixedHashMap<K,V>::FixedHashMap(size_t M)
   _buckets = new node*[_M]();
 }
 
+
 /**
  * @brief Destructor deletes all nodes in the linked lists associated with each
  *      bucket in the fixed-size table and their pointers.
  */
 template <class K, class V>
-FixedHashMap<K,V>::~FixedHashMap()
-{
+FixedHashMap<K,V>::~FixedHashMap() {
   /* for each bucket, scan through linked list and delete all nodes */
-  for (size_t i=0; i<_M; i++)
-  {
+  for (size_t i=0; i<_M; i++) {
     node *iter_node = _buckets[i];
-    while (iter_node != NULL)
-    {
+    while (iter_node != NULL) {
       node *next_node = iter_node->next;
       delete iter_node;
       iter_node = next_node;
@@ -171,8 +169,9 @@ FixedHashMap<K,V>::~FixedHashMap()
   }
 
   /* delete all buckets (now pointers to empty linked lists) */
-  delete[] _buckets;
+  delete [] _buckets;
 }
+
 
 /**
  * @brief Determine whether the fixed-size table contains a given key
@@ -182,15 +181,14 @@ FixedHashMap<K,V>::~FixedHashMap()
  * @return boolean value referring to whether the key is contained in the map
  */
 template <class K, class V>
-bool FixedHashMap<K,V>::contains(K key)
-{
+bool FixedHashMap<K,V>::contains(K key) {
+
   /* get hash into table assuming M is a power of 2, using fast modulus */
   size_t key_hash = std::hash<K>()(key) & (_M-1);
 
   /* search corresponding bucket for key */
   node *iter_node = _buckets[key_hash];
-  while (iter_node != NULL)
-  {
+  while (iter_node != NULL) {
     if (iter_node->key == key)
       return true;
     else
@@ -198,6 +196,7 @@ bool FixedHashMap<K,V>::contains(K key)
   }
   return false;
 }
+
 
 /**
  * @brief Determine the value associated with a given key in the fixed-size
@@ -209,8 +208,8 @@ bool FixedHashMap<K,V>::contains(K key)
  * @return value associated with the given key
  */
 template <class K, class V>
-V& FixedHashMap<K,V>::at(K key)
-{
+V& FixedHashMap<K,V>::at(K key) {
+
   /* get hash into table assuming M is a power of 2, using fast modulus */
   size_t key_hash = std::hash<K>()(key) & (_M-1);
 
@@ -237,8 +236,8 @@ V& FixedHashMap<K,V>::at(K key)
  * @param value value of the key/value pair to be inserted
  */
 template <class K, class V>
-void FixedHashMap<K,V>::insert(K key, V value)
-{
+void FixedHashMap<K,V>::insert(K key, V value) {
+
   /* get hash into table using fast modulus */
   size_t key_hash = std::hash<K>()(key) & (_M-1);
 
@@ -262,6 +261,7 @@ void FixedHashMap<K,V>::insert(K key, V value)
   _N++;
 }
 
+
 /**
  * @brief Inserts a key/value pair into the fixed-size table and returns the
  *      order number with which it was inserted.
@@ -274,8 +274,8 @@ void FixedHashMap<K,V>::insert(K key, V value)
  *      key was already present in map.
  */
 template <class K, class V>
-int FixedHashMap<K,V>::insert_and_get_count(K key, V value)
-{
+int FixedHashMap<K,V>::insert_and_get_count(K key, V value) {
+
   /* get hash into table using fast modulus */
   size_t key_hash = std::hash<K>()(key) & (_M-1);
 
@@ -304,25 +304,26 @@ int FixedHashMap<K,V>::insert_and_get_count(K key, V value)
   return (int) N;
 }
 
+
 /**
  * @brief Returns the number of key/value pairs in the fixed-size table
  * @return number of key/value pairs in the map
  */
 template <class K, class V>
-size_t FixedHashMap<K,V>::size()
-{
+size_t FixedHashMap<K,V>::size() {
   return _N;
 }
+
 
 /**
  * @brief Returns the number of buckets in the fixed-size table
  * @return number of buckets in the map
  */
 template <class K, class V>
-size_t FixedHashMap<K,V>::bucket_count()
-{
+size_t FixedHashMap<K,V>::bucket_count() {
   return _M;
 }
+
 
 /**
  * @brief Returns an array of the keys in the fixed-size table
@@ -334,18 +335,16 @@ size_t FixedHashMap<K,V>::bucket_count()
  *      pairs in the table.
 */
 template <class K, class V>
-K* FixedHashMap<K,V>::keys()
-{
+K* FixedHashMap<K,V>::keys() {
+
   /* allocate array of keys */
   K *key_list = new K[_N];
 
   /* fill array with keys */
   size_t ind = 0;
-  for (size_t i=0; i<_M; i++)
-  {
+  for (size_t i=0; i<_M; i++) {
     node *iter_node = _buckets[i];
-    while (iter_node != NULL)
-    {
+    while (iter_node != NULL) {
       key_list[ind] = iter_node->key;
       iter_node = iter_node->next;
       ind++;
@@ -353,6 +352,7 @@ K* FixedHashMap<K,V>::keys()
   }
   return key_list;
 }
+
 
 /**
  * @brief Returns an array of the values in the fixed-size table
@@ -364,8 +364,8 @@ K* FixedHashMap<K,V>::keys()
  *      key/value pairs in the table.
 */
 template <class K, class V>
-V* FixedHashMap<K,V>::values()
-{
+V* FixedHashMap<K,V>::values() {
+
   /* allocate array of values */
   V *values = new V[_N];
 
@@ -384,18 +384,17 @@ V* FixedHashMap<K,V>::values()
   return values;
 }
 
+
 /**
  * @brief Clears all key/value pairs form the hash table.
  */
 template <class K, class V>
-void FixedHashMap<K,V>::clear()
-{
+void FixedHashMap<K,V>::clear() {
+
   /* for each bucket, scan through linked list and delete all nodes */
-  for (size_t i=0; i<_M; i++)
-  {
+  for (size_t i=0; i<_M; i++) {
     node *iter_node = _buckets[i];
-    while (iter_node != NULL)
-    {
+    while (iter_node != NULL) {
       node *next_node = iter_node->next;
       delete iter_node;
       iter_node = next_node;
@@ -410,6 +409,7 @@ void FixedHashMap<K,V>::clear()
   _N = 0;
 }
 
+
 /**
  * @brief Prints the contents of each bucket to the screen
  * @details All buckets are scanned and the contents of the buckets are
@@ -418,10 +418,8 @@ void FixedHashMap<K,V>::clear()
  *      screen.
  */
 template <class K, class V>
-void FixedHashMap<K,V>::print_buckets()
-{
-  for (size_t i=0; i<_M; i++)
-  {
+void FixedHashMap<K,V>::print_buckets() {
+  for (size_t i=0; i<_M; i++) {
     if (_buckets[i] == NULL)
       std::cout << i << " -> NULL" << std::endl;
     else
@@ -429,41 +427,42 @@ void FixedHashMap<K,V>::print_buckets()
   }
 }
 
+
 /**
  * @brief Constructor generates initial underlying table as a fixed-sized
  *      hash map and intializes concurrency structures.
  */
 template <class K, class V>
-ParallelHashMap<K,V>::ParallelHashMap(size_t M, size_t L)
-{
+ParallelHashMap<K,V>::ParallelHashMap(size_t M, size_t L) {
+
   /* allocate table */
   _table = new FixedHashMap<K,V>(M);
 
   /* get number of threads and create concurrency structures */
   _num_threads = 1;
-  #ifdef OPENMP
+#ifdef OPENMP
   _num_threads = omp_get_max_threads();
   _num_locks = L;
   _locks = new omp_lock_t[_num_locks];
   for (size_t i=0; i<_num_locks; i++)
     omp_init_lock(&_locks[i]);
-  #endif
+#endif
 
   _announce = new paddedPointer[_num_threads];
 }
+
 
 /**
  * @brief Destructor frees memory associated with fixed-sized hash map and
  *      concurrency structures.
  */
 template <class K, class V>
-ParallelHashMap<K,V>::~ParallelHashMap()
-{
+ParallelHashMap<K,V>::~ParallelHashMap() {
   delete _table;
-  #ifdef OPENMP
-  delete[] _locks;
-  #endif
-  delete[] _announce;
+#ifdef OPENMP
+  delete [] _locks;
+#endif
+  delete [] _announce;
 }
 
 
@@ -480,18 +479,18 @@ ParallelHashMap<K,V>::~ParallelHashMap()
  * @return boolean value referring to whether the key is contained in the map
  */
 template <class K, class V>
-bool ParallelHashMap<K,V>::contains(K key)
-{
+bool ParallelHashMap<K,V>::contains(K key) {
+
   /* get thread ID */
   size_t tid = 0;
-  #ifdef OPENMP
+#ifdef OPENMP
   tid = omp_get_thread_num();
-  #endif
+#endif
 
   /* get pointer to table, announce it will be searched,
      and ensure consistency */
   FixedHashMap<K,V> *table_ptr;
-  do{
+  do {
     table_ptr = _table;
     _announce[tid].value = table_ptr;
 #pragma omp flush(_announce)
@@ -506,33 +505,30 @@ bool ParallelHashMap<K,V>::contains(K key)
   return present;
 }
 
+
 /**
  * @brief Determine the value associated with a given key.
  * @details This function follows the same algorithm as <contains> except that
  *      the value associated with the searched key is returned.
- *      First the thread accessing the table announces its presence and
- *      which table it is reading. Then the linked list in the bucket
- *      associated with the key is searched without setting any locks
- *      to determine the associated value. An exception is thrown if the
+ *      First the thread accessing the table acquires the lock corresponding
+ *      with the associated bucket based on the key. Then the linked list
+ *      in the bucket is searched for the key. An exception is thrown if the
  *      key is not found. When the thread has finished accessing the table,
- *      the announcement is reset to NULL. The announcement ensures that
- *      the data in the map is not freed during a resize until all threads
- *      have finished accessing the map.
+ *      it releases the lock.
  * @param key key to be searched
  * @return value associated with the key
  */
 template <class K, class V>
-V ParallelHashMap<K,V>::at(K key)
-{
+V ParallelHashMap<K,V>::at(K key) {
   /* get thread ID */
   size_t tid = 0;
-  #ifdef OPENMP
+#ifdef OPENMP
   tid = omp_get_thread_num();
-  #endif
+#endif
 
   /* get pointer to table, announce it will be searched */
   FixedHashMap<K,V> *table_ptr;
-  do{
+  do {
     table_ptr = _table;
     _announce[tid].value = table_ptr;
 #pragma omp flush(_announce)
@@ -547,6 +543,7 @@ V ParallelHashMap<K,V>::at(K key)
   return value;
 }
 
+
 /**
  * @brief Insert a given key/value pair into the parallel hash map.
  * @details First the underlying table is checked to determine if a resize
@@ -558,8 +555,7 @@ V ParallelHashMap<K,V>::at(K key)
  * @param value value of the key/value pair to be inserted
  */
 template <class K, class V>
-void ParallelHashMap<K,V>::insert(K key, V value)
-{
+void ParallelHashMap<K,V>::insert(K key, V value) {
   /* check if resize needed */
   if (2*_table->size() > _table->bucket_count())
     resize();
@@ -569,53 +565,52 @@ void ParallelHashMap<K,V>::insert(K key, V value)
     return;
 
   /* get lock hash */
-  #ifdef OPENMP
+#ifdef OPENMP
   size_t lock_hash = (std::hash<K>()(key) & (_table->bucket_count() - 1))
     % _num_locks;
 
   /* acquire lock */
   omp_set_lock(&_locks[lock_hash]);
-  #endif
+#endif
 
   /* insert value */
   _table->insert(key, value);
 
   /* release lock */
-  #ifdef OPENMP
+#ifdef OPENMP
   omp_unset_lock(&_locks[lock_hash]);
-  #endif
+#endif
 }
 
 
 /**
- * @brief Insert a given key/value pair into the parallel hash map.
- * @details First the underlying table is checked to determine if a resize
- *      should be conducted. Then, the table is checked to see if it
- *      already contains the key. If so, the key/value pair is not inserted
- *      and the function returns. Otherwise, the lock of the associated
- *      bucket is acquired and the key/value pair is added to the bucket.
- * @param key key of the key/value pair to be inserted
- * @param value value of the key/value pair to be inserted
+ * @brief Updates the value associated with a key in the parallel hash map.
+ * @details The thread first acquires the lock for the bucket associated with
+ *      the key is acquired, then the linked list in the bucket is searched
+ *      for the key. If the key is not found, an exception is returned. When
+ *      the key is found, the value is updated and the lock is released.
+ * @param key the key of the key/value pair to be updated
+ * @param value the new value for the key/value pair
  */
 template <class K, class V>
-void ParallelHashMap<K,V>::update(K key, V value)
-{
+void ParallelHashMap<K,V>::update(K key, V value) {
+
   /* get lock hash */
-  #ifdef OPENMP
+#ifdef OPENMP
   size_t lock_hash = (std::hash<K>()(key) & (_table->bucket_count() - 1))
     % _num_locks;
 
   /* acquire lock */
   omp_set_lock(&_locks[lock_hash]);
-  #endif
+#endif
 
   /* insert value */
   _table->at(key) = value;
 
   /* release lock */
-  #ifdef OPENMP
+#ifdef OPENMP
   omp_unset_lock(&_locks[lock_hash]);
-  #endif
+#endif
 }
 
 
@@ -633,8 +628,8 @@ void ParallelHashMap<K,V>::update(K key, V value)
  *      already exists
  */
 template <class K, class V>
-int ParallelHashMap<K,V>::insert_and_get_count(K key, V value)
-{
+int ParallelHashMap<K,V>::insert_and_get_count(K key, V value) {
+
   /* check if resize needed */
   if (2*_table->size() > _table->bucket_count())
     resize();
@@ -644,24 +639,26 @@ int ParallelHashMap<K,V>::insert_and_get_count(K key, V value)
     return -1;
 
   /* get lock hash */
-  #ifdef OPENMP
+#ifdef OPENMP
   size_t lock_hash = (std::hash<K>()(key) & (_table->bucket_count() - 1))
     % _num_locks;
 
   /* acquire lock */
   omp_set_lock(&_locks[lock_hash]);
-  #endif
+#endif
 
   /* insert value */
   int N =_table->insert_and_get_count(key, value);
 
   /* release lock */
-  #ifdef OPENMP
+#ifdef OPENMP
   omp_unset_lock(&_locks[lock_hash]);
-  #endif
+#endif
 
   return N;
 }
+
+
 /**
  * @brief Resizes the underlying table to twice its current capacity.
  * @details In a thread-safe manner, this procedure resizes the underlying
@@ -675,22 +672,22 @@ int ParallelHashMap<K,V>::insert_and_get_count(K key, V value)
  *    to be free of references to the old table before freeing the memory.
  */
 template <class K, class V>
-void ParallelHashMap<K,V>::resize()
-{
+void ParallelHashMap<K,V>::resize() {
+
   /* acquire all locks in order */
-  #ifdef OPENMP
+#ifdef OPENMP
   for (size_t i=0; i<_num_locks; i++)
     omp_set_lock(&_locks[i]);
-  #endif
+#endif
 
   /* recheck if resize needed */
   if (2*_table->size() < _table->bucket_count())
   {
     /* release locks */
-    #ifdef OPENMP
+#ifdef OPENMP
     for (size_t i=0; i<_num_locks; i++)
       omp_unset_lock(&_locks[i]);
-    #endif
+#endif
 
     return;
   }
@@ -715,14 +712,14 @@ void ParallelHashMap<K,V>::resize()
 #pragma omp flush(_table)
 
   /* release all locks */
-  #ifdef OPENMP
+#ifdef OPENMP
   for (size_t i=0; i<_num_locks; i++)
     omp_unset_lock(&_locks[i]);
-  #endif
+#endif
 
   /* delete key and value list */
-  delete[] key_list;
-  delete[] value_list;
+  delete [] key_list;
+  delete [] value_list;
 
   /* wait for all threads to stop reading from the old table */
   for (size_t i=0; i<_num_threads; i++)
@@ -732,35 +729,36 @@ void ParallelHashMap<K,V>::resize()
   delete old_table;
 }
 
+
 /**
  * @brief Returns the number of key/value pairs in the underlying table
  * @return number of key/value pairs in the map
  */
 template <class K, class V>
-size_t ParallelHashMap<K,V>::size()
-{
+size_t ParallelHashMap<K,V>::size() {
   return _table->size();
 }
+
 
 /**
  * @brief Returns the number of buckets in the underlying table
  * @return number of buckets in the map
  */
 template <class K, class V>
-size_t ParallelHashMap<K,V>::bucket_count()
-{
+size_t ParallelHashMap<K,V>::bucket_count() {
   return _table->bucket_count();
 }
+
 
 /**
  * @brief Returns the number of locks in the parallel hash map
  * @return number of locks in the map
  */
 template <class K, class V>
-size_t ParallelHashMap<K,V>::num_locks()
-{
+size_t ParallelHashMap<K,V>::num_locks() {
   return _num_locks;
 }
+
 
 /**
  * @brief Returns an array of the keys in the underlying table
@@ -773,17 +771,17 @@ size_t ParallelHashMap<K,V>::num_locks()
  *      pairs in the table.
  */
 template <class K, class V>
-K* ParallelHashMap<K,V>::keys()
-{
+K* ParallelHashMap<K,V>::keys() {
+
   /* get thread ID */
   size_t tid = 0;
-  #ifdef OPENMP
+#ifdef OPENMP
   tid = omp_get_thread_num();
-  #endif
+#endif
 
   /* get pointer to table, announce it will be searched */
   FixedHashMap<K,V> *table_ptr;
-  do{
+  do {
     table_ptr = _table;
     _announce[tid].value = table_ptr;
 #pragma omp flush(_announce)
@@ -798,6 +796,7 @@ K* ParallelHashMap<K,V>::keys()
   return key_list;
 }
 
+
 /**
  * @brief Returns an array of the values in the underlying table
  * @details All buckets are scanned in order to form a list of all values
@@ -809,17 +808,17 @@ K* ParallelHashMap<K,V>::keys()
  *      pairs in the table.
  */
 template <class K, class V>
-V* ParallelHashMap<K,V>::values()
-{
+V* ParallelHashMap<K,V>::values() {
+
   /* get thread ID */
   size_t tid = 0;
-  #ifdef OPENMP
+#ifdef OPENMP
   tid = omp_get_thread_num();
-  #endif
+#endif
 
   /* get pointer to table, announce it will be searched */
   FixedHashMap<K,V> *table_ptr;
-  do{
+  do {
     table_ptr = _table;
     _announce[tid].value = table_ptr;
 #pragma omp flush(_announce)
@@ -834,21 +833,23 @@ V* ParallelHashMap<K,V>::values()
   return value_list;
 }
 
+
 /**
  * @brief Clears all key/value pairs form the hash table.
  */
 template <class K, class V>
-void ParallelHashMap<K,V>::clear()
-{
+void ParallelHashMap<K,V>::clear() {
+
   /* acquire all locks in order */
-  #ifdef OPENMP
+#ifdef OPENMP
   for (size_t i=0; i<_num_locks; i++)
     omp_set_lock(&_locks[i]);
-  #endif
+#endif
 
   /* clear underlying fixed table */
   _table->clear();
 }
+
 
 /**
  * @brief Prints the contents of each bucket to the screen
@@ -859,17 +860,17 @@ void ParallelHashMap<K,V>::clear()
  *      not freed during access.
  */
 template <class K, class V>
-void ParallelHashMap<K,V>::print_buckets()
-{
+void ParallelHashMap<K,V>::print_buckets() {
+
   /* get thread ID */
   size_t tid = 0;
-  #ifdef OPENMP
+#ifdef OPENMP
   tid = omp_get_thread_num();
-  #endif
+#endif
 
   /* get pointer to table, announce it will be searched */
   FixedHashMap<K,V> *table_ptr;
-  do{
+  do {
     table_ptr = _table;
     _announce[tid].value = table_ptr;
 #pragma omp flush(_announce)


### PR DESCRIPTION
As noted in #265, the current ``ParallelHashMap`` has the potential to seg fault. This is because the write buffer for each core doesn't necessarily get flushed immediately after a write. This isn't generally a problem, except the lock-free contains function needs to announce its presence to other threads. If this announcement gets stuck in a write buffer without getting flushed, then there is the potential during a resize for the table which the contains thread is looking at to be deleted by a thread attempting a resize. In order to fix this, ``#pragma omp flush`` directives are added after announcements to force the thread to wait for the write buffer to flush before proceeding. 

In addition, there is another error in the parallel hash map. Right now,the ``at(K key)`` function of ``ParallelHashMap`` returns a reference to the value associated with the ``key``. This allows for assignment of a new value to the key/value pair. However, this is fundamentally flawed since even a thread-safe parallel hash map will not be able to produce thread safe behavior in this case since the act of returning a reference to a value and assigning a new value are two distinct operations, thus there are no correction safeguards for this behavior as it occurs outside of ``ParallelHashMap``. Therefore the ``at(K key)`` function of ``ParallelHashMap`` is changed so that it only returns the value, not a reference. This will cause an error to be thrown any time an update to the value is attempted using ``at(K key)``. To allow values to be updated the ``update(K key, V value)`` function is added so that updates can take place completely inside the ``ParallelHashMap`` where correctness over multiple threads is ensured. This new ``update(K key, V value)`` ensures correctness by acquiring the lock associated with the ``key`` before updating the underlying hash table using ``FixedHashMap::at(K key)``.