### PR TITLE
Extend Tracking Algorithms with Abstract Tracking Structure

### DIFF
--- a/src/MOCKernel.cpp
+++ b/src/MOCKernel.cpp
@@ -64,7 +64,7 @@ void MOCKernel::newTrack(Track* track) {
 void VolumeKernel::newTrack(Track* track) {
 
   /* Compute the Track cross-sectional area */
-  int azim_index = track->getAzimAngleIndex();
+  int azim_index = track->getAzimIndex();
   _weight = _quadrature->getAzimSpacing(azim_index)
       * _quadrature->getAzimWeight(azim_index);
 

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -330,7 +330,7 @@ double Track::getPhi() const {
  *        x-axis).
  * @return th azimuthal angle index
  */
-int Track::getAzimAngleIndex() const {
+int Track::getAzimIndex() const {
   return _azim_angle_index;
 }
 

--- a/src/Track.h
+++ b/src/Track.h
@@ -128,7 +128,7 @@ public:
   Point* getEnd();
   Point* getStart();
   double getPhi() const;
-  int getAzimAngleIndex() const;
+  int getAzimIndex() const;
   int getPeriodicTrackIndex() const;
   int getReflectiveTrackIndex() const;
   segment* getSegment(int s);

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -693,7 +693,7 @@ void TrackGenerator::generateTracks(bool store, bool neighbor_cells) {
       recalibrateTracksToOrigin();
       segmentize();
       if (store)
-	      dumpTracksToFile();
+        dumpTracksToFile();
     }
     catch (std::exception &e) {
       log_printf(ERROR, "Unable to allocate memory for Tracks");
@@ -1441,7 +1441,6 @@ bool TrackGenerator::readTracksFromFile() {
   int ret;
   FILE* in;
   in = fopen(_tracks_filename.c_str(), "r");
-
   int string_length;
 
   /* Import Geometry metadata from the Track file */
@@ -1551,12 +1550,10 @@ bool TrackGenerator::readTracksFromFile() {
   }
 
   /* Inform the rest of the class methods that Tracks have been initialized */
-  if (ret) {
+  if (ret)
     _contains_segments = true;
-  }
-  else {
+  else
     _contains_tracks = false;
-  }
 
   /* Close the Track file */
   fclose(in);

--- a/src/TrackGenerator.h
+++ b/src/TrackGenerator.h
@@ -92,6 +92,14 @@ protected:
   /** Boolean whether the Tracks have been generated (true) or not (false) */
   bool _contains_tracks;
 
+  /** Boolean whether segments have been generated for every Track (true) or
+      not (false) */
+  bool _contains_segments;
+
+  /** Boolean whether to print segments to a tracking file (true) or not
+   *  (false) */
+  bool _dump_segments;
+
   /** The z-coord where the 2D Tracks should be created */
   double _z_coord;
 
@@ -160,9 +168,11 @@ public:
   void setQuadrature(Quadrature* quadrature);
   void setNumThreads(int num_threads);
   void setZCoord(double z_coord);
+  void setMaxOpticalLength(FP_PRECISION tau);
 
   /* Worker functions */
   bool containsTracks();
+  bool containsSegments();
   void retrieveTrackCoords(double* coords, int num_tracks);
   void retrieveSegmentCoords(double* coords, int num_segments);
   void generateTracks(bool store=true, bool neighbor_cells=false);

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -4,6 +4,147 @@
 
 
 /**
+ * @brief Constructor for MaxOpticalLength calls the TraverseTracks
+ *        constructor and sets the max optical path length to zero
+ * @param track_generator The TrackGenerator to pull tracking information from
+ */
+MaxOpticalLength::MaxOpticalLength(TrackGenerator* track_generator)
+                                 : TraverseTracks(track_generator) {
+  _max_tau = 0;
+}
+
+
+/**
+ * @brief Determines the maximum optical path length for the TrackGenerator
+ *        provided during construction
+ * @details The maximum optical path length is initialized to infinity for
+ *          segmentation within the TrackGenerator. Then Tracks are traversed
+ *          and onTrack(...) is applied, calculating a maximum optical length
+ *          and setting it on the TrackGenerator.
+*/
+void MaxOpticalLength::execute() {
+  FP_PRECISION infinity = std::numeric_limits<FP_PRECISION>::max();
+  _track_generator->setMaxOpticalLength(infinity);
+#pragma omp parallel
+  {
+    loopOverTracks(NULL);
+  }
+  _track_generator->setMaxOpticalLength(_max_tau);
+}
+
+
+/**
+ * @brief Calculates the optical path length for the provided segments and
+ *        updates the maximum optical path length if necessary
+ * @param track The track associated with the segments
+ * @param segments The segments for which the optical path length is calculated
+ */
+void MaxOpticalLength::onTrack(Track* track, segment* segments) {
+  for (int s=0; s < track->getNumSegments(); s++) {
+    FP_PRECISION length = segments[s]._length;
+    Material* material = segments[s]._material;
+    FP_PRECISION* sigma_t = material->getSigmaT();
+
+    for (int e=0; e < material->getNumEnergyGroups(); e++) {
+      FP_PRECISION tau = length*sigma_t[e];
+      if (tau > _max_tau) {
+#pragma omp critical
+        _max_tau = std::max(_max_tau, tau);
+      }
+    }
+  }
+}
+
+
+/**
+ * @brief Constructor for SegmentSplitter calls the TraverseTracks
+ *        constructor
+ * @param track_generator The TrackGenerator to pull tracking information from
+ */
+SegmentSplitter::SegmentSplitter(TrackGenerator* track_generator)
+                               : TraverseTracks(track_generator) {
+}
+
+
+/**
+ * @brief Splits segments stored explicity along each Track
+ * @details No MOCKernels are initialized for this function.
+ */
+void SegmentSplitter::execute() {
+#pragma omp parallel
+  {
+    loopOverTracks(NULL);
+  }
+}
+
+
+/**
+ * @brief Segments for the provided Track are split so that no segment has a
+ *        larger optical path length than the maximum optical path length
+ * @param track The Track whose segments are potentially split
+ * @param segments The segments associated with the Track
+ */
+void SegmentSplitter::onTrack(Track* track, segment* segments) {
+
+  /* Get the max optical length from the TrackGenerator */
+  FP_PRECISION max_optical_length =
+    _track_generator->retrieveMaxOpticalLength();
+
+  /* Extract data from this segment to compute its optical
+   * length */
+  for (int s = 0; s < track->getNumSegments(); s++) {
+    segment* curr_segment = track->getSegment(s);
+    Material* material = curr_segment->_material;
+    FP_PRECISION length = curr_segment->_length;
+    int fsr_id = curr_segment->_region_id;
+
+    /* Compute number of segments to split this segment into */
+    int min_num_cuts = 1;
+    int num_groups = material->getNumEnergyGroups();
+    FP_PRECISION* sigma_t = material->getSigmaT();
+
+    for (int g=0; g < num_groups; g++) {
+      FP_PRECISION tau = length * sigma_t[g];
+      int num_cuts = ceil(tau / max_optical_length);
+      min_num_cuts = std::max(num_cuts, min_num_cuts);
+    }
+
+    /* If the segment does not need subdivisions, go to next
+     * segment */
+    if (min_num_cuts == 1)
+      continue;
+
+    /* Record the CMFD surfaces */
+    int cmfd_surface_fwd = curr_segment->_cmfd_surface_fwd;
+    int cmfd_surface_bwd = curr_segment->_cmfd_surface_bwd;
+
+    /* Split the segment into sub-segments */
+    for (int k=0; k < min_num_cuts; k++) {
+
+      /* Create a new Track segment */
+      segment* new_segment = new segment;
+      new_segment->_material = material;
+      new_segment->_length = length / FP_PRECISION(min_num_cuts);
+      new_segment->_region_id = fsr_id;
+
+      /* Assign CMFD surface boundaries */
+      if (k == 0)
+        new_segment->_cmfd_surface_bwd = cmfd_surface_bwd;
+
+      if (k == min_num_cuts-1)
+        new_segment->_cmfd_surface_fwd = cmfd_surface_fwd;
+
+      /* Insert the new segment to the Track */
+      track->insertSegment(s+k+1, new_segment);
+    }
+
+    /* Remove the original segment from the Track */
+    track->removeSegment(s);
+  }
+}
+
+
+/**
  * @brief Constructor for VolumeCalculator calls the TraverseTracks
  *        constructor
  * @param track_generator The TrackGenerator to pull tracking information
@@ -26,6 +167,97 @@ void VolumeCalculator::execute() {
     loopOverTracks(&kernel);
   }
 }
+
+
+/**
+ * @brief Constructor for CentroidGenerator calls the TraverseTracks
+ *        constructor and imports refernces to both the FSR volumes and FSR
+ *        locks arrays
+ * @param track_generator The TrackGenerator to pull tracking information from
+ */
+CentroidGenerator::CentroidGenerator(TrackGenerator* track_generator)
+                                  : TraverseTracks(track_generator) {
+
+  _FSR_volumes = track_generator->getFSRVolumes();
+  _FSR_locks = track_generator->getFSRLocks();
+  _quadrature = track_generator->getQuadrature();
+}
+
+
+/**
+ * @brief Calculates the centroid of every FSR
+ * @details On each segment, onTrack(...) calculates the contribution to each
+ *          FSR centroid and saves the centroids in the centroids array
+ *          provided by setCentroids(...).
+ */
+void CentroidGenerator::execute() {
+#pragma omp parallel
+  {
+    loopOverTracks(NULL);
+  }
+}
+
+
+/**
+ * @brief Specifies an array to save calculated FSR centroids
+ * @brief centroids The array of FSR centroids pointers
+ */
+void CentroidGenerator::setCentroids(Point** centroids) {
+  _centroids = centroids;
+}
+
+
+/**
+ * @brief Centroid contributions are calculated for every segment in the Track
+ * @param track The Track associated with the segments
+ * @param segments The segments whose contributions are added to the centroids
+ */
+void CentroidGenerator::onTrack(Track* track, segment* segments) {
+
+  /* Extract common information from the Track */
+  Point* start = track->getStart();
+  int azim_index = track->getAzimIndex();
+  double phi = track->getPhi();
+
+  /* Compute the Track cross-sectional area */
+  double wgt = _quadrature->getAzimSpacing(azim_index)
+      * _quadrature->getAzimWeight(azim_index);
+
+  /* Pre-compute azimuthal angles for efficiency */
+  double sin_phi = sin(phi);
+  double cos_phi = cos(phi);
+
+  /* Extract starting points */
+  double x = track->getStart()->getX();
+  double y = track->getStart()->getY();
+
+  /* Loop over segments to accumlate contribution to centroids */
+  for (int s=0; s < track->getNumSegments(); s++) {
+
+    segment* curr_segment = &segments[s];
+    int fsr = curr_segment->_region_id;
+
+    /* Set the lock for this FSR */
+    omp_set_lock(&_FSR_locks[fsr]);
+
+    _centroids[fsr]->
+        setX(_centroids[fsr]->getX() + wgt *
+        (x + cos_phi * curr_segment->_length / 2.0)
+        * curr_segment->_length / _FSR_volumes[fsr]);
+
+    _centroids[fsr]->
+        setY(_centroids[fsr]->getY() + wgt *
+        (y + sin_phi * curr_segment->_length / 2.0)
+        * curr_segment->_length / _FSR_volumes[fsr]);
+
+    /* Unset the lock for this FSR */
+    omp_unset_lock(&_FSR_locks[fsr]);
+
+    x += cos_phi * curr_segment->_length;
+    y += sin_phi * curr_segment->_length;
+  }
+}
+
 
 
 /**
@@ -80,7 +312,7 @@ void TransportSweep::onTrack(Track* track, segment* segments) {
 
   /* Extract Track information */
   int track_id = track->getUid();
-  int azim_index = track->getAzimAngleIndex();
+  int azim_index = track->getAzimIndex();
   int num_segments = track->getNumSegments();
   FP_PRECISION* track_flux;
 
@@ -115,3 +347,159 @@ void TransportSweep::onTrack(Track* track, segment* segments) {
   /* Transfer boundary angular flux to outgoing Track */
   _cpu_solver->transferBoundaryFlux(track_id, azim_index, false, track_flux);
 }
+
+
+/**
+ * @brief Constructor for DumpSegments calls the TraverseTracks
+ *        constructor and initializes the output FILE to NULL
+ * @param track_generator The TrackGenerator to pull tracking information from
+ */
+DumpSegments::DumpSegments(TrackGenerator* track_generator)
+                           : TraverseTracks(track_generator) {
+  _out = NULL;
+}
+
+
+/**
+ * @brief Wrties all tracking information to file
+ * @details For each Track, onTrack(...) writes the tracking information to
+ *          file.
+ */
+void DumpSegments::execute() {
+  loopOverTracks(NULL);
+}
+
+
+/**
+ * @brief Sets the file which to write tracking information
+ * @param out the file which to write tracking infmormation
+ */
+void DumpSegments::setOutputFile(FILE* out) {
+  _out = out;
+}
+
+
+/**
+ * @brief Writes tracking information to file for a Track and associated
+ *        segments
+ * @param track The Track whose information is written to file
+ * @param segments The segments associated with the Track whose information is
+ *        written to file
+ */
+void DumpSegments::onTrack(Track* track, segment* segments) {
+
+  /* Write data for this Track to the Track file */
+  int num_segments = track->getNumSegments();
+  fwrite(&num_segments, sizeof(int), 1, _out);
+
+  /* Get CMFD mesh object */
+  Cmfd* cmfd = _track_generator->getGeometry()->getCmfd();
+
+  /* Loop over all segments for this Track */
+  for (int s=0; s < num_segments; s++) {
+
+    /* Get data for this segment */
+    segment* curr_segment = &segments[s];
+    FP_PRECISION length = curr_segment->_length;
+    int material_id = curr_segment->_material->getId();
+    int region_id = curr_segment->_region_id;
+
+    /* Write data for this segment to the Track file */
+    fwrite(&length, sizeof(double), 1, _out);
+    fwrite(&material_id, sizeof(int), 1, _out);
+    fwrite(&region_id, sizeof(int), 1, _out);
+
+    /* Write CMFD-related data for the Track if needed */
+    if (cmfd != NULL) {
+      int cmfd_surface_fwd = curr_segment->_cmfd_surface_fwd;
+      int cmfd_surface_bwd = curr_segment->_cmfd_surface_bwd;
+      fwrite(&cmfd_surface_fwd, sizeof(int), 1, _out);
+      fwrite(&cmfd_surface_bwd, sizeof(int), 1, _out);
+    }
+  }
+}
+
+
+/**
+ * @brief Constructor for ReadSegments calls the TraverseTracks
+ *        constructor and initializes the input FILE to NULL
+ * @param track_generator The TrackGenerator to pull tracking information from
+ */
+ReadSegments::ReadSegments(TrackGenerator* track_generator)
+                           : TraverseTracks(track_generator) {
+  _in = NULL;
+}
+
+
+/**
+ * @brief Reads a tracking file and saves the information explicitly for every
+ *        Track in the TrackGenerator.
+ * @details The tracking file is set by setInputFile(...)
+ */
+void ReadSegments::execute() {
+  loopOverTracks(NULL);
+}
+
+
+/**
+ * @brief Sets the input file to read in tracking information
+ * @param in The input tracking file
+ */
+void ReadSegments::setInputFile(FILE* in) {
+  _in = in;
+}
+
+
+/**
+ * @brief Saves tracking information to the corresponding Track explicity
+ * @param track The track for which all tracking information is explicitly
+ *        saved (including segments)
+ * @param segments The segments associated with the Track
+ */
+void ReadSegments::onTrack(Track* track, segment* segments) {
+
+  /* Get CMFD mesh object */
+  Geometry* geometry = _track_generator->getGeometry();
+  Cmfd* cmfd = geometry->getCmfd();
+  int ret;
+
+  /* Get materials map */
+  std::map<int, Material*> materials = geometry->getAllMaterials();
+
+  /* Import data for this Track from Track file */
+  int num_segments;
+  ret = fread(&num_segments, sizeof(int), 1, _in);
+
+  /* Loop over all segments in this Track */
+  for (int s=0; s < num_segments; s++) {
+
+    /* Import data for this segment from Track file */
+    double length;
+    ret = fread(&length, sizeof(double), 1, _in);
+    int material_id;
+    ret = fread(&material_id, sizeof(int), 1, _in);
+    int region_id;
+    ret = fread(&region_id, sizeof(int), 1, _in);
+
+    /* Initialize segment with the data */
+    segment* curr_segment = new segment;
+    curr_segment->_length = length;
+    curr_segment->_material = materials[material_id];
+    curr_segment->_region_id = region_id;
+
+    /* Import CMFD-related data if needed */
+    if (cmfd != NULL) {
+      int cmfd_surface_fwd;
+      ret = fread(&cmfd_surface_fwd, sizeof(int), 1, _in);
+      curr_segment->_cmfd_surface_fwd = cmfd_surface_fwd;
+      int cmfd_surface_bwd;
+      ret = fread(&cmfd_surface_bwd, sizeof(int), 1, _in);
+      curr_segment->_cmfd_surface_bwd = cmfd_surface_bwd;
+    }
+
+    /* Add this segment to the Track */
+    track->addSegment(curr_segment);
+  }
+}
+
+

--- a/src/TrackTraversingAlgorithms.h
+++ b/src/TrackTraversingAlgorithms.h
@@ -169,6 +169,8 @@ class ReadSegments: public TraverseTracks {
 private:
 
   FILE* _in;
+  Quadrature* _quadrature;
+  int _num_azim_2;
 
 public:
 

--- a/src/TrackTraversingAlgorithms.h
+++ b/src/TrackTraversingAlgorithms.h
@@ -27,6 +27,44 @@ class CPUSolver;
 
 
 /**
+ * @class MaxOpticalLength TrackTraversingAlgorithms.h
+ *        "src/TrackTraversingAlgorithms.h"
+ * @brief A class used to calculate the maximum optical path length across
+ *        all segments in the Geometry
+ * @details The segments are traversed and the maximium optical path length
+ *          is calculated.
+ */
+class MaxOpticalLength: public TraverseTracks {
+private:
+  FP_PRECISION _max_tau;
+
+public:
+
+  MaxOpticalLength(TrackGenerator* track_generator);
+  void execute();
+  void onTrack(Track* track, segment* segments);
+};
+
+
+/**
+ * @class SegmentSplitter TrackTraversingAlgorithms.h
+ *        "src/TrackTraversingAlgorithms.h"
+ * @brief A class used to split explicit segments along Tracks
+ * @details A SegmentSplitter imports a maximum optical path length from the
+ *          provided TrackGenerator and then ensures all segments have an
+ *          optical path length less than the maximum optical path length by
+ *          splitting segments stored in the Tracks.
+ */
+class SegmentSplitter: public TraverseTracks {
+
+public:
+
+  SegmentSplitter(TrackGenerator* track_generator);
+  void execute();
+  void onTrack(Track* track, segment* segments);
+};
+
+/**
  * @class VolumeCalculator TrackTraversingAlgorithms.h
  *        "src/TrackTraversingAlgorithms.h"
  * @brief A class used to calculate FSR volumes
@@ -41,6 +79,35 @@ public:
 
   VolumeCalculator(TrackGenerator* track_generator);
   void execute();
+};
+
+
+/**
+ * @class CentroidGenerator TrackTraversingAlgorithms.h
+ *        "src/TrackTraversingAlgorithms.h"
+ * @brief A class used to calculate the centroids of each FSR
+ * @details A CentroidGenerator imports FSR Volumes and associated locks form
+ *          the provided TrackGenerator, then centroids are calculated and
+ *          stored in the provided buffer by looping over all segments and
+ *          adding their contribution to each FSR centroid.
+ */
+class CentroidGenerator: public TraverseTracks {
+
+private:
+
+  Point** _centroids;
+  FP_PRECISION* _FSR_volumes;
+  omp_lock_t* _FSR_locks;
+  Quadrature* _quadrature;
+  Point** _starting_points;
+  bool** _new_track;
+
+public:
+
+  CentroidGenerator(TrackGenerator* track_generator);
+  void setCentroids(Point** centroids);
+  void execute();
+  void onTrack(Track* track, segment* segments);
 };
 
 
@@ -63,6 +130,50 @@ public:
 
   TransportSweep(TrackGenerator* track_generator);
   void setCPUSolver(CPUSolver* cpu_solver);
+  void execute();
+  void onTrack(Track* track, segment* segments);
+};
+
+
+/**
+ * @class DumpSegments TrackTraversingAlgorithms.h
+ *        "src/TrackTraversingAlgorithms.h"
+ * @brief A class used to write tracking data to a file
+ * @details DumpSegments imports Track data from the provided TrackGenerator
+ *          and writes the tracking data to the provided file.
+ */
+class DumpSegments: public TraverseTracks {
+
+private:
+
+  FILE* _out;
+
+public:
+
+  DumpSegments(TrackGenerator* track_generator);
+  void setOutputFile(FILE* out);
+  void execute();
+  void onTrack(Track* track, segment* segments);
+};
+
+
+/**
+ * @class ReadSegments TrackTraversingAlgorithms.h
+ *        "src/TrackTraversingAlgorithms.h"
+ * @brief A class used to read tracking data from a file.
+ * @details ReadSegments imports Track data from the provided file and writes
+ *          the tracking data to the Tracks in the provided TrackGenerator.
+ */
+class ReadSegments: public TraverseTracks {
+
+private:
+
+  FILE* _in;
+
+public:
+
+  ReadSegments(TrackGenerator* track_generator);
+  void setInputFile(FILE* in);
   void execute();
   void onTrack(Track* track, segment* segments);
 };

--- a/src/accel/cuda/clone.cu
+++ b/src/accel/cuda/clone.cu
@@ -91,7 +91,7 @@ void clone_track(Track* track_h, dev_track* track_d,
 
   new_track._uid = track_h->getUid();
   new_track._num_segments = track_h->getNumSegments();
-  new_track._azim_angle_index = track_h->getAzimAngleIndex();
+  new_track._azim_angle_index = track_h->getAzimIndex();
   new_track._next_in = track_h->isNextIn();
   new_track._next_out = track_h->isNextOut();
   new_track._transfer_flux_in = track_h->getTransferFluxIn();


### PR DESCRIPTION
This PR build off of #307 to include more "micro-algorithms" with the abstract tracking/looping structure:
- Calculating the maximum optical path length
- Splitting segments to conform to the maximum optical path length
- Generating FSR centroids for use in CMFD calculations
- Writing tracking data to a file
- Reading tracking data from a file
