### PR TITLE
Code coverage testing for OpenMOC Python API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy h5py pandas matplotlib pillow
   - source activate test-environment
   - pip install python-coveralls
+  - pip install coverage
 
 install:
   # ================= Get C++11-compatible compiler ==================

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,7 @@ install:
 script:
   - cd tests
   - ./travis.sh
-  - cd ..
 
 after_success:
-  - cd tests
   - coveralls
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy h5py pandas matplotlib pillow
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy h5py pandas matplotlib pillow coveralls
   - source activate test-environment
 
 install:
@@ -41,3 +41,6 @@ script:
   - cd tests
   - ./travis.sh
   - cd ..
+
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,9 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy h5py pandas matplotlib pillow coveralls
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy h5py pandas matplotlib pillow
   - source activate test-environment
+  - pip install python-coveralls
 
 install:
   # ================= Get C++11-compatible compiler ==================

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,6 @@ script:
   - cd ..
 
 after_success:
+  - cd tests
   - coveralls
+  - cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,16 @@ foreach(test ${TESTS})
   get_filename_component(TEST_NAME ${test} NAME)
   get_filename_component(TEST_PATH ${test} PATH)
 
-  add_test(NAME ${TEST_NAME}
-    WORKING_DIRECTORY ${TEST_PATH}
-    COMMAND coverage run ${TEST_NAME}
+  if(${COVERAGE})
+    add_test(NAME ${TEST_NAME}
+      WORKING_DIRECTORY ${TEST_PATH}
+      COMMAND ${PYTHON_EXECUTABLE} run --omit=${OMIT} ${TEST_NAME}
   )
+  else()
+    add_test(NAME ${TEST_NAME}
+      WORKING_DIRECTORY ${TEST_PATH}
+      COMMAND ${PYTHON_EXECUTABLE} ${TEST_NAME}
+  )
+  endif()
 
 endforeach(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(test ${TESTS})
 
   add_test(NAME ${TEST_NAME}
     WORKING_DIRECTORY ${TEST_PATH}
-    COMMAND ${PYTHON_EXECUTABLE} ${TEST_NAME}
+    COMMAND coverage run ${TEST_NAME}
   )
 
 endforeach(test)

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ OpenMOC
 
 .. image:: https://api.travis-ci.org/mit-crpg/OpenMOC.svg?branch=develop
     :target: https://travis-ci.org/mit-crpg/OpenMOC
-.. image:: https://coveralls.io/repos/github/mit-crpg/OpenMOC/badge.svg?branch=develop
-    :target: https://coveralls.io/github/mit-crpg/OpenMOC?branch=develop
+.. image:: https://coveralls.io/repos/github/mit-crpg/GiudGiud/badge.svg?branch=develop
+    :target: https://coveralls.io/github/GiudGiud/OpenMOC?branch=develop
 .. image:: https://img.shields.io/badge/powered%20by-OpenMOC-blue.svg
     :target: https://mit-crpg.github.io/OpenMOC/
 .. image:: https://img.shields.io/badge/license-MIT%20License-brightgreen.svg

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -26,6 +26,9 @@ parser.add_option('-C', '--build-config', dest='build_config',
                         "Specific build configurations can be printed out with "
                         "optional argument -p, --print. This uses standard "
                         "regex syntax to select build configurations.")
+parser.add_option('-c', '--coverage', dest='coverage',
+                  help="Run tests with coverage.py to output Python code "
+                  "coverage.")
 parser.add_option('-l', '--list', action="store_true",
                   dest="list_build_configs", default=False,
                   help="List out build configurations.")
@@ -110,7 +113,6 @@ class Test(object):
             ctest_cmd += ['-R', str(options.regex_tests)]
 
         # Run CTest
-        print(ctest_cmd)
         rc = subprocess.call(ctest_cmd)
 
         # Check for error code
@@ -126,7 +128,7 @@ def add_test(name, cc='gcc', num_threads=1, debug=False, ):
 # List of all tests that may be run. User can add -C to command line to specify
 # a subset of these configurations
 add_test('normal-gcc', cc='gcc', num_threads=1)
-add_test('normal-openmp-gcc', cc='gcc', num_threads=4)
+#add_test('normal-openmp-gcc', cc='gcc', num_threads=4)
 #add_test('normal-icpc', cc='icpc', num_threads=1)
 #add_test('normal-openmp-icpc', cc='icpc', num_threads=4)
 #add_test('normal-clang', cc='clang', num_threads=1)
@@ -189,9 +191,14 @@ for key in iter(tests):
         logfilename = logfilename + '_{0}.log'.format(test.name)
         shutil.copy(logfile[0], logfilename)
 
+# Combine all coverage files
+if coverage == True:
+    os.system('coverage combine test*/.coverage')
+
 # Clear build directory and remove binary and hdf5 files
 shutil.rmtree('build', ignore_errors=True)
-shutil.rmtree('openmoc', ignore_errors=True)
+if coverage == False:
+    shutil.rmtree('openmoc', ignore_errors=True)
 subprocess.call(['./cleanup'])
 
 # Print out summary of results

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -83,7 +83,7 @@ class Test(object):
         cmake_cmd = ['cmake', '-H..', '-Bbuild']
 
         # Run tests with coverage option or not
-        if options.coverage and sys.version_info.major > 3:
+        if options.coverage and sys.version_info.major >= 3:
             cmake_cmd += ['-DPYTHON_EXECUTABLE=' + shutil.which('coverage')]
             cmake_cmd += ['-DCOVERAGE=True']
             cmake_cmd += ['-DOMIT=test*']
@@ -200,7 +200,7 @@ for key in iter(tests):
         shutil.copy(logfile[0], logfilename)
 
 # Combine all coverage files
-if options.coverage and sys.version_info.major > 3:
+if options.coverage and sys.version_info.major >= 3:
     os.system('coverage combine test*/.coverage')
 
 # Clear build directory and remove binary and hdf5 files

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -10,6 +10,7 @@ import glob
 import subprocess
 from collections import OrderedDict
 from optparse import OptionParser
+from distutils.spawn import find_executable
 
 # Command line parsing
 parser = OptionParser()
@@ -83,8 +84,8 @@ class Test(object):
         cmake_cmd = ['cmake', '-H..', '-Bbuild']
 
         # Run tests with coverage option or not
-        if options.coverage and sys.version_info.major >= 3:
-            cmake_cmd += ['-DPYTHON_EXECUTABLE=' + shutil.which('coverage')]
+        if options.coverage:
+            cmake_cmd += ['-DPYTHON_EXECUTABLE=' + find_executable('coverage')]
             cmake_cmd += ['-DCOVERAGE=True']
             cmake_cmd += ['-DOMIT=test*']
         else:
@@ -200,7 +201,7 @@ for key in iter(tests):
         shutil.copy(logfile[0], logfilename)
 
 # Combine all coverage files
-if options.coverage and sys.version_info.major >= 3:
+if options.coverage:
     os.system('coverage combine test*/.coverage')
 
 # Clear build directory and remove binary and hdf5 files

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -78,7 +78,6 @@ class Test(object):
         """Run CMake to create CTest script"""
 
         cmake_cmd = ['cmake', '-H..', '-Bbuild']
-        cmake_cmd += ['-DPYTHON_EXECUTABLE=' + sys.executable]
 
         # Run CMake
         rc = subprocess.call(cmake_cmd)
@@ -127,7 +126,7 @@ def add_test(name, cc='gcc', num_threads=1, debug=False, ):
 # List of all tests that may be run. User can add -C to command line to specify
 # a subset of these configurations
 add_test('normal-gcc', cc='gcc', num_threads=1)
-#add_test('normal-openmp-gcc', cc='gcc', num_threads=4)
+add_test('normal-openmp-gcc', cc='gcc', num_threads=4)
 #add_test('normal-icpc', cc='icpc', num_threads=1)
 #add_test('normal-openmp-icpc', cc='icpc', num_threads=4)
 #add_test('normal-clang', cc='clang', num_threads=1)
@@ -191,9 +190,9 @@ for key in iter(tests):
         shutil.copy(logfile[0], logfilename)
 
 # Clear build directory and remove binary and hdf5 files
-#shutil.rmtree('build', ignore_errors=True)
-#shutil.rmtree('openmoc', ignore_errors=True)
-#subprocess.call(['./cleanup'])
+shutil.rmtree('build', ignore_errors=True)
+shutil.rmtree('openmoc', ignore_errors=True)
+subprocess.call(['./cleanup'])
 
 # Print out summary of results
 print('\n' + '='*54)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -15,6 +15,8 @@ from optparse import OptionParser
 parser = OptionParser()
 parser.add_option('-j', '--parallel', dest='n_procs', default='1',
                   help="Number of parallel jobs.")
+parser.add_option('-v', '--verbose', action="store_true", dest="verbose",
+                  default=False, help="Make CTest verbose.")
 parser.add_option('-R', '--tests-regex', dest='regex_tests',
                   help="Run tests matching regular expression. "
                   "Test names are the directories present in tests folder. "
@@ -96,6 +98,10 @@ class Test(object):
         # Default CTest string
         ctest_cmd = ['ctest']
 
+        # Check for verbose
+        if options.verbose:
+            ctest_cmd += ['--verbose']
+
         # Check for parallel
         if options.n_procs:
             ctest_cmd += ['-j', str(options.n_procs)]
@@ -105,6 +111,7 @@ class Test(object):
             ctest_cmd += ['-R', str(options.regex_tests)]
 
         # Run CTest
+        print(ctest_cmd)
         rc = subprocess.call(ctest_cmd)
 
         # Check for error code
@@ -120,7 +127,7 @@ def add_test(name, cc='gcc', num_threads=1, debug=False, ):
 # List of all tests that may be run. User can add -C to command line to specify
 # a subset of these configurations
 add_test('normal-gcc', cc='gcc', num_threads=1)
-add_test('normal-openmp-gcc', cc='gcc', num_threads=4)
+#add_test('normal-openmp-gcc', cc='gcc', num_threads=4)
 #add_test('normal-icpc', cc='icpc', num_threads=1)
 #add_test('normal-openmp-icpc', cc='icpc', num_threads=4)
 #add_test('normal-clang', cc='clang', num_threads=1)
@@ -184,9 +191,9 @@ for key in iter(tests):
         shutil.copy(logfile[0], logfilename)
 
 # Clear build directory and remove binary and hdf5 files
-shutil.rmtree('build', ignore_errors=True)
-shutil.rmtree('openmoc', ignore_errors=True)
-subprocess.call(['./cleanup'])
+#shutil.rmtree('build', ignore_errors=True)
+#shutil.rmtree('openmoc', ignore_errors=True)
+#subprocess.call(['./cleanup'])
 
 # Print out summary of results
 print('\n' + '='*54)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -83,7 +83,7 @@ class Test(object):
         cmake_cmd = ['cmake', '-H..', '-Bbuild']
 
         # Run tests with coverage option or not
-        if options.coverage:
+        if options.coverage and sys.version_info.major > 3:
             cmake_cmd += ['-DPYTHON_EXECUTABLE=' + shutil.which('coverage')]
             cmake_cmd += ['-DCOVERAGE=True']
             cmake_cmd += ['-DOMIT=test*']
@@ -200,7 +200,7 @@ for key in iter(tests):
         shutil.copy(logfile[0], logfilename)
 
 # Combine all coverage files
-if options.coverage:
+if options.coverage and sys.version_info.major > 3:
     os.system('coverage combine test*/.coverage')
 
 # Clear build directory and remove binary and hdf5 files

--- a/tests/testing_harness.py
+++ b/tests/testing_harness.py
@@ -16,9 +16,6 @@ import openmoc
 import openmoc.plotter
 import openmoc.process
 
-print(openmoc)
-print(openmoc.plotter)
-
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt

--- a/tests/testing_harness.py
+++ b/tests/testing_harness.py
@@ -16,6 +16,9 @@ import openmoc
 import openmoc.plotter
 import openmoc.process
 
+print(openmoc)
+print(openmoc.plotter)
+
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -4,5 +4,5 @@ set -ev
 
 # Run all debug tests
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  ./run_tests.py
+  ./run_tests.py -c
 fi


### PR DESCRIPTION
This PR uses coverage.py and coveralls to implement code coverage testing for the OpenMOC Python API
While it is somewhat unfair the SWIG generated code (openmoc.py) is being tested for coverage, it's still a good indicator of how much our test suite covers the code.

In the future we will want to cover the C++ source code as well.