### PR TITLE
Fix for true division in Python 3

### DIFF
--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -1215,7 +1215,7 @@ def plot_quadrature(solver, get_figure=False):
     num_azim = track_generator.getNumAzim()
     azim_spacing = track_generator.getDesiredAzimSpacing()
     num_polar_2 = int(quad.getNumPolarAngles() / 2)
-    phis = np.zeros(num_azim/4)
+    phis = np.zeros(int(num_azim/4))
     thetas = np.zeros(num_polar_2)
 
     # Get the polar angles

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -102,8 +102,8 @@ def plot_tracks(track_generator, get_figure=False):
 
     # Convert data to NumPy arrays
     coords = np.array(coords)
-    x = coords[0::vals_per_track/2]
-    y = coords[1::vals_per_track/2]
+    x = coords[0::int(vals_per_track/2)]
+    y = coords[1::int(vals_per_track/2)]
 
     # Make figure of line segments for each Track
     fig = plt.figure()

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -102,8 +102,8 @@ def plot_tracks(track_generator, get_figure=False):
 
     # Convert data to NumPy arrays
     coords = np.array(coords)
-    x = coords[0::int(vals_per_track/2)]
-    y = coords[1::int(vals_per_track/2)]
+    x = coords[0::vals_per_track//2]
+    y = coords[1::vals_per_track//2]
 
     # Make figure of line segments for each Track
     fig = plt.figure()
@@ -1215,7 +1215,7 @@ def plot_quadrature(solver, get_figure=False):
     num_azim = track_generator.getNumAzim()
     azim_spacing = track_generator.getDesiredAzimSpacing()
     num_polar_2 = int(quad.getNumPolarAngles() / 2)
-    phis = np.zeros(int(num_azim/4))
+    phis = np.zeros(num_azim//4)
     thetas = np.zeros(num_polar_2)
 
     # Get the polar angles


### PR DESCRIPTION
`plotter.py` occasionally uses division to calculate values which need to be integers. The division operator performs integer division in Python 2, but true division in Python 3.

This PR ensures that three of these quotients are integers. There may be other instances, but these are the ones I encountered running the test suite.