### PR TITLE
Fixed the translation direction when filling a Cell with a Universe

### DIFF
--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -237,7 +237,6 @@ Cmfd::~Cmfd() {
       delete [] _old_boundary_flux;
       delete [] _boundary_surface_currents;
     }
-    //delete _domain_communicator;
   }
 
   for (long r=0; r < _axial_interpolants.size(); r++)
@@ -2447,9 +2446,7 @@ void Cmfd::generateKNearestStencils() {
     /* Initialize axial quadratic interpolant values */
     _axial_interpolants.resize(_num_FSRs);
     for (long r=0; r < _num_FSRs; r++) {
-      _axial_interpolants.at(r) = new double[3];
-      for (int j=0; j < 3; j++)
-        _axial_interpolants.at(r)[j] = 0.0;
+      _axial_interpolants.at(r) = new double[3]();
     }
     
     /* Calculate common factors */
@@ -2640,7 +2637,7 @@ CMFD_PRECISION Cmfd::getFluxRatio(int cell_id, int group, int fsr) {
   if (_use_axial_interpolation)
     interpolants = _axial_interpolants.at(fsr);
   if (_use_axial_interpolation && _local_num_z >= 3 && 
-    ( interpolants[0] != 0 || interpolants[2] != 0) ) {
+    (interpolants[0] != 0 || interpolants[2] != 0)) {
     int z_ind = cell_id / (_local_num_x * _local_num_y);
     int cell_mid = cell_id;
     if (z_ind == 0)

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1403,7 +1403,7 @@ void Lattice::updateUniverse(int lat_x, int lat_y, int lat_z,
          "array of Universes", universe->getId(), _id, lat_x);
   if (lat_y < 0 || lat_y >= _num_y)
     log_printf(ERROR, "Unable to set Universe %d in Lattice %d with "
-         "Lattice cell index lat_z=%d which is outside the "
+         "Lattice cell index lat_y=%d which is outside the "
          "array of Universes", universe->getId(), _id, lat_z);
   if (lat_z < 0 || lat_z >= _num_z)
     log_printf(ERROR, "Unable to set Universe %d in Lattice %d with "

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1404,7 +1404,7 @@ void Lattice::updateUniverse(int lat_x, int lat_y, int lat_z,
   if (lat_y < 0 || lat_y >= _num_y)
     log_printf(ERROR, "Unable to set Universe %d in Lattice %d with "
          "Lattice cell index lat_y=%d which is outside the "
-         "array of Universes", universe->getId(), _id, lat_z);
+         "array of Universes", universe->getId(), _id, lat_y);
   if (lat_z < 0 || lat_z >= _num_z)
     log_printf(ERROR, "Unable to set Universe %d in Lattice %d with "
          "Lattice cell index lat_z=%d which is outside the "

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -528,9 +528,9 @@ Cell* Universe::findCell(LocalCoords* coords) {
         /* Apply translation to position in the next coords */
         if (cell->isTranslated()){
           double* translation = cell->getTranslation();
-          double new_x = coords->getX() + translation[0];
-          double new_y = coords->getY() + translation[1];
-          double new_z = coords->getZ() + translation[2];
+          double new_x = coords->getX() - translation[0];
+          double new_y = coords->getY() - translation[1];
+          double new_z = coords->getZ() - translation[2];
           next_coords->setX(new_x);
           next_coords->setY(new_y);
           next_coords->setZ(new_z);
@@ -1395,20 +1395,20 @@ void Lattice::updateUniverse(int lat_x, int lat_y, int lat_z,
 
   if (_num_x == -1 || _num_y == -1 || _num_z == -1)
     log_printf(ERROR, "Unable to set Universe %d in Lattice %d which "
-	       "has not yet been assigned an array of Universes",
-	       universe->getId(), _id);
+         "has not yet been assigned an array of Universes",
+         universe->getId(), _id);
   if (lat_x < 0 || lat_x >= _num_x)
     log_printf(ERROR, "Unable to set Universe %d in Lattice %d with "
-	       "Lattice cell index lat_x=%d which is outside the "
-	       "array of Universes", universe->getId(), _id, lat_x);
+         "Lattice cell index lat_x=%d which is outside the "
+         "array of Universes", universe->getId(), _id, lat_x);
   if (lat_y < 0 || lat_y >= _num_y)
     log_printf(ERROR, "Unable to set Universe %d in Lattice %d with "
-	       "Lattice cell index lat_z=%d which is outside the "
-	       "array of Universes", universe->getId(), _id, lat_z);
+         "Lattice cell index lat_z=%d which is outside the "
+         "array of Universes", universe->getId(), _id, lat_z);
   if (lat_z < 0 || lat_z >= _num_z)
     log_printf(ERROR, "Unable to set Universe %d in Lattice %d with "
-	       "Lattice cell index lat_z=%d which is outside the "
-	       "array of Universes", universe->getId(), _id, lat_z);
+         "Lattice cell index lat_z=%d which is outside the "
+         "array of Universes", universe->getId(), _id, lat_z);
 
   /* Assign the Universe to the array */
   _universes.at(lat_z).at(lat_y).at(lat_x) =


### PR DESCRIPTION
It is possible to fill a Cell with a Universe just as in the OpenMC. However, the direction is opposite to that in the OpenMC. Therefore, I fixed it to keep them consistent.
Also, some fixes for PR #347 