### PR TITLE
Fixed lingering bug with setting the FSR Keys Map after reading in tracks

### DIFF
--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -919,8 +919,7 @@ void Geometry::initializeFSRVectors() {
 
   /* fill vectors key and material ID information */
 #pragma omp parallel for
-  for (int i=0; i < num_FSRs; i++)
-  {
+  for (int i=0; i < num_FSRs; i++) {
     std::string key = key_list[i];
     fsr_data* fsr = value_list[i];
     int fsr_id = fsr->_fsr_id;
@@ -1113,8 +1112,8 @@ void Geometry::initializeCmfd() {
  * @brief Returns a pointer to the map that maps FSR keys to FSR IDs
  * @return pointer to _FSR_keys_map map of FSR keys to FSR IDs
  */
-ParallelHashMap<std::string, fsr_data*>* Geometry::getFSRKeysMap() {
-  return &_FSR_keys_map;
+ParallelHashMap<std::string, fsr_data*> & Geometry::getFSRKeysMap() {
+  return _FSR_keys_map;
 }
 
 
@@ -1122,8 +1121,8 @@ ParallelHashMap<std::string, fsr_data*>* Geometry::getFSRKeysMap() {
  * @brief Returns the vector that maps FSR IDs to FSR key hashes
  * @return _FSR_keys_map map of FSR keys to FSR IDs
  */
-std::vector<std::string>* Geometry::getFSRsToKeys() {
-  return &_FSRs_to_keys;
+std::vector<std::string> & Geometry::getFSRsToKeys() {
+  return _FSRs_to_keys;
 }
 
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1127,31 +1127,6 @@ std::vector<std::string> & Geometry::getFSRsToKeys() {
 
 
 /**
- * @brief Sets the _FSR_keys_map map
- * @details The _FSR_keys_map stores a hash of a std::string representing
- *          the Lattice/Cell/Universe hierarchy for a unique region
- *          and the associated FSR data. fsr_data is a struct that contains
- *          a unique FSR id and a Point located in the highest level Universe
- *          that is contained in the FSR. This method is used when the tracks
- *          are read from file to avoid unnecessary segmentation.
- * @param FSR_keys_map map of FSR keys to FSR data
- */
-void Geometry::setFSRKeysMap(ParallelHashMap<std::string, fsr_data*>*
-                             FSR_keys_map) {
-  _FSR_keys_map = *FSR_keys_map;
-}
-
-
-/**
- * @brief Sets the _FSRs_to_keys vector
- * @param FSRs_to_keys vector of FSR key hashes indexed by FSR IDs
- */
-void Geometry::setFSRsToKeys(std::vector<std::string>* FSRs_to_keys) {
-  _FSRs_to_keys = *FSRs_to_keys;
-}
-
-
-/**
  * @brief Determins whether a point is within the bounding box of the geometry.
  * @param coords a populated LocalCoords linked list
  * @return boolean indicating whether the coords is within the geometry

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1112,7 +1112,7 @@ void Geometry::initializeCmfd() {
  * @brief Returns a pointer to the map that maps FSR keys to FSR IDs
  * @return pointer to _FSR_keys_map map of FSR keys to FSR IDs
  */
-ParallelHashMap<std::string, fsr_data*> & Geometry::getFSRKeysMap() {
+ParallelHashMap<std::string, fsr_data*>& Geometry::getFSRKeysMap() {
   return _FSR_keys_map;
 }
 
@@ -1121,7 +1121,7 @@ ParallelHashMap<std::string, fsr_data*> & Geometry::getFSRKeysMap() {
  * @brief Returns the vector that maps FSR IDs to FSR key hashes
  * @return _FSR_keys_map map of FSR keys to FSR IDs
  */
-std::vector<std::string> & Geometry::getFSRsToKeys() {
+std::vector<std::string>& Geometry::getFSRsToKeys() {
   return _FSRs_to_keys;
 }
 

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -156,10 +156,8 @@ public:
   ParallelHashMap<std::string, fsr_data*> & getFSRKeysMap();
 
   /* Set parameters */
-  void setFSRsToKeys(std::vector<std::string>* FSRs_to_keys);
   void setCmfd(Cmfd* cmfd);
   void setFSRCentroid(int fsr, Point* centroid);
-  void setFSRKeysMap(ParallelHashMap<std::string, fsr_data*>* FSR_keys_map);
 
   /* Find methods */
   Cell* findCellContainingCoords(LocalCoords* coords);

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -148,12 +148,12 @@ public:
   void setRootUniverse(Universe* root_universe);
 
   Cmfd* getCmfd();
-  std::vector<std::string>* getFSRsToKeys();
+  std::vector<std::string> & getFSRsToKeys();
   int getFSRId(LocalCoords* coords);
   Point* getFSRPoint(int fsr_id);
   Point* getFSRCentroid(int fsr_id);
   std::string getFSRKey(LocalCoords* coords);
-  ParallelHashMap<std::string, fsr_data*>* getFSRKeysMap();
+  ParallelHashMap<std::string, fsr_data*> & getFSRKeysMap();
 
   /* Set parameters */
   void setFSRsToKeys(std::vector<std::string>* FSRs_to_keys);

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -148,12 +148,12 @@ public:
   void setRootUniverse(Universe* root_universe);
 
   Cmfd* getCmfd();
-  std::vector<std::string> & getFSRsToKeys();
+  std::vector<std::string>& getFSRsToKeys();
   int getFSRId(LocalCoords* coords);
   Point* getFSRPoint(int fsr_id);
   Point* getFSRCentroid(int fsr_id);
   std::string getFSRKey(LocalCoords* coords);
-  ParallelHashMap<std::string, fsr_data*> & getFSRKeysMap();
+  ParallelHashMap<std::string, fsr_data*>& getFSRKeysMap();
 
   /* Set parameters */
   void setCmfd(Cmfd* cmfd);

--- a/src/ParallelHashMap.h
+++ b/src/ParallelHashMap.h
@@ -812,6 +812,10 @@ void ParallelHashMap<K,V>::clear() {
 
   /* clear underlying fixed table */
   _table->clear();
+
+  /* release all locks in order */
+  for (size_t i=0; i<_num_locks; i++)
+    omp_unset_lock(&_locks[i]);
 }
 
 

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1453,9 +1453,9 @@ void TrackGenerator::dumpTracksToFile() {
   }
 
   /* Get FSR vector maps */
-  ParallelHashMap<std::string, fsr_data*> & FSR_keys_map =
+  ParallelHashMap<std::string, fsr_data*>& FSR_keys_map =
       _geometry->getFSRKeysMap();
-  std::vector<std::string> & FSRs_to_keys = _geometry->getFSRsToKeys();
+  std::vector<std::string>& FSRs_to_keys = _geometry->getFSRsToKeys();
   std::string fsr_key;
   int fsr_id;
   double x, y, z;
@@ -1660,9 +1660,9 @@ bool TrackGenerator::readTracksFromFile() {
   }
 
   /* Create FSR vector maps */
-  ParallelHashMap<std::string, fsr_data*> & FSR_keys_map =
+  ParallelHashMap<std::string, fsr_data*>& FSR_keys_map =
       _geometry->getFSRKeysMap();
-  std::vector<std::string> & FSRs_to_keys =
+  std::vector<std::string>& FSRs_to_keys =
       _geometry->getFSRsToKeys();
   FSR_keys_map.clear();
   FSRs_to_keys.clear();
@@ -1982,9 +1982,9 @@ void TrackGenerator::initializeSegments() {
   std::map<int, Material*> materials = _geometry->getAllMaterials();
 
   /* Get the mappings of FSR to keys to fsr_data to update Materials */
-  ParallelHashMap<std::string, fsr_data*> & FSR_keys_map =
+  ParallelHashMap<std::string, fsr_data*>& FSR_keys_map =
       _geometry->getFSRKeysMap();
-  std::vector<std::string> & FSRs_to_keys = _geometry->getFSRsToKeys();
+  std::vector<std::string>& FSRs_to_keys = _geometry->getFSRsToKeys();
 
 #pragma omp parallel
   {


### PR DESCRIPTION
This PR fixed the lingering issue that we have had trouble debugging. The issue boiled down to the behavior of the methods used to get and set the `_FSR_keys_map` and `_FSRs_to_keys` variables in the Geometry. The methods have been updated to pass a reference to `_FSR_keys_map` and `_FSRs_to_keys` so the original object is modified instead of a new object being created and passed in to the geometry. 

Additionally, one bug was fixed in the ParallelHashMap where the locks needed to be unset in the clear() method. Also, several loops in the TrackGenerator have been parallelized.

This PR builds on PRs #270 and #284.