### PR TITLE
Fixed bug in Lattice desctructor

### DIFF
--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -843,8 +843,8 @@ Lattice::Lattice(const int id, const char* name): Universe(id, name) {
 Lattice::~Lattice() {
 
   /* Clear the triple-nested vector of Universes */
-  for (int k=0; k < _num_z; k++) {
-    for (int j=0; j < _num_y; j++)
+  for (int k=0; k < _universes.size(); k++) {
+    for (int j=0; j < _universes.at(k).size(); j++)
       _universes.at(k).at(j).clear();
     _universes.at(k).clear();
   }


### PR DESCRIPTION
This bug potentially shows up whenever CMFD is used. Currently, the ``Lattice`` class destructor clears the local multi-dimensional ``_universes`` vector based on attributes ``_num_z`` and ``_num_y``. However it is possible to set ``_num_z`` and ``_num_y`` without any change to ``_universes``. Particularly the CMFD mesh is formed using a ``Lattice`` but does not fill in ``_universes`` since they are not needed for its purposes. Therefore, whenever the destructor is called to delete the ``Lattice``, it potentially goes outside the bounds of the ``_universes`` vector. This PR changes the ``Lattice`` destructor so that it clears the ``_universes`` vector based on its actual size rather than ``_num_z`` and ``_num_y``.