### PR TITLE
[HOTFIX] Fixed bug in Lattice::getMinX

### DIFF
--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -940,7 +940,7 @@ double Lattice::getWidthZ() const {
  * @return the minimum reachable x-coordinate
  */
 double Lattice::getMinX() {
-  return _offset.getX() - (_num_x + _width_x / 2.);
+  return _offset.getX() - (_num_x * _width_x / 2.);
 }
 
 


### PR DESCRIPTION
Lattice::getMinX had a '+' where it should have had a '*' and wasn't calculating minX properly.