### PR TITLE
Allow for None Matplotlib Colormap

### DIFF
--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -1555,7 +1555,7 @@ class PlotParams(object):
 
     @cmap.setter
     def cmap(self, cmap):
-        cv.check_type('cmap', cmap, matplotlib.colors.Colormap)
+        cv.check_type('cmap', cmap, (matplotlib.colors.Colormap, type(None)))
         self._cmap = cmap
 
     @vmin.setter


### PR DESCRIPTION
This short PR allows one to assign `None` to the `PlotParams.cmap` property.