### PR TITLE
Switching to Point Jacobi Iteration Scheme

### DIFF
--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -9,7 +9,6 @@ Solver::Solver(TrackGenerator* track_generator) {
   /* Default values */
   _num_materials = 0;
   _num_groups = 0;
-  _num_parallel_track_groups = 0;
 
   _num_FSRs = 0;
   _num_fissionable_FSRs = 0;
@@ -351,9 +350,8 @@ void Solver::setTrackGenerator(TrackGenerator* track_generator) {
   _track_generator = track_generator;
   _quadrature = track_generator->getQuadrature();
   _num_polar_2 = _quadrature->getNumPolarAngles() / 2;
-  _num_parallel_track_groups = _track_generator->getNumParallelTrackGroups();
   _tot_num_tracks = _track_generator->getNumTracks();
-  _tracks = _track_generator->getTracksByParallelGroup();
+  _tracks = _track_generator->getTracksArray();
 
   /* Retrieve and store the Geometry from the TrackGenerator */
   setGeometry(_track_generator->getGeometry());

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -182,10 +182,6 @@ protected:
   /** A pointer to a Coarse Mesh Finite Difference (CMFD) acceleration object */
   Cmfd* _cmfd;
 
-  /** The number of groups of tracks that can be looped over in parallel
-   *  without data races between threads */
-  int _num_parallel_track_groups;
-
   void clearTimerSplits();
 
 public:

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -38,13 +38,12 @@ TrackGenerator::~TrackGenerator() {
     delete [] _num_tracks;
     delete [] _num_x;
     delete [] _num_y;
-    delete [] _num_tracks_by_parallel_group;
 
     for (int i = 0; i < _num_azim_2; i++)
       delete [] _tracks[i];
 
     delete [] _tracks;
-    delete [] _tracks_by_parallel_group;
+    delete [] _tracks_array;
   }
 
   if (_FSR_locks != NULL)
@@ -194,8 +193,7 @@ Track **TrackGenerator::getTracks() {
 
 /**
  * @brief Returns a 1D array of Track pointers.
- * @details The tracks in the _tracks_by_parallel_group array are organized
- *          by UID.
+ * @details The tracks in the tracks array are organized by UID.
  * @return The 1D array of Track pointers
  */
 Track **TrackGenerator::getTracksArray() {
@@ -663,10 +661,9 @@ void TrackGenerator::generateTracks(bool store, bool neighbor_cells) {
   /* Deletes Tracks arrays if Tracks have been generated */
   if (_contains_tracks) {
     delete [] _num_tracks;
-    delete [] _num_tracks_by_parallel_group;
     delete [] _num_x;
     delete [] _num_y;
-    delete [] _tracks_by_parallel_group;
+    delete [] _tracks_array;
 
     for (int i = 0; i < _num_azim_2; i++)
       delete [] _tracks[i];

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1106,7 +1106,6 @@ void TrackGenerator::initializeTrackUids() {
       Track* track = &_tracks[a][i];
       track->setUid(uid);
       uid++;
-      }
     }
   }
 }

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -127,20 +127,6 @@ int TrackGenerator::getNumTracks() {
 
 
 /**
- * @brief Return the number of parallel track groups.
- * @return The number of parallel track groups
- */
-int TrackGenerator::getNumParallelTrackGroups() {
-
-  if (!_contains_tracks)
-    log_printf(ERROR, "Unable to return the number of parallel track groups "
-               "since Tracks have not yet been generated.");
-
-  return _num_parallel_track_groups;
-}
-
-
-/**
  * @brief Return the number of tracks on the x-axis for a given azimuthal angle.
  * @param azim An azimuthal angle index
  * @return The number of Tracks on the x-axis
@@ -167,26 +153,6 @@ int TrackGenerator::getNumY(int azim) {
                "generated.", azim);
 
   return _num_y[azim];
-}
-
-
-/**
- * @brief Return the number of tracks in a given parallel track group.
- * @return the number of tracks in a given parallel track group.
- */
-int TrackGenerator::getNumTracksByParallelGroup(int group) {
-
-  if (group < 0 || group >= _num_parallel_track_groups)
-    log_printf(ERROR, "Unable to return the number of tracks in parallel track"
-               " group %d which is not between 0 and the number of parallel "
-               "groups, %d", group, _num_parallel_track_groups);
-
-  if (!_contains_tracks)
-    log_printf(ERROR, "Unable to return the number of tracks in the parallel "
-               "track group %d since Tracks have not yet been generated."
-               , group);
-
-  return _num_tracks_by_parallel_group[group];
 }
 
 
@@ -229,17 +195,15 @@ Track **TrackGenerator::getTracks() {
 /**
  * @brief Returns a 1D array of Track pointers.
  * @details The tracks in the _tracks_by_parallel_group array are organized
- *          by parallel track group. The index into the array is also the
- *          corresponding Track's UID.
+ *          by UID.
  * @return The 1D array of Track pointers
  */
-Track **TrackGenerator::getTracksByParallelGroup() {
+Track **TrackGenerator::getTracksArray() {
   if (!_contains_tracks)
     log_printf(ERROR, "Unable to return the 1D array of the Track pointers "
-               "arranged by parallel group since Tracks have not yet been "
-               "generated.");
+               "since Tracks have not yet been generated.");
 
-  return _tracks_by_parallel_group;
+  return _tracks_array;
 }
 
 
@@ -1131,104 +1095,22 @@ void TrackGenerator::initializeTrackCycleIndices(boundaryType bc) {
 
 /**
  * @brief Set the Track UIDs for all tracks and generate the 1D array of
- *        track pointers that separates the groups of tracks by parallel group.
- * @details The Solver requires the tracks to be separated into groups of tracks
- *          that can be looped over in parallel without data races. This method
- *          creates a 1D array of Track pointers where the tracks are arranged
- *          by parallel group. If the geometry has a periodic BC, 6 periodic
- *          groups are created; otherwise, 2 periodic groups are created. The
- *          Track UIDs are also set to their index in the tracks by periodic
- *          group array.
+ *        track pointers.
  */
 void TrackGenerator::initializeTrackUids() {
 
-  Track* track;
-  bool periodic;
+  /* Allocate memory for the 1D tracks array */
+  _tracks_array = new Track*[getNumTracks()];
+
+  /* Loop over all tracks and assigns UIDs */
   int uid = 0;
-  int azim_group_id, periodic_group_id;
-  int track_azim_group_id, track_periodic_group_id;
-  int track_periodic_index;
-  int num_tracks;
-
-  /* If periodic boundary conditions are present, set the number of parallel
-   * track groups to 6; else, set the number of parallel track groups to 2. Also
-   * set the periodic boolean indicating whether periodic bcs are present. */
-  if (_geometry->getMinXBoundaryType() == PERIODIC ||
-      _geometry->getMinYBoundaryType() == PERIODIC) {
-    _num_parallel_track_groups = 6;
-    periodic = true;
-  }
-  else {
-    _num_parallel_track_groups = 2;
-    periodic = false;
-  }
-
-  /* Allocate memory for the num tracks by parallel group array */
-  _num_tracks_by_parallel_group = new int[_num_parallel_track_groups];
-
-  /* Allocate memory for the tracks by parallel group array */
-  _tracks_by_parallel_group = new Track*[getNumTracks()];
-
-  /* Loop over the parallel track groups */
-  for (int g = 0; g < _num_parallel_track_groups; g++) {
-
-    /* Initialize the number of tracks counter */
-    num_tracks = 0;
-
-    /* Set the azimuthal and periodic group ids */
-    azim_group_id = g % 2;
-    periodic_group_id = g / 2;
-
-    /* Loop over all tracks and add all tracks belonging to the current
-     * parallel group to the tracks by parallel groups array */
-    for (int a=0; a < _num_azim_2; a++) {
-      for (int i=0; i < _num_tracks[a]; i++) {
-
-        /* Get current track */
-        track = &_tracks[a][i];
-
-        /* Get the track azim group id */
-        track_azim_group_id = a / (_num_azim_2 / 2);
-
-        /* Get the track periodic group id */
-        if (periodic) {
-          track_periodic_index = track->getPeriodicTrackIndex();
-
-          /* If the track is the first track in periodic cycle, assign it a
-           * periodic group id of 0 */
-          if (track_periodic_index == 0)
-            track_periodic_group_id = 0;
-
-          /* If the track has an odd periodic cycle index, assign it a periodic
-           * group id of 1 */
-          else if (track_periodic_index % 2 == 1)
-            track_periodic_group_id = 1;
-
-          /* Else the track must have an even periodic cycle index and not be
-           * the first track in the periodic cycle; assign it a periodic group
-           * id of 2 */
-          else
-            track_periodic_group_id = 2;
-        }
-
-        /* If the geometry does not have any periodic BCs, assign the track a
-         * periodic group id of 0 */
-        else
-          track_periodic_group_id = 0;
-
-        /* Check if track has current azim_group_id and periodic_group_id */
-        if (azim_group_id == track_azim_group_id &&
-            periodic_group_id == track_periodic_group_id) {
-          track->setUid(uid);
-          _tracks_by_parallel_group[uid] = track;
-          uid++;
-          num_tracks++;
-        }
+  for (int a=0; a < _num_azim_2; a++) {
+    for (int i=0; i < _num_tracks[a]; i++) {
+      Track* track = &_tracks[a][i];
+      track->setUid(uid);
+      uid++;
       }
     }
-
-    /* Set the number of tracks in this parallel group */
-    _num_tracks_by_parallel_group[g] = num_tracks;
   }
 }
 

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1105,6 +1105,7 @@ void TrackGenerator::initializeTrackUids() {
     for (int i=0; i < _num_tracks[a]; i++) {
       Track* track = &_tracks[a][i];
       track->setUid(uid);
+      _tracks_array[uid] = track;
       uid++;
     }
   }

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1099,7 +1099,7 @@ void TrackGenerator::initializeTrackUids() {
   /* Allocate memory for the 1D tracks array */
   _tracks_array = new Track*[getNumTracks()];
 
-  /* Loop over all tracks and assigns UIDs */
+  /* Loop over all tracks and assign UIDs */
   int uid = 0;
   for (int a=0; a < _num_azim_2; a++) {
     for (int i=0; i < _num_tracks[a]; i++) {

--- a/src/TrackGenerator.h
+++ b/src/TrackGenerator.h
@@ -50,13 +50,6 @@ protected:
   /** An integer array of the number of Tracks for each azimuthal angle */
   int* _num_tracks;
 
-  /** An integer array with the number of Tracks in each parallel track group */
-  int* _num_tracks_by_parallel_group;
-
-  /** The number of the track groups needed to ensure data races don't occur
-   *  during the Solver's transportSweep */
-  int _num_parallel_track_groups;
-
   /** An integer array of the number of Tracks starting on the x-axis for each
    *  azimuthal angle */
   int* _num_x;
@@ -74,8 +67,8 @@ protected:
   /** A 2D ragged array of Tracks */
   Track** _tracks;
 
-  /** A 1D array of Track pointers arranged by parallel group */
-  Track** _tracks_by_parallel_group;
+  /** A 1D array of Track pointers arranged by UID */
+  Track** _tracks_array;
 
   /** Pointer to the Geometry */
   Geometry* _geometry;
@@ -139,11 +132,9 @@ public:
   int getNumTracks();
   int getNumX(int azim);
   int getNumY(int azim);
-  int getNumTracksByParallelGroup(int group);
-  int getNumParallelTrackGroups();
   int getNumSegments();
   Track** getTracks();
-  Track** getTracksByParallelGroup();
+  Track** getTracksArray();
   FP_PRECISION retrieveMaxOpticalLength();
   int getNumThreads();
   FP_PRECISION* getFSRVolumes();

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1481,8 +1481,6 @@ void GPUSolver::computeFSRScatterSources() {
 void GPUSolver::transportSweep() {
 
   int shared_mem = _T * _num_polar_2 * 2 * sizeof(FP_PRECISION);
-  int tid_offset = 0;
-  int tid_max = 0;
 
   log_printf(DEBUG, "Transport sweep on device with %d blocks and %d threads",
              _B, _T);

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1499,8 +1499,9 @@ void GPUSolver::transportSweep() {
   flattenFSRFluxes(0.0);
 
   /* Copy starting flux to current flux */
-  cudaMemcpy((void*)boundary_flux, (void*)start_flux, _tot_num_tracks
-             * sizeof(FP_PRECISION), cudaMemcpyDeviceToDevice);
+  cudaMemcpy((void*)boundary_flux, (void*)start_flux, _tot_num_tracks *
+             _polar_times_groups * sizeof(FP_PRECISION),
+             cudaMemcpyDeviceToDevice);
 
   /* Perform transport sweep on all tracks */
   transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1499,7 +1499,7 @@ void GPUSolver::transportSweep() {
   flattenFSRFluxes(0.0);
 
   /* Copy starting flux to current flux */
-  cudaMemcpy((void*)boundary_flux, (void*)start_flux, _tot_num_tracks *
+  cudaMemcpy((void*)boundary_flux, (void*)start_flux, 2 * _tot_num_tracks *
              _polar_times_groups * sizeof(FP_PRECISION),
              cudaMemcpyDeviceToDevice);
 

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1214,7 +1214,7 @@ void GPUSolver::initializeTracks() {
     cudaFree(_dev_tracks);
 
   /* Allocate memory for all Tracks and Track offset indices on the device */
-  try{
+  try {
 
     /* Allocate array of dev_tracks */
     cudaMalloc((void**)&_dev_tracks, _tot_num_tracks * sizeof(dev_track));
@@ -1502,8 +1502,7 @@ void GPUSolver::transportSweep() {
   cudaMemcpy((void*)boundary_flux, (void*)start_flux, _tot_num_tracks
              * sizeof(FP_PRECISION), cudaMemcpyDeviceToDevice);
 
-  /* Loop over the parallel track groups and perform transport sweep on tracks
-   * in that group */
+  /* Perform transport sweep on all tracks */
   transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
                                                  start_flux, reduced_sources,
                                                  _materials, _dev_tracks,

--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -53,6 +53,7 @@
 /** Indexing macro for the angular fluxes for each polar angle and energy
  *  group for a given Track */
 #define boundary_flux(t,pe2) (boundary_flux[2*(t)*(*polar_times_groups)+(pe2)])
+#define start_flux(t,pe2) (start_flux[2*(t)*(*polar_times_groups)+(pe2)])
 
 
 /**
@@ -98,7 +99,7 @@ private:
 
   /** Map of Material IDs to indices in _materials array */
   std::map<int, int> _material_IDs_to_indices;
-  
+
   void copyQuadrature();
 
 public:

--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -53,8 +53,11 @@
 /** Indexing macro for the angular fluxes for each polar angle and energy
  *  group for a given Track */
 #define boundary_flux(t,pe2) (boundary_flux[2*(t)*(*polar_times_groups)+(pe2)])
-#define start_flux(t,pe2) (start_flux[2*(t)*(*polar_times_groups)+(pe2)])
 
+/** Indexing macro for the starting angular fluxes for each polar angle and
+ *  energy group for a given Track. These are copied to the boundary fluxes
+ *  array at the beginning of each transport sweep */
+#define start_flux(t,pe2) (start_flux[2*(t)*(*polar_times_groups)+(pe2)])
 
 /**
  * @class GPUSolver GPUSolver.h "openmoc/src/dev/gpu/GPUSolver.h"
@@ -84,6 +87,8 @@ private:
 
   /** Thrust vector of angular fluxes for each track */
   thrust::device_vector<FP_PRECISION> _boundary_flux;
+
+  /** Thrust vector of starting angular fluxes for each track */
   thrust::device_vector<FP_PRECISION> _start_flux;
 
   /** Thrust vector of FSR scalar fluxes */

--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -84,6 +84,7 @@ private:
 
   /** Thrust vector of angular fluxes for each track */
   thrust::device_vector<FP_PRECISION> _boundary_flux;
+  thrust::device_vector<FP_PRECISION> _start_flux;
 
   /** Thrust vector of FSR scalar fluxes */
   thrust::device_vector<FP_PRECISION> _scalar_flux;


### PR DESCRIPTION
In #307, the CPU solver changed the iteration scheme from updating boundary angular fluxes between connecting tracks immediately within parallel groups (sometimes loosely referred to as "Gauss-Siedel") to updating all boundary angular fluxes at the end of each iteration (referred to as Point Jacobi).

The "Gauss-Siedel" scheme is advantageous for a few reasons:
* More recent update on angular flux provides a better convergence rate
* Only one group of boundary angular fluxes need to be stored

However, it also has its disadvantages:
* Increased complexity due to the need to form "parallel groups" that can be run concurrently
* A slight reduction in parallelism (only tracks in a parallel group can be run concurrently)
* Difficult to extend with domain decomposition due to increased communication between nodes

For primarily the last reason (domain decomposition) we move to a Point Jacobi iteration scheme throughout the entire code in this PR. With this decision we do loose a bit of performance. First, we require more iterations to converge the solution due to a lagged update of the boundary angular fluxes. However with CMFD acceleration this effect is minimal (often only one or two iterations). Second, we double the storage requirements for boundary angular fluxes since we need to store a copy for each boundary angular flux which is transferred at the end of the iteration. Since we expect boundary angular flues to dominate the storage requirements in large MOC problems (particularly 3D MOC) this doubles the entire memory footprint of the problem. However, we have decided the reduction in complexity is worth taking this penalty. 

This PR mainly focuses on the GPU and implements the Point Jacobi scheme on the GPU.