### PR TITLE
Changed "spectral" to "nipy_spectral" in plotter

### DIFF
--- a/docs/source/usersguide/processing.rst
+++ b/docs/source/usersguide/processing.rst
@@ -734,7 +734,7 @@ Property                  Type                      Default                 Note
 ``transparent_zeros``     boolean                   False                   Make zeros in the data appear transparent
 ``interpolation``         string                    None                    Interpolation used between points (e.g., 'nearest')
 ``colorbar``              boolean                   False                   Include a colorbar to the right of the plot
-``cmap``                  ``matplotlib.colormap``   ``cmap('spectral')``    A Matplotlib colormap for the plot
+``cmap``                  ``matplotlib.colormap``   ``cmap('nipy_spectral')``    A Matplotlib colormap for the plot
 ``vmin``                  float                     None                    The minimum value used in colormapping the data
 ``vmax``                  float                     None                    The maximum value used in colormapping the data
 ========================  ========================  ======================  ==========================================================

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -1352,7 +1352,7 @@ class PlotParams(object):
         self._transparent_zeros = False
         self._interpolation = None
         self._colorbar = False
-        self._cmap = plt.get_cmap('spectral')
+        self._cmap = plt.get_cmap('nipy_spectral')
         self._vmin = None
         self._vmax = None
 


### PR DESCRIPTION
https://matplotlib.org/api/api_changes.html#the-spectral-colormap-is-now-nipy-spectral

> The colormaps formerly known as `spectral` and `spectral_r` have been replaced by `nipy_spectral` and `nipy_spectral_r` since Matplotlib 1.3.0. Even though the colormap was deprecated in Matplotlib 1.3.0, it never raised a warning. As of Matplotlib 2.0.0, using the old names raises a deprecation warning. In the future, using the old names will raise an error.

This PR fixes the name of the colormap selected in plotter.py.