### PR TITLE
Local storage of Universe boundaries

### DIFF
--- a/profile/Makefile
+++ b/profile/Makefile
@@ -37,14 +37,13 @@ TrackGenerator.cpp \
 TrackTraversingAlgorithms.cpp \
 TraverseTracks.cpp \
 Universe.cpp \
-Vector.cpp 
+Vector.cpp
 
 cases = \
 gradients/one-directional/one-directional-gradient.cpp \
 gradients/two-directional/two-directional-gradient.cpp \
 homogeneous/homogeneous-one-group.cpp \
 c5g7/c5g7.cpp \
-monte_carlo/monte_carlo.cpp \
 c5g7/c5g7-cmfd.cpp
 
 #===============================================================================

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -13,7 +13,7 @@ PRECISION   = single
 # Source Code List
 #===============================================================================
 
-case = c5g7/c5g7-cmfd.cpp
+case = monte_carlo/monte_carlo.cpp
 
 source = \
 Cell.cpp \
@@ -37,13 +37,18 @@ TrackGenerator.cpp \
 TrackTraversingAlgorithms.cpp \
 TraverseTracks.cpp \
 Universe.cpp \
-Vector.cpp
+Vector.cpp \
+Tally.cpp \
+Fission.cpp \
+MCSolver.cpp \
+Neutron.cpp
 
 cases = \
 gradients/one-directional/one-directional-gradient.cpp \
 gradients/two-directional/two-directional-gradient.cpp \
 homogeneous/homogeneous-one-group.cpp \
 c5g7/c5g7.cpp \
+monte_carlo/monte_carlo.cpp \
 c5g7/c5g7-cmfd.cpp
 
 #===============================================================================

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -13,7 +13,7 @@ PRECISION   = single
 # Source Code List
 #===============================================================================
 
-case = monte_carlo/monte_carlo.cpp
+case = c5g7/c5g7-cmfd.cpp
 
 source = \
 Cell.cpp \
@@ -37,11 +37,7 @@ TrackGenerator.cpp \
 TrackTraversingAlgorithms.cpp \
 TraverseTracks.cpp \
 Universe.cpp \
-Vector.cpp \
-Tally.cpp \
-Fission.cpp \
-MCSolver.cpp \
-Neutron.cpp
+Vector.cpp 
 
 cases = \
 gradients/one-directional/one-directional-gradient.cpp \

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -94,7 +94,6 @@ double Geometry::getWidthZ() {
  * @return the minimum x-coordinate (cm)
  */
 double Geometry::getMinX() {
-  std::cout << "get min x\n";
   return _root_universe->getMinX();
 }
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1292,3 +1292,18 @@ Cell* Geometry::findCellContainingFSR(int fsr_id) {
 
   return cell;
 }
+
+
+/**
+  * @brief  Resets the boundaries of each Universe in the Geometry
+  */
+void Geometry::resetBoundaries() {
+
+  std::map<int, Universe*> universes = getAllUniverses();
+  std::map<int, Universe*>::iterator u_iter;
+
+  /* Reset the boundaries in each Universe */
+  for (u_iter = universes.begin(); u_iter != universes.end(); ++u_iter)
+    u_iter->second->resetBoundaries();
+
+}

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -94,6 +94,7 @@ double Geometry::getWidthZ() {
  * @return the minimum x-coordinate (cm)
  */
 double Geometry::getMinX() {
+  std::cout << "get min x\n";
   return _root_universe->getMinX();
 }
 
@@ -1305,5 +1306,4 @@ void Geometry::resetBoundaries() {
   /* Reset the boundaries in each Universe */
   for (u_iter = universes.begin(); u_iter != universes.end(); ++u_iter)
     u_iter->second->resetBoundaries();
-
 }

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -175,6 +175,7 @@ public:
 					std::vector<double> grid_y,
 					double zcoord,
 					const char* domain_type="material");
+  void resetBoundaries();
 
   std::string toString();
   void printString();

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -842,6 +842,8 @@ void TrackGenerator::initializeTracks() {
 
   log_printf(INFO, "Computing azimuthal angles and track spacing...");
 
+  _geometry->resetBoundaries();
+
   /* Each element in arrays corresponds to an angle in phi_eff */
   /* Track spacing along x,y-axes, and perpendicular to each Track */
   double* dx_eff = new double[_num_azim_2];

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1656,7 +1656,7 @@ void Universe::calculateExtrema() {
 
       if (surf->getSurfaceType() == XPLANE && halfspace == +1 &&
           surf->getBoundaryType() != BOUNDARY_NONE)
-        return surf->getMinX(halfspace);
+        min_x = surf->getMinX(halfspace);
     }
   }
 
@@ -1680,7 +1680,7 @@ void Universe::calculateExtrema() {
       halfspace = s_iter->second->_halfspace;
       if (surf->getSurfaceType() == XPLANE && halfspace == -1 &&
           surf->getBoundaryType() != BOUNDARY_NONE)
-        return surf->getMaxX(halfspace);
+        max_x = surf->getMaxX(halfspace);
     }
   }
 
