### PR TITLE
Fix and documentation for Krylov subspace methods

### DIFF
--- a/docs/source/methods/index.rst
+++ b/docs/source/methods/index.rst
@@ -14,3 +14,4 @@ Theory and Methodology
     constructive_solid_geometry
     track_generation
     cmfd
+    krylov

--- a/docs/source/methods/krylov.rst
+++ b/docs/source/methods/krylov.rst
@@ -1,0 +1,53 @@
+.. _krylov:
+
+=======================
+Krylov Subspace Methods
+=======================
+
+The MOC equations are traditionally solved using a non-linear power iteration method.  This is not the only way to solve MOC, but many of the alternatives require the equations to be rewritten in a linear fashion.  To convert into a linear operator form, we need to essentially repeat the derivation shown in :ref:`Section 2 <method_of_characteristics>`, with a slight modification.  Starting with the Boltzmann transport equation:
+
+.. math::
+   \mathbf{\Omega} \cdot \nabla \Psi(\mathbf{r},\mathbf{\Omega},E) + \Sigma^T(\mathbf{r},E)\Psi(\mathbf{r},\mathbf{\Omega},E) = \int_{0}^{\infty} \mathrm{d}E' \int_{4\pi} \mathrm{d}\mathbf{\Omega'}\Sigma^S(\mathbf{r},{\mathbf{\Omega'}\rightarrow\mathbf{\Omega}},{E'\rightarrow E}) \Psi(\mathbf{r},\mathbf{\Omega'},E') + \frac{\chi(\mathbf{r},E)}{4\pi k_{eff}} \int_{0}^{\infty} \mathrm{d}E' \nu\Sigma^F(\mathbf{r},E') \int_{4\pi} \mathrm{d}\mathbf{\Omega'}\Psi(\mathbf{r},\mathbf{\Omega'},E')
+
+Instead of replacing the right hand side with :math:`Q(\mathbf{r}, \mathbf{\Omega}, E)`, we replace it with a fission and a scatter source.  The idea is to factor out the eigenvalue.  The resulting source terms are:
+
+**Scatter Source**
+
+.. math::
+   Q^S(\mathbf{r}, \mathbf{\Omega}, E) &= \int_{0}^{\infty} \mathrm{d}E' \int_{4\pi} \mathrm{d}\mathbf{\Omega'}\Sigma^S(\mathbf{r},{\mathbf{\Omega'}\rightarrow\mathbf{\Omega}},{E'\rightarrow E}) \Psi(\mathbf{r},\mathbf{\Omega'},E')
+
+**Fission Source**
+
+.. math::
+   \frac{1}{k_\text{eff}} Q^F(\mathbf{r}, \mathbf{\Omega}, E) &= \frac{\chi(\mathbf{r},E)}{4\pi k_\text{eff}} \int_{0}^{\infty} \mathrm{d}E' \nu\Sigma^F(\mathbf{r},E') \int_{4\pi} \mathrm{d}\mathbf{\Omega'}\Psi(\mathbf{r},\mathbf{\Omega'},E')
+
+Similar to before, the transport equation can be more concisely written as:
+
+.. math::
+   \mathbf{\Omega} \cdot \nabla \Psi(\mathbf{r},\mathbf{\Omega},E) + \Sigma^T(\mathbf{r},E)\Psi(\mathbf{r},\mathbf{\Omega},E) =  Q^S(\mathbf{r}, \mathbf{\Omega}, E) +\frac{1}{k_\text{eff}} Q^F(\mathbf{r}, \mathbf{\Omega}, E)
+
+From here, we follow the exact same process all the way to the end.  The MOC sweep operator :math:`\mathcal{T}` (explicitly for a vacuum boundary condition, as non-vacuum conditions add another non-linearity) is given by the following equation:
+
+.. math::
+   \Phi_{i,g} = \mathcal{T}(Q_{i,g}) \Phi_{i,g} &= \frac{4\pi}{\Sigma_{i,g}}\left[Q_{i,g} + \frac{1}{A_i}\displaystyle\sum\limits_{k\in A_{i}}\omega_{m(k)}\omega_{p(k)}\omega_{k}\sin\theta_{p(k)}\Delta\Psi_{k,i,g}(Q_{i,g}) \right]
+
+Since this is the linear Boltzmann transport equation, we can separate the sources (as was done earlier), solve for them separately, and add the results back together.  Each source will generate its own angular fluxes as well.
+
+.. math::
+   \Phi_{i,g} = \mathcal{T}(Q^S_{i,g}) \Phi_{i,g} + \frac{1}{k_\text{eff}}\mathcal{T}(Q^F_{i,g}) \Phi_{i,g}
+
+One can now view the above equation in the light of linear algebra, as each of these new :math:`\mathcal{T}` operators no longer have any dependence on the eigenvalue, and are themselves linear with respect to the flux.  They can now be treated as linear operators and manipulated.
+
+.. math::
+   \Phi &= \mathcal{T}(Q^S) \Phi + \frac{1}{k_\text{eff}} \mathcal{T} (Q^F) \Phi
+   
+.. math::
+   \Phi &= \mathbf{T}_S \Phi + \frac{1}{k_\text{eff}} \mathbf{T}_F \Phi
+
+.. math::
+   k_\text{eff}\left(\mathbf{I} - \mathbf{T}_S\right) \Phi &= \mathbf{T}_F \Phi
+
+.. math::
+   k_\text{eff} \Phi &= \left(\mathbf{I} - \mathbf{T}_S\right)^{-1}\mathbf{T}_F \Phi
+
+As each term here is not defined as a matrix, but as a linear operator, any algorithm that operates on it must necessarily only use operator-vector products.  Krylov subspace algorithms, such as the generalized minimal residual method (GMRES) for the inversion, and implicitly restarted Arnoldi iteration (IRAM) for the eigenvalue problem itself, are ideal.  IRAM also gives the added benefit of being able to calculate multiple eigenmodes of the problem, which can be used in stability analysis and dominance ratio calculations.

--- a/openmoc/krylov.py
+++ b/openmoc/krylov.py
@@ -106,12 +106,9 @@ class IRAMSolver(object):
         # Set solution-dependent class attributes based on parameters
         # These are accessed and used by the LinearOperators
         self._num_modes = num_modes
-        self._inner_method = inner_method
         self._outer_tol = outer_tol
-        self._inner_tol = inner_tol
-        self._interval = interval
 
-        self.initializeOperators(solver_mode)
+        self.initializeOperators(solver_mode, inner_method, inner_tol, interval)
 
         # Solve the eigenvalue problem
         timer = openmoc.Timer()
@@ -135,13 +132,20 @@ class IRAMSolver(object):
         # Restore the material data
         self._moc_solver.resetMaterials(solver_mode)
 
-    def initializeOperators(self, solver_mode=openmoc.FORWARD):
+    def initializeOperators(self, solver_mode=openmoc.FORWARD,
+                            inner_method='gmres', inner_tol=1e-6, interval=10):
         """Initialize the operators M, A, and F.
 
         Parameters
         ----------
         solver_mode : {openmoc.FORWARD, openmoc.ADJOINT}
             The type of eigenmodes to compute (default is openmoc.FORWARD)
+        inner_method : {'gmres', 'lgmres', 'bicgstab', 'cgs'}
+            Krylov subspace method used for the Ax=b solve (default is 'gmres')
+        inner_tol : Real
+            The tolerance on the inner Ax=b solve (default is 1E-5)
+        interval : Integral
+            The inner iteration interval for logging messages (default is 10)
         """
 
         import scipy.sparse.linalg as linalg
@@ -149,6 +153,12 @@ class IRAMSolver(object):
         # Initialize inner/outer iteration counters to zero
         self._m_count = 0
         self._a_count = 0
+        
+        # Set solution-dependent class attributes based on parameters
+        # These are accessed and used by the LinearOperators
+        self._inner_method = inner_method
+        self._inner_tol = inner_tol
+        self._interval = interval
 
         # Initialize MOC solver
         self._moc_solver.initializeFSRs()

--- a/openmoc/krylov.py
+++ b/openmoc/krylov.py
@@ -116,13 +116,12 @@ class IRAMSolver(object):
         self._a_count = 0
 
         # Initialize MOC solver
-        self._moc_solver.initializePolarQuadrature()
-        self._moc_solver.initializeExpEvaluator()
+        self._moc_solver.initializeFSRs()
         self._moc_solver.initializeMaterials(solver_mode)
+        self._moc_solver.countFissionableFSRs()
+        self._moc_solver.initializeExpEvaluator()
         self._moc_solver.initializeFluxArrays()
         self._moc_solver.initializeSourceArrays()
-        self._moc_solver.initializeFSRs()
-        self._moc_solver.countFissionableFSRs()
         self._moc_solver.zeroTrackFluxes()
 
         # Initialize SciPy operators

--- a/sample-input/krylov/adjoint-eigenmodes.py
+++ b/sample-input/krylov/adjoint-eigenmodes.py
@@ -52,6 +52,7 @@ openmoc.plotter.plot_materials(geometry, gridsize=500)
 openmoc.plotter.plot_cells(geometry, gridsize=500)
 openmoc.plotter.plot_flat_source_regions(geometry, gridsize=500)
 openmoc.plotter.plot_eigenmode_fluxes(iram_solver, gridsize=250,
-                                      energy_groups=[1,2,3,4,5,6,7])
+                                      energy_groups=[1,2,3,4,5,6,7],
+                                      eigenmodes=range(1,num_modes+1))
 
 openmoc.log.py_printf('TITLE', 'Finished')

--- a/sample-input/krylov/forward-eigenmodes.py
+++ b/sample-input/krylov/forward-eigenmodes.py
@@ -51,6 +51,7 @@ openmoc.plotter.plot_materials(geometry, gridsize=500)
 openmoc.plotter.plot_cells(geometry, gridsize=500)
 openmoc.plotter.plot_flat_source_regions(geometry, gridsize=500)
 openmoc.plotter.plot_eigenmode_fluxes(iram_solver, gridsize=250,
-                                      energy_groups=[1,2,3,4,5,6,7])
+                                      energy_groups=[1,2,3,4,5,6,7],
+                                      eigenmodes=range(1,num_modes+1))
 
 openmoc.log.py_printf('TITLE', 'Finished')


### PR DESCRIPTION
This pull request makes 4 changes. 
1. It fixes the memory allocation issues with the Krylov solver.
2. It ensures that the Krylov solver outputs plots.
3. It extracts the operator initialize tasks into a separate function, so that users can play with the operators themselves.
4. It adds documentation on how the method was derived.

The documentation is fairly terse and just kinda tacked on into the middle of nowhere, so any comments would be great.