### PR TITLE
Fix for performance problem in transport sweeps

### DIFF
--- a/src/TrackTraversingAlgorithms.h
+++ b/src/TrackTraversingAlgorithms.h
@@ -58,10 +58,12 @@ class TransportSweep: public TraverseTracks {
 private:
 
   CPUSolver* _cpu_solver;
+  FP_PRECISION** _thread_fsr_fluxes;
 
 public:
 
   TransportSweep(TrackGenerator* track_generator);
+  virtual ~TransportSweep();
   void setCPUSolver(CPUSolver* cpu_solver);
   void execute();
   void onTrack(Track* track, segment* segments);


### PR DESCRIPTION
This PR addresses a problem that caused the transport sweeps to be very slow after the TraverseTracks abstraction update. Previously the number of groups was calculated by looping through all materials in order to allocate a temporary array. This would be computed for every Track during the transport sweep. Now that array has been made a class variable so the temporary allocation only occurs once per sweep.