### PR TITLE
[HOTFIX] GPUSolver Type Checking

### DIFF
--- a/openmoc/checkvalue.py
+++ b/openmoc/checkvalue.py
@@ -11,12 +11,6 @@ if (sys.version_info[0] == 2):
 else:
     from openmoc.log import *
 
-# Import OpenMOC's CUDA module if possible
-#try:
-#    import openmoc.cuda
-#except ImportError:
-#    pass
-
 
 def _isinstance(value, expected_type):
     """A Numpy-aware replacement for isinstance

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -28,6 +28,18 @@ else:
     from openmoc.process import get_scalar_fluxes
     import openmoc.checkvalue as cv
 
+# Store viable OpenMOC solver types for type checking
+solver_types = (openmoc.Solver,)
+try:
+    # Try to import OpenMOC's CUDA module
+    if (sys.version_info[0] == 2):
+        from cuda import GPUSolver
+    else:
+        from openmoc.cuda import GPUSolver
+    solver_types += (GPUSolver,)
+except ImportError:
+    pass
+
 # Force non-interactive mode for plotting on clusters
 plt.ioff()
 
@@ -643,7 +655,8 @@ def plot_spatial_fluxes(solver, energy_groups=[1], norm=False, gridsize=250,
 
     """
 
-    cv.check_type('solver', solver, openmoc.Solver)
+    global solver_types
+    cv.check_type('solver', solver, solver_types)
     cv.check_type('energy_groups', energy_groups, Iterable, Integral)
 
     py_printf('NORMAL', 'Plotting the FSR scalar fluxes...')
@@ -723,7 +736,9 @@ def plot_energy_fluxes(solver, fsrs, group_bounds=None, norm=True,
 
     """
 
-    cv.check_type('solver', solver, openmoc.Solver)
+    global solver_types
+    cv.check_type('solver', solver, solver_types)
+#    cv.check_type('solver', solver, (openmoc.Solver, openmoc.cuda.GPUSolver))
     cv.check_type('fsrs', fsrs, Iterable, Integral)
     cv.check_type('norm', norm, bool)
     cv.check_type('loglog', loglog, bool)
@@ -865,7 +880,9 @@ def plot_fission_rates(solver, norm=False, transparent_zeros=True, gridsize=250,
 
     """
 
-    cv.check_type('solver', solver, openmoc.Solver)
+    global solver_types
+    cv.check_type('solver', solver, solver_types)
+#    cv.check_type('solver', solver, (openmoc.Solver, openmoc.cuda.GPUSolver))
 
     py_printf('NORMAL', 'Plotting the flat source region fission rates...')
 
@@ -1216,7 +1233,9 @@ def plot_quadrature(solver, get_figure=False):
 
     """
 
-    cv.check_type('solver', solver, openmoc.Solver)
+    global solver_types
+    cv.check_type('solver', solver, solver_types)
+#    cv.check_type('solver', solver, (openmoc.Solver, openmoc.cuda.GPUSolver))
 
     py_printf('NORMAL', 'Plotting the quadrature...')
 

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -738,7 +738,6 @@ def plot_energy_fluxes(solver, fsrs, group_bounds=None, norm=True,
 
     global solver_types
     cv.check_type('solver', solver, solver_types)
-#    cv.check_type('solver', solver, (openmoc.Solver, openmoc.cuda.GPUSolver))
     cv.check_type('fsrs', fsrs, Iterable, Integral)
     cv.check_type('norm', norm, bool)
     cv.check_type('loglog', loglog, bool)
@@ -882,7 +881,6 @@ def plot_fission_rates(solver, norm=False, transparent_zeros=True, gridsize=250,
 
     global solver_types
     cv.check_type('solver', solver, solver_types)
-#    cv.check_type('solver', solver, (openmoc.Solver, openmoc.cuda.GPUSolver))
 
     py_printf('NORMAL', 'Plotting the flat source region fission rates...')
 
@@ -1235,7 +1233,6 @@ def plot_quadrature(solver, get_figure=False):
 
     global solver_types
     cv.check_type('solver', solver, solver_types)
-#    cv.check_type('solver', solver, (openmoc.Solver, openmoc.cuda.GPUSolver))
 
     py_printf('NORMAL', 'Plotting the quadrature...')
 

--- a/openmoc/process.py
+++ b/openmoc/process.py
@@ -23,6 +23,18 @@ else:
     from openmoc.log import *
     import openmoc.checkvalue as cv
 
+# Store viable OpenMOC solver types for type checking
+solver_types = (openmoc.Solver,)
+try:
+    # Try to import OpenMOC's CUDA module
+    if (sys.version_info[0] == 2):
+        from cuda import GPUSolver
+    else:
+        from openmoc.cuda import GPUSolver
+    solver_types += (GPUSolver,)
+except ImportError:
+    pass
+
 if sys.version_info[0] >= 3:
     basestring = str
 
@@ -55,7 +67,8 @@ def get_scalar_fluxes(solver, fsrs='all', groups='all'):
 
     """
 
-    cv.check_type('solver', solver, openmoc.Solver)
+    global solver_types
+    cv.check_type('solver', solver, solver_types)
 
     if isinstance('fsrs', basestring):
         cv.check_value('fsrs', fsrs, 'all')
@@ -127,7 +140,8 @@ def compute_fission_rates(solver, use_hdf5=False):
 
     """
 
-    cv.check_type('solver', solver, openmoc.Solver)
+    global solver_types
+    cv.check_type('solver', solver, solver_types)
     cv.check_type('use_hdf5', use_hdf5, bool)
 
     # Make directory if it does not exist
@@ -267,7 +281,8 @@ def store_simulation_state(solver, fluxes=False, sources=False,
 
     """
 
-    cv.check_type('solver', solver, openmoc.Solver)
+    global solver_types
+    cv.check_type('solver', solver, solver_types)
     cv.check_type('fluxes', fluxes, bool)
     cv.check_type('sources', sources, bool)
     cv.check_type('fission_rates', fission_rates, bool)
@@ -876,7 +891,8 @@ class Mesh(object):
 
         """
 
-        cv.check_type('solver', solver, openmoc.Solver)
+        global solver_types
+        cv.check_type('solver', solver, solver_types)
         cv.check_value('volume', volume, ('averaged', 'integrated'))
 
         geometry = solver.getGeometry()
@@ -937,7 +953,8 @@ class Mesh(object):
 
         """
 
-        cv.check_type('solver', solver, openmoc.Solver)
+        global solver_types
+        cv.check_type('solver', solver, solver_types)
         cv.check_value('domain_type', domain_type, ('fsr', 'cell', 'material'))
         cv.check_value('volume', volume, ('averaged', 'integrated'))
         cv.check_value('energy', energy, ('by_group', 'integrated'))


### PR DESCRIPTION
This PR fixes some type checking for `Solver` classes in the `openmoc.process` and `openmoc.plotter` modules. Now one can extract, plot and store fluxes from a `GPUSolver` without one of those modules throwing an error in the new type checking interface.