### PR TITLE
Fix some bugs of run and compile options

### DIFF
--- a/config.py
+++ b/config.py
@@ -384,8 +384,9 @@ class configuration:
     if self.debug_mode:
       for k in self.compiler_flags:
         self.compiler_flags[k].append('-g')
-        ind = [i for i, item in enumerate(self.compiler_flags[k]) if item.startswith('-O')]
-        self.compiler_flags[k][ind[0]] = '-O0'
+        ind = [i for i, item in enumerate(self.compiler_flags[k]) \
+         if item.startswith('-O')]
+        self.compiler_flags[k][ind[0]] = '-Og'
 
     # If the user wishes to compile using the address sanitizer, append
     # flag to all lists of compiler flags for all distribution types

--- a/config.py
+++ b/config.py
@@ -384,6 +384,8 @@ class configuration:
     if self.debug_mode:
       for k in self.compiler_flags:
         self.compiler_flags[k].append('-g')
+        ind = [i for i, item in enumerate(self.compiler_flags[k]) if item.startswith('-O')]
+        self.compiler_flags[k][ind[0]] = '-O0'
 
     # If the user wishes to compile using the address sanitizer, append
     # flag to all lists of compiler flags for all distribution types

--- a/openmoc/options.py
+++ b/openmoc/options.py
@@ -62,12 +62,14 @@ class Options(object):
         """Initialize default values for each runtime parameter and parses the
         command line arguments assigns the appropriate value to each."""
 
-        self._short_args = 'hfa:s:i:c:t:b:g:r:l:'
+        self._short_args = 'fha:s:r:l:i:c:t:b:g:'
         self._long_args = ['help',
                            'num-azim=',
                            'azim-spacing=',
-                           'tolerance=',
+                           'num_polar=',
+                           'polar-spacing=',
                            'max-iters=',
+                           'tolerance=',                           
                            'num-omp-threads=',
                            'num-thread-blocks=',
                            'num-threads-per-block=']
@@ -169,7 +171,7 @@ class Options(object):
                 num_azim += 'the number of azimuthal angles\n'
                 print(num_azim)
 
-                num_polar = '\t{: <35}'.format('-a, --num-polar=<6>')
+                num_polar = '\t{: <35}'.format('-r, --num-polar=<6>')
                 num_polar += 'the number of polar angles\n'
                 print(num_polar)
 
@@ -177,7 +179,7 @@ class Options(object):
                 azim_spacing += 'The azimuthal track spacing [cm]\n'
                 print(azim_spacing)
 
-                polar_spacing = '\t{: <35}'.format('-s, --polar-spacing=<0.1>')
+                polar_spacing = '\t{: <35}'.format('-l, --polar-spacing=<0.1>')
                 polar_spacing += 'The polar track spacing [cm]\n'
                 print(polar_spacing)
 
@@ -207,11 +209,11 @@ class Options(object):
 
             elif opt in ('-a', '--num-azim'):
                 self._num_azim = int(arg)
-            elif opt in ('-a', '--num-polar'):
+            elif opt in ('-r', '--num-polar'):
                 self._num_polar = int(arg)
             elif opt in ('-s', '--azim-spacing'):
                 self._azim_spacing = float(arg)
-            elif opt in ('-s', '--polar-spacing'):
+            elif opt in ('-l', '--polar-spacing'):
                 self._polar_spacing = float(arg)
             elif opt in ('-i', '--max-iters'):
                 self._max_iters = int(arg)

--- a/openmoc/options.py
+++ b/openmoc/options.py
@@ -62,11 +62,11 @@ class Options(object):
         """Initialize default values for each runtime parameter and parses the
         command line arguments assigns the appropriate value to each."""
 
-        self._short_args = 'fha:s:r:l:i:c:t:b:g:'
+        self._short_args = 'fha:s:p:l:i:c:t:b:g:'
         self._long_args = ['help',
                            'num-azim=',
                            'azim-spacing=',
-                           'num_polar=',
+                           'num-polar=',
                            'polar-spacing=',
                            'max-iters=',
                            'tolerance=',                           
@@ -77,7 +77,7 @@ class Options(object):
         self._num_azim = 4
         self._num_polar = 6
         self._azim_spacing = 0.1
-        self._polar_spacing = 0.1
+        self._polar_spacing = 0.75
         self._max_iters = 1000
         self._tolerance = 1E-5
         self._num_omp_threads = multiprocessing.cpu_count()
@@ -171,7 +171,7 @@ class Options(object):
                 num_azim += 'the number of azimuthal angles\n'
                 print(num_azim)
 
-                num_polar = '\t{: <35}'.format('-r, --num-polar=<6>')
+                num_polar = '\t{: <35}'.format('-p, --num-polar=<6>')
                 num_polar += 'the number of polar angles\n'
                 print(num_polar)
 
@@ -209,7 +209,7 @@ class Options(object):
 
             elif opt in ('-a', '--num-azim'):
                 self._num_azim = int(arg)
-            elif opt in ('-r', '--num-polar'):
+            elif opt in ('-p', '--num-polar'):
                 self._num_polar = int(arg)
             elif opt in ('-s', '--azim-spacing'):
                 self._azim_spacing = float(arg)

--- a/openmoc/options.py
+++ b/openmoc/options.py
@@ -77,7 +77,7 @@ class Options(object):
         self._num_azim = 4
         self._num_polar = 6
         self._azim_spacing = 0.1
-        self._polar_spacing = 0.75
+        self._polar_spacing = 1.5
         self._max_iters = 1000
         self._tolerance = 1E-5
         self._num_omp_threads = multiprocessing.cpu_count()
@@ -179,7 +179,7 @@ class Options(object):
                 azim_spacing += 'The azimuthal track spacing [cm]\n'
                 print(azim_spacing)
 
-                polar_spacing = '\t{: <35}'.format('-l, --polar-spacing=<0.1>')
+                polar_spacing = '\t{: <35}'.format('-l, --polar-spacing=<1.5>')
                 polar_spacing += 'The polar track spacing [cm]\n'
                 print(polar_spacing)
 


### PR DESCRIPTION
1) Two options were added from 2D to 3D, which are num-polar and polar-spacing. Bugs fixed.
2) To compile the debug mode executive, it's better to set the optimization -O0. Otherwise, $1 = <value optimized out> trouble would show up when debugging.