### PR TITLE
Standalone FSR Centroid Initialization

### DIFF
--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -596,7 +596,7 @@ void Solver::initializeFSRs() {
   _FSR_volumes = _track_generator->getFSRVolumes();
 
   /* Generate the FSR centroids */
-  _track_generator->generateFSRCentroids(_FSR_volumes);
+  _track_generator->generateFSRCentroids();
 
   /* Attach the correct materials to each track segment */
   _track_generator->initializeSegments();

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1760,11 +1760,11 @@ void TrackGenerator::correctFSRVolume(int fsr_id, FP_PRECISION fsr_volume) {
  *          FSR by the segment's length and azimuthal weight. The numerical
  *          centroid fomula can be found in R. Ferrer et. al. "Linear Source
  *          Approximation in CASMO 5", PHYSOR 2012.
- * @param FSR_volumes An array of FSR volumes.
  */
-void TrackGenerator::generateFSRCentroids(FP_PRECISION* FSR_volumes) {
+void TrackGenerator::generateFSRCentroids() {
 
   int num_FSRs = _geometry->getNumFSRs();
+  FP_PRECISION* FSR_volumes = getFSRVolumes();
 
   /* Create array of centroids and initialize to origin */
   Point** centroids = new Point*[num_FSRs];
@@ -1808,6 +1808,7 @@ void TrackGenerator::generateFSRCentroids(FP_PRECISION* FSR_volumes) {
 
   /* Delete temporary array of FSR volumes and centroids */
   delete [] centroids;
+  delete [] FSR_volumes;
 }
 
 

--- a/src/TrackGenerator.h
+++ b/src/TrackGenerator.h
@@ -141,7 +141,7 @@ public:
   void retrieveSegmentCoords(double* coords, int num_segments);
   void generateTracks(bool neighbor_cells=false);
   void correctFSRVolume(int fsr_id, FP_PRECISION fsr_volume);
-  void generateFSRCentroids(FP_PRECISION* FSR_volumes);
+  void generateFSRCentroids();
   void splitSegments(FP_PRECISION max_optical_length);
   void initializeSegments();
 };


### PR DESCRIPTION
This short PR refactors `TrackGenerator::generateFSRCentroids()` to allow it to be called from Python. I've found this method to be useful if one wishes to query the centroids without actually running a calculation with a `Solver` object.