@@ -1705,7 +1705,7 @@ void Universe::calculateExtrema() {
 
       if (surf->getSurfaceType() == YPLANE && halfspace == +1 &&
           surf->getBoundaryType() != BOUNDARY_NONE)
-        return surf->getMinY(halfspace);
+        min_y = surf->getMinY(halfspace);
     }
   }
 
@@ -1728,7 +1728,7 @@ void Universe::calculateExtrema() {
       halfspace = s_iter->second->_halfspace;
       if (surf->getSurfaceType() == YPLANE && halfspace == -1 &&
           surf->getBoundaryType() != BOUNDARY_NONE)
-        return surf->getMaxY(halfspace);
+        max_y = surf->getMaxY(halfspace);
     }
   }
 

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -68,6 +68,8 @@ Universe::Universe(const int id, const char* name) {
   _type = SIMPLE;
 
   _cell_added = true;
+  _boundary_types_not_updated = true;
+
 
   /* By default, the Universe's fissionability is unknown */
   _fissionable = false;
@@ -216,27 +218,10 @@ double Universe::getMaxZ() {
  */
 boundaryType Universe::getMinXBoundaryType() {
 
-  std::map<int, Cell*>::iterator c_iter;
-  std::map<int, surface_halfspace*>::iterator s_iter;
-  Surface* surf;
-  int halfspace;
-  boundaryType bc_x = BOUNDARY_NONE;
+  if (_boundary_types_not_updated)
+    calculateBoundaryTypes();
 
-  /* Check if the universe contains a cell with an x-min boundary */
-  for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
-    std::map<int, surface_halfspace*>surfs = c_iter->second->getSurfaces();
-
-    for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
-      surf = s_iter->second->_surface;
-      halfspace = s_iter->second->_halfspace;
-
-      if (surf->getSurfaceType() == XPLANE && halfspace == +1 &&
-          surf->getBoundaryType() != BOUNDARY_NONE)
-        bc_x = surf->getBoundaryType();
-    }
-  }
-
-  return bc_x;
+  return _min_x_bound;
 }
 
 
@@ -247,27 +232,10 @@ boundaryType Universe::getMinXBoundaryType() {
  */
 boundaryType Universe::getMaxXBoundaryType() {
 
-  std::map<int, Cell*>::iterator c_iter;
-  std::map<int, surface_halfspace*>::iterator s_iter;
-  Surface* surf;
-  int halfspace;
-  boundaryType bc_x = BOUNDARY_NONE;
+  if (_boundary_types_not_updated)
+    calculateBoundaryTypes();
 
-  /* Check if the universe contains a cell with an x-min boundary */
-  for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
-    std::map<int, surface_halfspace*>surfs = c_iter->second->getSurfaces();
-
-    for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
-      surf = s_iter->second->_surface;
-      halfspace = s_iter->second->_halfspace;
-
-      if (surf->getSurfaceType() == XPLANE && halfspace == -1 &&
-          surf->getBoundaryType() != BOUNDARY_NONE)
-        bc_x = surf->getBoundaryType();
-    }
-  }
-
-  return bc_x;
+  return _max_x_bound;
 }
 
 
