### PR TITLE
Support for multi-line headers and titles

### DIFF
--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -63,7 +63,7 @@ Material::Material(int id, const char* name) {
   _volume = 0.;
   _num_instances = 0;
 
-  /* Initialize a dummy number groups */
+  /* Initialize a dummy number of energy groups */
   _num_groups = -1;
 
   _sigma_t = NULL;
@@ -406,7 +406,7 @@ int Material::getNumVectorGroups() {
 
 
 /**
- * @brief Sets the name of the Material
+ * @brief Sets the name of the Material.
  * @param name the Material name string
  */
 void Material::setName(const char* name) {
@@ -547,7 +547,7 @@ void Material::setNumEnergyGroups(const int num_groups) {
  *
  *          NOTE: This routine will override an zero-valued cross-sections
  *          (e.g., in void or gap regions) with a minimum value of 1E-10 to
- *          void numerical issues in the MOC solver.
+ *          avoid numerical issues in the MOC solver.
  *
  * @param xs the array of total cross-sections
  * @param num_groups the number of energy groups

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -378,11 +378,11 @@ void log_printf(logLevel level, const char* format, ...) {
       }
     case (HEADER):
       {
-        std::string prefix = std::string("[  HEADER ]  ");
+        std::string level_prefix = std::string("[  HEADER ]  ");
 
         /* If message is too long for a line, split into many lines */
         if (int(msg.length()) > line_length)
-          msg_string = create_multiline_msg(prefix, msg);
+          msg_string = create_multiline_msg(level_prefix, msg);
 
         /* Puts message on single line */
         else{
@@ -393,22 +393,22 @@ void log_printf(logLevel level, const char* format, ...) {
                            (line_length - 4 - size) % 2, header_char);
           std::string prefix = std::string("[  HEADER ]  ");
           std::stringstream ss;
-          ss << prefix << pad1 << "  " << buffer << "  " << pad2 << "\n";
+          ss << level_prefix << pad1 << "  " << buffer << "  " << pad2 << "\n";
           msg_string = ss.str();
         }
         break;
       }
     case (TITLE):
       {
-        std::string prefix = std::string("[  TITLE  ]  ");
+        std::string level_prefix = std::string("[  TITLE  ]  ");
 
         /* If message is too long for a line, split into many lines */
         if (int(msg.length()) > line_length){
-          msg_string = create_multiline_msg(prefix, msg);
+          msg_string = create_multiline_msg(level_prefix, msg);
           std::stringstream ss;
-          ss << prefix << std::string(line_length, title_char) << "\n";
+          ss << level_prefix << std::string(line_length, title_char) << "\n";
           ss << msg_string;
-          ss << prefix << std::string(line_length, title_char) << "\n";
+          ss << level_prefix << std::string(line_length, title_char) << "\n";
           msg_string = ss.str();
         }
 
@@ -419,9 +419,9 @@ void log_printf(logLevel level, const char* format, ...) {
           std::string pad = std::string(halfpad, ' ');
 
           std::stringstream ss;
-          ss << prefix << std::string(line_length, title_char) << "\n";
-          ss << prefix << pad << buffer << pad << "\n";
-          ss << prefix << std::string(line_length, title_char) << "\n";
+          ss << level_prefix << std::string(line_length, title_char) << "\n";
+          ss << level_prefix << pad << buffer << pad << "\n";
+          ss << level_prefix << std::string(line_length, title_char) << "\n";
           msg_string = ss.str();
         }
         break;

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -557,7 +557,7 @@ std::string create_multiline_msg(std::string level, std::string message) {
     substring = message.substr(start, line_length);
 
     /* Begin multiline messages with ellipsis */
-    if (start != 0 and substring.back() != '*')
+    if (start != 0)
       msg_string += "... ";
 
     /* Truncate substring to last complete word */

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -370,9 +370,9 @@ void log_printf(logLevel level, const char* format, ...) {
     case (SEPARATOR):
       {
         std::string pad = std::string(line_length, separator_char);
-        std::string prefix = std::string("[SEPARATOR]  ");
+        std::string level_prefix = std::string("[SEPARATOR]  ");
         std::stringstream ss;
-        ss << prefix << pad << "\n";
+        ss << level_prefix << pad << "\n";
         msg_string = ss.str();
         break;
       }
@@ -391,7 +391,6 @@ void log_printf(logLevel level, const char* format, ...) {
           std::string pad1 = std::string(halfpad, header_char);
           std::string pad2 = std::string(halfpad +
                            (line_length - 4 - size) % 2, header_char);
-          std::string prefix = std::string("[  HEADER ]  ");
           std::stringstream ss;
           ss << level_prefix << pad1 << "  " << buffer << "  " << pad2 << "\n";
           msg_string = ss.str();

--- a/tests/test_logger/results_true.dat
+++ b/tests/test_logger/results_true.dat
@@ -1,6 +1,12 @@
 [  NORMAL ]  This is a normal message
 [SEPARATOR]  *******************************************************************
 [  HEADER ]  *******************  This is a header message  ********************
+[  HEADER ]  This is a very very very very very very very very very long header
+[  HEADER ]  ...  message
+[  TITLE  ]  *******************************************************************
+[  TITLE  ]  This is a very very very very very very very very very very long
+[  TITLE  ]  ...  title message
+[  TITLE  ]  *******************************************************************
 [  TITLE  ]  *******************************************************************
 [  TITLE  ]                        This is a title message                      
 [  TITLE  ]  *******************************************************************
@@ -10,6 +16,12 @@
 [  NORMAL ]  This is a normal message
 [SEPARATOR]  *******************************************************************
 [  HEADER ]  *******************  This is a header message  ********************
+[  HEADER ]  This is a very very very very very very very very very long header
+[  HEADER ]  ...  message
+[  TITLE  ]  *******************************************************************
+[  TITLE  ]  This is a very very very very very very very very very very long
+[  TITLE  ]  ...  title message
+[  TITLE  ]  *******************************************************************
 [  TITLE  ]  *******************************************************************
 [  TITLE  ]                        This is a title message                      
 [  TITLE  ]  *******************************************************************

--- a/tests/test_logger/test_logger.py
+++ b/tests/test_logger/test_logger.py
@@ -37,6 +37,10 @@ class LoggerTestHarness(TestHarness):
         openmoc.log_printf(openmoc.NORMAL, 'This is a normal message')
         openmoc.log_printf(openmoc.SEPARATOR, 'This is a separator message')
         openmoc.log_printf(openmoc.HEADER, 'This is a header message')
+        openmoc.log_printf(openmoc.HEADER, 'This is a very very very very very '
+             'very very very very long header message')
+        openmoc.log_printf(openmoc.TITLE, 'This is a very very very very very '
+             'very very very very very long title message')
         openmoc.log_printf(openmoc.TITLE, 'This is a title message')
         openmoc.log_printf(openmoc.WARNING, 'This is a warning message')
         openmoc.log_printf(openmoc.CRITICAL, 'This is a critical message')
@@ -48,6 +52,10 @@ class LoggerTestHarness(TestHarness):
         py_printf('NORMAL', 'This is a normal message')
         py_printf('SEPARATOR', 'This is a separator message')
         py_printf('HEADER', 'This is a header message')
+        py_printf('HEADER', 'This is a very very very very very '
+             'very very very very long header message')
+        py_printf('TITLE', 'This is a very very very very very '
+             'very very very very very long title message')
         py_printf('TITLE', 'This is a title message')
         py_printf('WARNING', 'This is a warning message')
         py_printf('CRITICAL', 'This is a critical message')


### PR DESCRIPTION
- Changed log.cpp for multi-line titles and headers, using existing function create_multi_line_msg
- Added arguments for "filling the paddings" on both sides of the title and header messages (that are centered) (removed)
- took into account parity of number of characters to make title well centered and nice even when odd/even number of characters in it (or in level) (removed)
- updated test_plotter.py and results_true.dat

To meet Issue #229 raised by @samuelshaner 

