### PR TITLE
Various fixes to behavior in presence of negative XS

### DIFF
--- a/src/CPULSSolver.h
+++ b/src/CPULSSolver.h
@@ -65,16 +65,16 @@ public:
   void initializeCmfd();
   void initializeExpEvaluators();
   void initializeFSRs();
-  
-  //FIXME
-  void checkLimitXS(int iteration);
 
   void flattenFSRFluxes(FP_PRECISION value);
   double normalizeFluxes();
   void computeFSRSources(int iteration);
   void addSourceToScalarFlux();
+  
+  /* Transport stabilization routines */
   void computeStabilizingFlux();
   void stabilizeFlux();
+  void checkLimitXS(int iteration);
 
   void tallyLSScalarFlux(segment* curr_segment, int azim_index, int polar_index,
                          float* track_flux, FP_PRECISION* fsr_flux,

--- a/src/CPULSSolver.h
+++ b/src/CPULSSolver.h
@@ -25,9 +25,9 @@
  *  (\f$ \frac{Q}{\Sigma_t} \f$) in each FSR and energy group */
 #define _reduced_sources_xyz(r,e,x) (_reduced_sources_xyz[(r)*_num_groups*3 + (e)*3 + (x)])
 
-/** Indexing macro for the stabalizing scalar flux moments in each FSR and
+/** Indexing macro for the stabilizing scalar flux moments in each FSR and
  *  energy group */
-#define _stabalizing_flux_xyz(r,e,x) (_stabalizing_flux_xyz[(r)*_num_groups*3 + (e)*3 + (x)])
+#define _stabilizing_flux_xyz(r,e,x) (_stabilizing_flux_xyz[(r)*_num_groups*3 + (e)*3 + (x)])
 
 /**
  * @class CPULSSolver CPULSSolver.h "src/CPULSSolver.h"
@@ -50,11 +50,11 @@ protected:
   /** An array of the reduced source x, y, and z terms */
   FP_PRECISION* _reduced_sources_xyz;
   
-  /** The stabalizing flux for each energy group in each FSR */
-  FP_PRECISION* _stabalizing_flux_xyz;
+  /** The stabilizing flux for each energy group in each FSR */
+  FP_PRECISION* _stabilizing_flux_xyz;
 
-  /** Whether to stabalize the flux moments */
-  bool _stabalize_moments;
+  /** Whether to stabilize the flux moments */
+  bool _stabilize_moments;
 
 public:
   CPULSSolver(TrackGenerator* track_generator=NULL);
@@ -73,8 +73,8 @@ public:
   double normalizeFluxes();
   void computeFSRSources(int iteration);
   void addSourceToScalarFlux();
-  void computeStabalizingFlux();
-  void stabalizeFlux();
+  void computeStabilizingFlux();
+  void stabilizeFlux();
 
   void tallyLSScalarFlux(segment* curr_segment, int azim_index, int polar_index,
                          float* track_flux, FP_PRECISION* fsr_flux,

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -1800,7 +1800,8 @@ void CPUSolver::transportSweep() {
  *          energy groups and polar angles, and tallies it into the FSR
  *          scalar flux, and updates the Track's angular flux.
  * @param curr_segment a pointer to the Track segment of interest
- * @param azim_index a pointer to the azimuthal angle index for this segment
+ * @param azim_index azimuthal angle index for this segment
+ * @param polar_index polar angle index for this segment 
  * @param track_flux a pointer to the Track's angular flux
  * @param fsr_flux a pointer to the temporary FSR flux buffer
  */
@@ -1878,6 +1879,7 @@ void CPUSolver::tallyScalarFlux(segment* curr_segment,
  *        the appropriate CMFD mesh cell surface.
  * @param curr_segment a pointer to the Track segment of interest
  * @param azim_index the azimuthal index for this segmenbt
+ * @param polar_index the polar index for this segmenbt
  * @param track_flux a pointer to the Track's angular flux
  * @param fwd boolean indicating direction of integration along segment
  */
@@ -1896,8 +1898,9 @@ void CPUSolver::tallyCurrent(segment* curr_segment, int azim_index,
  * @details For reflective boundary conditions, the outgoing boundary flux
  *          for the Track is given to the reflecting Track. For vacuum
  *          boundary conditions, the outgoing flux tallied as leakage.
- * @param track_id the ID number for the Track of interest
- * @param azim_index a pointer to the azimuthal angle index for this segment
+ * @param track a pointer to the Track of interest
+ * @param azim_index azimuthal angle index for this segment
+ * @param polar_index polar angle index for this segment
  * @param direction the Track direction (forward - true, reverse - false)
  * @param track_flux a pointer to the Track's outgoing angular flux
  */

--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -92,8 +92,8 @@ protected:
   virtual double normalizeFluxes();
   virtual void computeFSRSources(int iteration);
   virtual void transportSweep();
-  virtual void computeStabalizingFlux();
-  virtual void stabalizeFlux();
+  virtual void computeStabilizingFlux();
+  virtual void stabilizeFlux();
   virtual void addSourceToScalarFlux();
   void computeKeff();
   double computeResidual(residualType res_type);

--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -108,35 +108,14 @@ public:
   void computeFSRFissionRates(double* fission_rates, long num_FSRs);
   virtual void printInputParamsSummary();
 
-  /**
-   * @brief Computes the contribution to the FSR flux from a Track segment.
-   * @param curr_segment a pointer to the Track segment of interest
-   * @param azim_index a pointer to the azimuthal angle index for this segment
-   * @param track_flux a pointer to the Track's angular flux
-   * @param fsr_flux a pointer to the temporary FSR scalar flux buffer
-   */
   virtual void tallyScalarFlux(segment* curr_segment, int azim_index,
                                int polar_index, float* track_flux,
                                FP_PRECISION* fsr_flux);
 
-  /**
-   * @brief Computes the contribution to surface current from a Track segment.
-   * @param curr_segment a pointer to the Track segment of interest
-   * @param azim_index a pointer to the azimuthal angle index for this segment
-   * @param track_flux a pointer to the Track's angular flux
-   * @param fwd the direction of integration along the segment
-   */
   virtual void tallyCurrent(segment* curr_segment, int azim_index,
                             int polar_index, float* track_flux,
                             bool fwd);
 
-  /**
-   * @brief Updates the boundary flux for a Track given boundary conditions.
-   * @param track_id the ID number for the Track of interest FIXME
-   * @param azim_index a pointer to the azimuthal angle index for this segment
-   * @param direction the Track direction (forward - true, reverse - false)
-   * @param track_flux a pointer to the Track's outgoing angular flux
-   */
   virtual void transferBoundaryFlux(Track* track, int azim_index,
                                     int polar_index, bool direction,
                                     float* track_flux);
@@ -145,7 +124,6 @@ public:
 
   void initializeFixedSources();
 
-  //FIXME
   void printFSRFluxes(std::vector<double> dim1,
                       std::vector<double> dim2, double offset,
                       const char* plane);

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -48,7 +48,7 @@ Solver::Solver(TrackGenerator* track_generator) {
   _scalar_flux = NULL;
   _old_scalar_flux = NULL;
   _reference_flux = NULL;
-  _stabalizing_flux = NULL;
+  _stabilizing_flux = NULL;
   _fixed_sources = NULL;
   _reduced_sources = NULL;
   _source_type = "None";
@@ -67,7 +67,7 @@ Solver::Solver(TrackGenerator* track_generator) {
   _timer = new Timer();
 
   _correct_xs = false;
-  _stabalize_transport = false;
+  _stabilize_transport = false;
   _verbose = false;
   _calculate_initial_spectrum = false;
   _initial_spectrum_thresh = 1.0;
@@ -110,8 +110,8 @@ Solver::~Solver() {
   if (_reference_flux != NULL)
     delete [] _reference_flux;
   
-  if (_stabalizing_flux != NULL)
-    delete [] _stabalizing_flux;
+  if (_stabilizing_flux != NULL)
+    delete [] _stabilizing_flux;
 
   if (_fixed_sources != NULL)
     delete [] _fixed_sources;
@@ -566,38 +566,38 @@ void Solver::correctXS() {
 
 
 /**
- * @brief   Directs OpenMOC to use the diagonal stabalizing correction to
+ * @brief   Directs OpenMOC to use the diagonal stabilizing correction to
  *          the source iteration transport sweep
  * @details The source iteration process which MOC uses can be unstable
  *          if negative cross-sections arise from transport correction. This
- *          instability causes issues in convergence. The stabalizing
+ *          instability causes issues in convergence. The stabilizing
  *          correction fixes this by adding a diagonal matrix to both sides
  *          of the discretized transport equation which introduces no bias
  *          but transforms the iteration matrix into one that is stable.
  *
- *          Three stabalization options exist: DIAGONAL, YAMAMOTO, and GLOBAL.
+ *          Three stabilization options exist: DIAGONAL, YAMAMOTO, and GLOBAL.
  *
- *          DIAGONAL: The stabalization is only applied to fluxes where the
+ *          DIAGONAL: The stabilization is only applied to fluxes where the
  *                    associated in-scatter cross-section is negative. The
- *                    added stabalizing flux is equal to the magnitude of the
+ *                    added stabilizing flux is equal to the magnitude of the
  *                    in-scatter cross-section divided by the total
- *                    cross-section and scaled by the stabalization factor.
+ *                    cross-section and scaled by the stabilization factor.
  *          YAMAMOTO: This is the same as DIAGONAL except that the largest
- *                    stabalization is applied to all regions, not just those
+ *                    stabilization is applied to all regions, not just those
  *                    containing negative in-scatter cross-sections.
- *          GLOBAL: This method applies a global stabalization factor to all
- *                  fluxes defined by the user. In addition, the stabalization
+ *          GLOBAL: This method applies a global stabilization factor to all
+ *                  fluxes defined by the user. In addition, the stabilization
  *                  factor in this option refers to a damping factor, not
- *                  the magnitude of the stabalizing correction.
+ *                  the magnitude of the stabilizing correction.
  *
- * @param stabalization_factor The factor applied to the stabalizing correction
- * @param stabalizaiton_type The type of stabalization to use
+ * @param stabilization_factor The factor applied to the stabilizing correction
+ * @param stabilizaiton_type The type of stabilization to use
  */
-void Solver::stabalizeTransport(double stabalization_factor, 
-                                stabalizationType stabalization_type) {
-  _stabalize_transport = true;
-  _stabalization_factor = stabalization_factor;
-  _stabalization_type = stabalization_type;
+void Solver::stabilizeTransport(double stabilization_factor, 
+                                stabilizationType stabilization_type) {
+  _stabilize_transport = true;
+  _stabilization_factor = stabilization_factor;
+  _stabilization_type = stabilization_type;
 }
   
 
@@ -1454,9 +1454,9 @@ void Solver::computeEigenvalue(int max_iters, residualType res_type) {
   /* Source iteration loop */
   for (int i=0; i < max_iters; i++) {
 
-    /* Comptue the stabalizing flux if necessary */
-    if (i > 0 && _stabalize_transport) {
-      computeStabalizingFlux();
+    /* Comptue the stabilizing flux if necessary */
+    if (i > 0 && _stabilize_transport) {
+      computeStabilizingFlux();
     }
     
     /* Perform the source iteration */
@@ -1473,9 +1473,9 @@ void Solver::computeEigenvalue(int max_iters, residualType res_type) {
     else
       computeKeff();
     
-    /* Apply the flux adjustment if transport stabalization is on */
-    if (i > 0 && _stabalize_transport) {
-      stabalizeFlux();
+    /* Apply the flux adjustment if transport stabilization is on */
+    if (i > 0 && _stabilize_transport) {
+      stabilizeFlux();
     }
 
     /* Normalize the flux and compute residuals */
@@ -2028,20 +2028,20 @@ void Solver::printInputParamsSummary() {
   /* Print source type */
   log_printf(NORMAL, "Source type = %s", _source_type.c_str());
   
-  /* Print MOC stabalization */
-  if (_stabalize_transport) {
+  /* Print MOC stabilization */
+  if (_stabilize_transport) {
 
-    std::string stabalization_str;
+    std::string stabilization_str;
     
-    if (_stabalization_type == DIAGONAL)
-      stabalization_str = "DIAGONAL";
-    else if (_stabalization_type == YAMAMOTO)
-      stabalization_str = "TY";
-    else if (_stabalization_type == GLOBAL)
-      stabalization_str = "GLOBAL";
+    if (_stabilization_type == DIAGONAL)
+      stabilization_str = "DIAGONAL";
+    else if (_stabilization_type == YAMAMOTO)
+      stabilization_str = "TY";
+    else if (_stabilization_type == GLOBAL)
+      stabilization_str = "GLOBAL";
 
-    log_printf(NORMAL, "MOC Damping = %s (%3.2f)", stabalization_str.c_str(), 
-               _stabalization_factor);
+    log_printf(NORMAL, "MOC Damping = %s (%3.2f)", stabilization_str.c_str(), 
+               _stabilization_factor);
   }
   else {
     log_printf(NORMAL, "MOC transport undamped");

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -36,8 +36,8 @@
 /** Indexing macro for the reference scalar flux in each FSR and energy group */
 #define reference_flux(r,e) (reference_flux[(r)*_num_groups + (e)])
 
-/** Indexing macro for the stabailizing flux in each FSR and energy group */
-#define _stabalizing_flux(r,e) (_stabalizing_flux[(r)*_num_groups + (e)])
+/** Indexing macro for the stabiilizing flux in each FSR and energy group */
+#define _stabilizing_flux(r,e) (_stabilizing_flux[(r)*_num_groups + (e)])
 
 /** Indexing macro for the total source divided by the total cross-section
  *  (\f$ \frac{Q}{\Sigma_t} \f$) in each FSR and energy group */
@@ -97,15 +97,15 @@ enum residualType {
 
 
 /**
- * @enum stabalizationType
- * @brief The type of stabalization to use on source iteration
+ * @enum stabilizationType
+ * @brief The type of stabilization to use on source iteration
  */
-enum stabalizationType {
+enum stabilizationType {
 
-  /** General diagonal stabalization */
+  /** General diagonal stabilization */
   DIAGONAL,
 
-  /** Yamamoto's groupwise stabalization */
+  /** Yamamoto's groupwise stabilization */
   YAMAMOTO,
 
   /** Global damping on the scalar flux update */
@@ -180,9 +180,9 @@ protected:
   /** Boolean for whether to correct unphysical cross-sections */
   bool _correct_xs;
 
-  /** Boolean for whether to apply the stabalizing correction to the source
+  /** Boolean for whether to apply the stabilizing correction to the source
     * iteration (transport sweep) process */
-  bool _stabalize_transport;
+  bool _stabilize_transport;
 
   /** Boolean for whether to print verbose iteration reports */
   bool _verbose;
@@ -240,8 +240,8 @@ protected:
   /** The reference scalar flux for each energy group in each FSR */
   FP_PRECISION* _reference_flux;
   
-  /** The stabalizing flux for each energy group in each FSR */
-  FP_PRECISION* _stabalizing_flux;
+  /** The stabilizing flux for each energy group in each FSR */
+  FP_PRECISION* _stabilizing_flux;
 
   /** Optional user-specified fixed sources in each FSR and energy group */
   FP_PRECISION* _fixed_sources;
@@ -275,10 +275,10 @@ protected:
   double _converge_thresh;
 
   /** The factor applied to the source iteration stabilization */
-  double _stabalization_factor;
+  double _stabilization_factor;
   
   /** The type of source iteration stabilization */
-  stabalizationType _stabalization_type;
+  stabilizationType _stabilization_type;
 
   /** A matrix of ExpEvaluators to compute exponentials in the transport
     * equation. The matrix is indexed by azimuthal index and polar index */
@@ -346,14 +346,14 @@ protected:
   virtual double normalizeFluxes() =0;
 
   /**
-   * @brief Computes the stabalizing flux for transport stabalization
+   * @brief Computes the stabilizing flux for transport stabilization
    */
-  virtual void computeStabalizingFlux() =0;
+  virtual void computeStabilizingFlux() =0;
   
   /**
-   * @brief Adjusts the scalar flux for transport stabalization
+   * @brief Adjusts the scalar flux for transport stabilization
    */
-  virtual void stabalizeFlux() =0;
+  virtual void stabilizeFlux() =0;
 
   /**
    * @brief Computes the total source (fission, scattering, fixed) for
@@ -434,8 +434,8 @@ public:
   void useExponentialInterpolation();
   void useExponentialIntrinsic();
   void correctXS();
-  void stabalizeTransport(double stabalization_factor,
-                          stabalizationType stabalization_type=DIAGONAL);
+  void stabilizeTransport(double stabilization_factor,
+                          stabilizationType stabilization_type=DIAGONAL);
   void setInitialSpectrumCalculation(double threshold);
   void setCheckXSLogLevel(logLevel log_level);
   void setChiSpectrumMaterial(Material* material);


### PR DESCRIPTION
This PRs attempts to make the code behavior in the presence of negative scattering cross sections, such as with P0-transport correction with some materials a bit more consistent. 

- Negative scattering cross sections are not discarded anymore for LS moments. This was inconsistent with using the transport corrected cross section when computing flux moments, and was inconsistent with regards to the treatment of the flat source. The flat source is being set to 0 when the sum of the fission and scattering contributions were negative.
- When the flat component of the source is 0, the linear source moments are set to 0. This avoids having an area with a negative source. 