@@ -278,27 +246,10 @@ boundaryType Universe::getMaxXBoundaryType() {
  */
 boundaryType Universe::getMinYBoundaryType() {
 
-  std::map<int, Cell*>::iterator c_iter;
-  std::map<int, surface_halfspace*>::iterator s_iter;
-  Surface* surf;
-  int halfspace;
-  boundaryType bc_y = BOUNDARY_NONE;
+  if (_boundary_types_not_updated)
+    calculateBoundaryTypes();
 
-  /* Check if the universe contains a cell with an x-min boundary */
-  for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
-    std::map<int, surface_halfspace*>surfs = c_iter->second->getSurfaces();
-
-    for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
-      surf = s_iter->second->_surface;
-      halfspace = s_iter->second->_halfspace;
-
-      if (surf->getSurfaceType() == YPLANE && halfspace == +1 &&
-          surf->getBoundaryType() != BOUNDARY_NONE)
-        bc_y = surf->getBoundaryType();
-    }
-  }
-
-  return bc_y;
+  return _min_y_bound;
 }
 
 
@@ -309,27 +260,10 @@ boundaryType Universe::getMinYBoundaryType() {
  */
 boundaryType Universe::getMaxYBoundaryType() {
 
-  std::map<int, Cell*>::iterator c_iter;
-  std::map<int, surface_halfspace*>::iterator s_iter;
-  Surface* surf;
-  int halfspace;
-  boundaryType bc_y = BOUNDARY_NONE;
+  if (_boundary_types_not_updated)
+    calculateBoundaryTypes();
 
-  /* Check if the universe contains a cell with an x-min boundary */
-  for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
-    std::map<int, surface_halfspace*>surfs = c_iter->second->getSurfaces();
-
-    for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
-      surf = s_iter->second->_surface;
-      halfspace = s_iter->second->_halfspace;
-
-      if (surf->getSurfaceType() == YPLANE && halfspace == -1 &&
-          surf->getBoundaryType() != BOUNDARY_NONE)
-        bc_y = surf->getBoundaryType();
-    }
-  }
-
-  return bc_y;
+  return _max_y_bound;
 }
 
 
@@ -505,6 +439,7 @@ void Universe::addCell(Cell* cell) {
   }
 
   _cell_added = true;
+  _boundary_types_not_updated = true;
 }
 
 
@@ -517,6 +452,7 @@ void Universe::removeCell(Cell* cell) {
     _cells.erase(cell->getId());
 
   _cell_added = true;
+  _boundary_types_not_updated = true;
 }
 
 
@@ -1763,3 +1699,102 @@ void Universe::calculateExtrema() {
 
   _cell_added = false;
 }
+
+
+/**
+  * @brief  Calculates the boundary conditions (VACUUM or REFLECTIVE at the
+  *         maximum and minimum reachable coordinates in the Universe
+  */
+void Universe::calculateBoundaryTypes() {
+
+  /* Calculate the boundary condition at the minimum 
+   * reachable x-coordinate in the Universe and store it in _min_x_bound.
+   */
+  std::map<int, Cell*>::iterator c_iter;
+  std::map<int, surface_halfspace*>::iterator s_iter;
+  Surface* surf;
+  int halfspace;
+  boundaryType bc_x_min = BOUNDARY_NONE;
+
+  /* Check if the universe contains a cell with an x-min boundary */
+  for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
+    std::map<int, surface_halfspace*>surfs = c_iter->second->getSurfaces();
+
+    for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
+      surf = s_iter->second->_surface;
+      halfspace = s_iter->second->_halfspace;
+
+      if (surf->getSurfaceType() == XPLANE && halfspace == +1 &&
+          surf->getBoundaryType() != BOUNDARY_NONE)
+        bc_x_min = surf->getBoundaryType();
+    }
+  }
+
+  _min_x_bound = bc_x_min;
+
+  /* Calculate the boundary condition at the maximum 
+   * reachable x-coordinate in the Universe and store it in _max_x_bound.
+   */
+  boundaryType bc_x_max = BOUNDARY_NONE;
+
+  /* Check if the universe contains a cell with an x-min boundary */
+  for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
+    std::map<int, surface_halfspace*>surfs = c_iter->second->getSurfaces();
+
+    for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
+      surf = s_iter->second->_surface;
+      halfspace = s_iter->second->_halfspace;
+
+      if (surf->getSurfaceType() == XPLANE && halfspace == -1 &&
+          surf->getBoundaryType() != BOUNDARY_NONE)
+        bc_x_max = surf->getBoundaryType();
+    }
+  }
+
+  _max_x_bound = bc_x_max;
+
+  /* Calculate the boundary condition at the minimum 
+   * reachable y-coordinate in the Universe and store it in _min_y_bound.
+   */
+  boundaryType bc_y_min = BOUNDARY_NONE;
+
+  /* Check if the universe contains a cell with an x-min boundary */
+  for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
+    std::map<int, surface_halfspace*>surfs = c_iter->second->getSurfaces();
+
+    for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
+      surf = s_iter->second->_surface;
+      halfspace = s_iter->second->_halfspace;
+
+      if (surf->getSurfaceType() == YPLANE && halfspace == +1 &&
+          surf->getBoundaryType() != BOUNDARY_NONE)
+        bc_y_min = surf->getBoundaryType();
+    }
+  }
+
+  _min_y_bound = bc_y_min;
+
+  /* Calculate the boundary condition at the maximum 
+   * reachable y-coordinate in the Universe and store it in _max_y_bound.
+   */
+  boundaryType bc_y_max = BOUNDARY_NONE;
+
+  /* Check if the universe contains a cell with an x-min boundary */
+  for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
+    std::map<int, surface_halfspace*>surfs = c_iter->second->getSurfaces();
+
+    for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
+      surf = s_iter->second->_surface;
+      halfspace = s_iter->second->_halfspace;
+
+      if (surf->getSurfaceType() == YPLANE && halfspace == -1 &&
+          surf->getBoundaryType() != BOUNDARY_NONE)
+        bc_y_max = surf->getBoundaryType();
+    }
+  }
+
+  _max_y_bound = bc_y_max;
+
+  _boundary_types_not_updated = false;
+}
+

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -67,8 +67,7 @@ Universe::Universe(const int id, const char* name) {
 
   _type = SIMPLE;
 
-  _cell_added = true;
-  _boundary_types_not_updated = true;
+  _boundaries_not_updated = true;
 
 
   /* By default, the Universe's fissionability is unknown */
@@ -139,8 +138,8 @@ int Universe::getNumCells() const {
  */
 double Universe::getMinX() {
 
-  if (_cell_added)
-    calculateExtrema();
+  if (_boundaries_not_updated)
+    calculateBoundaries();
 
   return _min_x;
 }
@@ -152,8 +151,8 @@ double Universe::getMinX() {
  */
 double Universe::getMaxX() {
 
-  if (_cell_added)
-    calculateExtrema();
+  if (_boundaries_not_updated)
+    calculateBoundaries();
 
   return _max_x;
 }
@@ -165,8 +164,8 @@ double Universe::getMaxX() {
  */
 double Universe::getMinY() {
 
-  if (_cell_added)
-    calculateExtrema();
+  if (_boundaries_not_updated)
+    calculateBoundaries();
 
   return _min_y;
 }
@@ -178,8 +177,8 @@ double Universe::getMinY() {
  */
 double Universe::getMaxY() {
 
-  if (_cell_added)
-    calculateExtrema();
+  if (_boundaries_not_updated)
+    calculateBoundaries();
 
   return _max_y;
 }
@@ -191,8 +190,8 @@ double Universe::getMaxY() {
  */
 double Universe::getMinZ() {
 
-  if (_cell_added)
-    calculateExtrema();
+  if (_boundaries_not_updated)
+    calculateBoundaries();
 
   return _min_z;
 }
@@ -204,8 +203,8 @@ double Universe::getMinZ() {
  */
 double Universe::getMaxZ() {
 
-  if (_cell_added)
-    calculateExtrema();
+  if (_boundaries_not_updated)
+    calculateBoundaries();
 
   return _max_z;
 }
@@ -218,8 +217,8 @@ double Universe::getMaxZ() {
  */
 boundaryType Universe::getMinXBoundaryType() {
 
-  if (_boundary_types_not_updated)
-    calculateBoundaryTypes();
+  if (_boundaries_not_updated)
+    calculateBoundaries();
 
   return _min_x_bound;
 }
@@ -232,8 +231,8 @@ boundaryType Universe::getMinXBoundaryType() {
  */
 boundaryType Universe::getMaxXBoundaryType() {
 
-  if (_boundary_types_not_updated)
-    calculateBoundaryTypes();
+  if (_boundaries_not_updated)
+    calculateBoundaries();
 
   return _max_x_bound;
 }
@@ -246,8 +245,8 @@ boundaryType Universe::getMaxXBoundaryType() {
  */
 boundaryType Universe::getMinYBoundaryType() {
 
-  if (_boundary_types_not_updated)
-    calculateBoundaryTypes();
+  if (_boundaries_not_updated)
+    calculateBoundaries();
 
   return _min_y_bound;
 }
@@ -260,8 +259,8 @@ boundaryType Universe::getMinYBoundaryType() {
  */
 boundaryType Universe::getMaxYBoundaryType() {
 
-  if (_boundary_types_not_updated)
-    calculateBoundaryTypes();
+  if (_boundaries_not_updated)
+    calculateBoundaries();
 
   return _max_y_bound;
 }
@@ -438,8 +437,7 @@ void Universe::addCell(Cell* cell) {
                " ID = %d. Backtrace:\n%s", cell, _id, e.what());
   }
 
-  _cell_added = true;
-  _boundary_types_not_updated = true;
+  _boundaries_not_updated = true;
 }
 
 
@@ -451,8 +449,7 @@ void Universe::removeCell(Cell* cell) {
   if (_cells.find(cell->getId()) != _cells.end())
     _cells.erase(cell->getId());
 
-  _cell_added = true;
-  _boundary_types_not_updated = true;
+  _boundaries_not_updated = true;
 }
 
 
@@ -1570,10 +1567,11 @@ int Lattice::getLatticeSurface(int cell, Point* point) {
 
 
 /**
-  * @brief  Calculates the extrema of the geometry and saves them to local
-  *         variables. _cell_added is set to false
+  * @brief  Calculates the boundary locations and 
+  *         conditions (VACUUM or REFLECTIVE) at the
+  *         maximum and minimum reachable coordinates in the Universe
   */
-void Universe::calculateExtrema() {
+void Universe::calculateBoundaries() {
 
   /* Calculate the minimum reachable x-coordinate in the geometry and store it
    * in _x_min */
@@ -1697,23 +1695,9 @@ void Universe::calculateExtrema() {
 
   _max_z = max_z;
 
-  _cell_added = false;
-}
-
-
-/**
-  * @brief  Calculates the boundary conditions (VACUUM or REFLECTIVE at the
-  *         maximum and minimum reachable coordinates in the Universe
-  */
-void Universe::calculateBoundaryTypes() {
-
   /* Calculate the boundary condition at the minimum 
    * reachable x-coordinate in the Universe and store it in _min_x_bound.
    */
-  std::map<int, Cell*>::iterator c_iter;
-  std::map<int, surface_halfspace*>::iterator s_iter;
-  Surface* surf;
-  int halfspace;
   boundaryType bc_x_min = BOUNDARY_NONE;
 
   /* Check if the universe contains a cell with an x-min boundary */
@@ -1795,6 +1779,14 @@ void Universe::calculateBoundaryTypes() {
 
   _max_y_bound = bc_y_max;
 
-  _boundary_types_not_updated = false;
+  _boundaries_not_updated = false;
 }
 
+/**
+  * @brief  sets _boundaries_not_updated to true so boundaries will be
+  *         recalculated if needed
+  */
+void Universe::resetBoundaries() {
+
+  _boundaries_not_updated = true;
+}

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1639,7 +1639,8 @@ int Lattice::getLatticeSurface(int cell, Point* point) {
   */
 void Universe::calculateExtrema() {
 
-  // min x
+  /* Calculate the minimum reachable x-coordinate in the geometry and store it
+   * in _x_min */
   double min_x = -std::numeric_limits<double>::infinity();
   std::map<int, Cell*>::iterator c_iter;
   std::map<int, surface_halfspace*>::iterator s_iter;
@@ -1667,8 +1668,8 @@ void Universe::calculateExtrema() {
 
   _min_x = min_x;
 
-
-  // max x
+  /* Calculate the maximum reachable x-coordinate in the geometry and store it
+   * in _x_max */
   double max_x = std::numeric_limits<double>::infinity();
 
   /* Check if the universe contains a cell with an x-max boundary */
@@ -1692,7 +1693,8 @@ void Universe::calculateExtrema() {
   _max_x = max_x;
 
 
-  // min y
+  /* Calculate the minimum reachable y-coordinate in the geometry and store it
+   * in _y_min */
   double min_y = -std::numeric_limits<double>::infinity();
 
   /* Check if the universe contains a cell with an y-min boundary */
@@ -1716,7 +1718,8 @@ void Universe::calculateExtrema() {
 
   _min_y = min_y;
 
-  // max y
+  /* Calculate the maximum reachable y-coordinate in the geometry and store it
+   * in _y_max */
   double max_y = std::numeric_limits<double>::infinity();
 
   /* Check if the universe contains a cell with an y-max boundary */
@@ -1739,7 +1742,8 @@ void Universe::calculateExtrema() {
 
   _max_y = max_y;
 
-  //min z
+  /* Calculate the minimum reachable z-coordinate in the geometry and store it
+   * in _z_min */
   double min_z = -std::numeric_limits<double>::infinity();
   std::map<int, Cell*>::iterator iter;
 
@@ -1748,7 +1752,8 @@ void Universe::calculateExtrema() {
 
   _min_z = min_z;
 
-  // max z
+  /* Calculate the maximum reachable z-coordinate in the geometry and store it
+   * in _z_max */
   double max_z = std::numeric_limits<double>::infinity();
 
   for (iter = _cells.begin(); iter != _cells.end(); ++iter)

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1695,7 +1695,7 @@ void Universe::calculateBoundaries() {
   _max_z = max_z;
 
   /* Calculate the boundary condition at the minimum 
-   * reachable x-coordinate in the Universe and store it in _min_x_bound.
+   * reachable x-coordinate in the Universe and store it in _min_x_bound
    */
   boundaryType bc_x_min = BOUNDARY_NONE;
 
@@ -1716,7 +1716,7 @@ void Universe::calculateBoundaries() {
   _min_x_bound = bc_x_min;
 
   /* Calculate the boundary condition at the maximum 
-   * reachable x-coordinate in the Universe and store it in _max_x_bound.
+   * reachable x-coordinate in the Universe and store it in _max_x_bound
    */
   boundaryType bc_x_max = BOUNDARY_NONE;
 
@@ -1737,7 +1737,7 @@ void Universe::calculateBoundaries() {
   _max_x_bound = bc_x_max;
 
   /* Calculate the boundary condition at the minimum 
-   * reachable y-coordinate in the Universe and store it in _min_y_bound.
+   * reachable y-coordinate in the Universe and store it in _min_y_bound
    */
   boundaryType bc_y_min = BOUNDARY_NONE;
 
@@ -1758,7 +1758,7 @@ void Universe::calculateBoundaries() {
   _min_y_bound = bc_y_min;
 
   /* Calculate the boundary condition at the maximum 
-   * reachable y-coordinate in the Universe and store it in _max_y_bound.
+   * reachable y-coordinate in the Universe and store it in _max_y_bound
    */
   boundaryType bc_y_max = BOUNDARY_NONE;
 
@@ -1786,6 +1786,5 @@ void Universe::calculateBoundaries() {
   *         recalculated if needed
   */
 void Universe::resetBoundaries() {
-
   _boundaries_inspected = false;
 }

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -137,7 +137,7 @@ int Universe::getNumCells() const {
  */
 double Universe::getMinX() {
 
-  if (!boundaries_inspected)
+  if (!_boundaries_inspected)
     calculateBoundaries();
 
   return _min_x;
@@ -150,7 +150,7 @@ double Universe::getMinX() {
  */
 double Universe::getMaxX() {
 
-  if (!boundaries_inspected)
+  if (!_boundaries_inspected)
     calculateBoundaries();
 
   return _max_x;
@@ -163,7 +163,7 @@ double Universe::getMaxX() {
  */
 double Universe::getMinY() {
 
-  if (!boundaries_inspected)
+  if (!_boundaries_inspected)
     calculateBoundaries();
 
   return _min_y;
@@ -176,7 +176,7 @@ double Universe::getMinY() {
  */
 double Universe::getMaxY() {
 
-  if (!boundaries_inspected)
+  if (!_boundaries_inspected)
     calculateBoundaries();
 
   return _max_y;
@@ -189,7 +189,7 @@ double Universe::getMaxY() {
  */
 double Universe::getMinZ() {
 
-  if (!boundaries_inspected)
+  if (!_boundaries_inspected)
     calculateBoundaries();
 
   return _min_z;
@@ -202,7 +202,7 @@ double Universe::getMinZ() {
  */
 double Universe::getMaxZ() {
 
-  if (!boundaries_inspected)
+  if (!_boundaries_inspected)
     calculateBoundaries();
 
   return _max_z;
@@ -216,7 +216,7 @@ double Universe::getMaxZ() {
  */
 boundaryType Universe::getMinXBoundaryType() {
 
-  if (!boundaries_inspected)
+  if (!_boundaries_inspected)
     calculateBoundaries();
 
   return _min_x_bound;
@@ -230,7 +230,7 @@ boundaryType Universe::getMinXBoundaryType() {
  */
 boundaryType Universe::getMaxXBoundaryType() {
 
-  if (!boundaries_inspected)
+  if (!_boundaries_inspected)
     calculateBoundaries();
 
   return _max_x_bound;
@@ -244,7 +244,7 @@ boundaryType Universe::getMaxXBoundaryType() {
  */
 boundaryType Universe::getMinYBoundaryType() {
 
-  if (!boundaries_inspected)
+  if (!_boundaries_inspected)
     calculateBoundaries();
 
   return _min_y_bound;
@@ -258,7 +258,7 @@ boundaryType Universe::getMinYBoundaryType() {
  */
 boundaryType Universe::getMaxYBoundaryType() {
 
-  if (!boundaries_inspected)
+  if (!_boundaries_inspected)
     calculateBoundaries();
 
   return _max_y_bound;

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -67,8 +67,7 @@ Universe::Universe(const int id, const char* name) {
 
   _type = SIMPLE;
 
-  _boundaries_not_updated = true;
-
+  _boundaries_inspected = false;
 
   /* By default, the Universe's fissionability is unknown */
   _fissionable = false;
@@ -138,7 +137,7 @@ int Universe::getNumCells() const {
  */
 double Universe::getMinX() {
 
-  if (_boundaries_not_updated)
+  if (!boundaries_inspected)
     calculateBoundaries();
 
   return _min_x;
@@ -151,7 +150,7 @@ double Universe::getMinX() {
  */
 double Universe::getMaxX() {
 
-  if (_boundaries_not_updated)
+  if (!boundaries_inspected)
     calculateBoundaries();
 
   return _max_x;
@@ -164,7 +163,7 @@ double Universe::getMaxX() {
  */
 double Universe::getMinY() {
 
-  if (_boundaries_not_updated)
+  if (!boundaries_inspected)
     calculateBoundaries();
 
   return _min_y;
@@ -177,7 +176,7 @@ double Universe::getMinY() {
  */
 double Universe::getMaxY() {
 
-  if (_boundaries_not_updated)
+  if (!boundaries_inspected)
     calculateBoundaries();
 
   return _max_y;
@@ -190,7 +189,7 @@ double Universe::getMaxY() {
  */
 double Universe::getMinZ() {
 
-  if (_boundaries_not_updated)
+  if (!boundaries_inspected)
     calculateBoundaries();
 
   return _min_z;
@@ -203,7 +202,7 @@ double Universe::getMinZ() {
  */
 double Universe::getMaxZ() {
 
-  if (_boundaries_not_updated)
+  if (!boundaries_inspected)
     calculateBoundaries();
 
   return _max_z;
@@ -217,7 +216,7 @@ double Universe::getMaxZ() {
  */
 boundaryType Universe::getMinXBoundaryType() {
 
-  if (_boundaries_not_updated)
+  if (!boundaries_inspected)
     calculateBoundaries();
 
   return _min_x_bound;
@@ -231,7 +230,7 @@ boundaryType Universe::getMinXBoundaryType() {
  */
 boundaryType Universe::getMaxXBoundaryType() {
 
-  if (_boundaries_not_updated)
+  if (!boundaries_inspected)
     calculateBoundaries();
 
   return _max_x_bound;
@@ -245,7 +244,7 @@ boundaryType Universe::getMaxXBoundaryType() {
  */
 boundaryType Universe::getMinYBoundaryType() {
 
-  if (_boundaries_not_updated)
+  if (!boundaries_inspected)
     calculateBoundaries();
 
   return _min_y_bound;
@@ -259,7 +258,7 @@ boundaryType Universe::getMinYBoundaryType() {
  */
 boundaryType Universe::getMaxYBoundaryType() {
 
-  if (_boundaries_not_updated)
+  if (!boundaries_inspected)
     calculateBoundaries();
 
   return _max_y_bound;
@@ -437,7 +436,7 @@ void Universe::addCell(Cell* cell) {
                " ID = %d. Backtrace:\n%s", cell, _id, e.what());
   }
 
-  _boundaries_not_updated = true;
+  _boundaries_inspected = false;
 }
 
 
@@ -449,7 +448,7 @@ void Universe::removeCell(Cell* cell) {
   if (_cells.find(cell->getId()) != _cells.end())
     _cells.erase(cell->getId());
 
-  _boundaries_not_updated = true;
+  _boundaries_inspected = false;
 }
 
 
@@ -1779,7 +1778,7 @@ void Universe::calculateBoundaries() {
 
   _max_y_bound = bc_y_max;
 
-  _boundaries_not_updated = false;
+  _boundaries_inspected = true;
 }
 
 /**
@@ -1788,5 +1787,5 @@ void Universe::calculateBoundaries() {
   */
 void Universe::resetBoundaries() {
 
-  _boundaries_not_updated = true;
+  _boundaries_inspected = false;
 }

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -89,8 +89,8 @@ protected:
   double _min_z;
   double _max_z;
 
-  /** A flag for determining if extrema are up to date */
-  bool _cell_added;
+  /** A flag for determining if boundaries are up to date */
+  bool _boundaries_not_updated;
 
   /** The boundaryTypes of the universe */
   boundaryType _min_x_bound;
@@ -98,8 +98,6 @@ protected:
   boundaryType _min_y_bound;
   boundaryType _max_y_bound;
 
-  /** A flag for determining if boundaries are up to date */
-  bool _boundary_types_not_updated;
 
 public:
 
@@ -128,8 +126,8 @@ public:
   std::map<int, Universe*> getAllUniverses();
   bool isFissionable();
 
-  void calculateExtrema();
-  void calculateBoundaryTypes();
+  void resetBoundaries();
+  void calculateBoundaries();
   void setName(const char* name);
   void setType(universeType type);
   void addCell(Cell* cell);

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -90,7 +90,7 @@ protected:
   double _max_z;
 
   /** A flag for determining if boundaries are up to date */
-  bool _boundaries_not_updated;
+  bool _boundaries_inspected;
 
   /** The boundaryTypes of the universe */
   boundaryType _min_x_bound;

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -98,7 +98,6 @@ protected:
   boundaryType _min_y_bound;
   boundaryType _max_y_bound;
 
-
 public:
 
   Universe(const int id=-1, const char* name="");

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -92,6 +92,15 @@ protected:
   /** A flag for determining if extrema are up to date */
   bool _cell_added;
 
+  /** The boundaryTypes of the universe */
+  boundaryType _min_x_bound;
+  boundaryType _max_x_bound;
+  boundaryType _min_y_bound;
+  boundaryType _max_y_bound;
+
+  /** A flag for determining if boundaries are up to date */
+  bool _boundary_types_not_updated;
+
 public:
 
   Universe(const int id=-1, const char* name="");
@@ -120,6 +129,7 @@ public:
   bool isFissionable();
 
   void calculateExtrema();
+  void calculateBoundaryTypes();
   void setName(const char* name);
   void setType(universeType type);
   void addCell(Cell* cell);

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -81,6 +81,17 @@ protected:
    *  with a non-zero fission cross-section and is fissionable */
   bool _fissionable;
 
+  /** The extrema of the Universe */
+  double _min_x;
+  double _max_x;
+  double _min_y;
+  double _max_y;
+  double _min_z;
+  double _max_z;
+
+  /** A flag for determining if extrema are up to date */
+  bool _cell_added;
+
 public:
 
   Universe(const int id=-1, const char* name="");
@@ -108,6 +119,7 @@ public:
   std::map<int, Universe*> getAllUniverses();
   bool isFissionable();
 
+  void calculateExtrema();
   void setName(const char* name);
   void setType(universeType type);
   void addCell(Cell* cell);


### PR DESCRIPTION
This is very similar to the "Created local variables to store Universe extrema" PR. Variables were made to store each boundaryType in the Universe. When getMinXBoundaryType() or a similar function is called, the boundary types are only recalculated (using a new function calculateBoundaryTypes()) if cells have been added to or removed from the Universe since the boundary types were last calculated.
