### PR TITLE
Fix 2D LS solver

### DIFF
--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -420,7 +420,7 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
       FP_PRECISION tau = sigma_t[e] * length_2D;
 
       // Compute the change in flux across the segment
-      exp_H *= length * track_flux[e] * length_2D * wgt;
+      exp_H *= length * track_flux[e] * tau * wgt;
       FP_PRECISION delta_psi = (tau * track_flux[e] - length_2D * src_flat) *
           exp_F1 - src_linear * length_2D * length_2D * exp_F2;
 
@@ -428,9 +428,8 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
       first_idx += e; // equivalent to 4*e
       fsr_flux[first_idx] += wgt * delta_psi;
       first_idx++;
-      FP_PRECISION reduced_delta = wgt * delta_psi / sigma_t[e];
       for (int i=0; i<3; i++)
-        fsr_flux[first_idx + i] += exp_H * direction[i] + reduced_delta * 
+        fsr_flux[first_idx + i] += exp_H * direction[i] + wgt * delta_psi *
                                     position[i];
 
       // Decrement the track flux

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -502,8 +502,8 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
       // Increment the fsr scalar flux and scalar flux moments
       fsr_flux[e*4] += polar_wgt_d_psi;
       for (int i=0; i<2; i++)
-        fsr_flux[e*4 + i + 1] += polar_wgt_exp_h * direction[i]
-              + polar_wgt_d_psi * position[i];
+        fsr_flux[e*4 + i + 1] += polar_wgt_exp_h * direction[i] / sigma_t[e]
+              + polar_wgt_d_psi * position[i] / sigma_t[e];
     }
   }
 

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -368,7 +368,7 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
   if (_solve_3D) {
 
     /* Compute the segment midpoint */
-    double center_x2[3];
+    FP_PRECISION center_x2[3];
     for (int i=0; i<3; i++)
       center_x2[i] = 2 * (position[i] + 0.5 * length * direction[i]);
 
@@ -442,7 +442,7 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
     int pe = 0;
 
     /* Compute the segment midpoint */
-    double center[2];
+    FP_PRECISION center[2];
     for (int i=0; i<2; i++)
       center[i] = position[i] + 0.5 * length * direction[i];
 
@@ -502,8 +502,8 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
       // Increment the fsr scalar flux and scalar flux moments
       fsr_flux[e*4] += polar_wgt_d_psi;
       for (int i=0; i<2; i++)
-        fsr_flux[e*4 + i + 1] += polar_wgt_exp_h * direction[i] / sigma_t[e]
-              + polar_wgt_d_psi * position[i] / sigma_t[e];
+        fsr_flux[e*4 + i + 1] += polar_wgt_exp_h * direction[i]
+              + polar_wgt_d_psi * position[i];
     }
   }
 
@@ -556,7 +556,7 @@ void CPULSSolver::addSourceToScalarFlux() {
 
       for (int e=0; e < _num_groups; e++) {
 
-        flux_const = FOUR_PI * 2 / sigma_t[e];
+        flux_const = FOUR_PI * 2;
 
         _scalar_flux(r,e) /= volume;
         _scalar_flux(r,e) += (FOUR_PI * _reduced_sources(r,e));
@@ -588,6 +588,11 @@ void CPULSSolver::addSourceToScalarFlux() {
           _scalar_flux_xyz(r,e,2) += flux_const * _reduced_sources_xyz(r,e,2)
               * _FSR_source_constants[r*_num_groups*nc + nc*e + 5];
         }
+
+        _scalar_flux_xyz(r,e,0) /= sigma_t[e];
+        _scalar_flux_xyz(r,e,1) /= sigma_t[e];
+        if (_solve_3D)
+          _scalar_flux_xyz(r,e,2) /= sigma_t[e];
       }
     }
   }
@@ -791,7 +796,7 @@ void CPULSSolver::checkLimitXS(int iteration) {
  * @param coords The coords of the point to get the flux at
  * @param group the energy group
  */
-double CPULSSolver::getFluxByCoords(LocalCoords* coords, int group) {
+FP_PRECISION CPULSSolver::getFluxByCoords(LocalCoords* coords, int group) {
 
   double x, y, z, xc, yc, zc;
 
@@ -806,7 +811,7 @@ double CPULSSolver::getFluxByCoords(LocalCoords* coords, int group) {
   yc = centroid->getY();
   zc = centroid->getZ();
 
-  double flux = _scalar_flux(fsr, group);
+  FP_PRECISION flux = _scalar_flux(fsr, group);
   double flux_x = 0.0;
   double flux_y = 0.0;
   double flux_z = 0.0;

--- a/src/CPULSSolver.h
+++ b/src/CPULSSolver.h
@@ -80,7 +80,7 @@ public:
                          float* track_flux, FP_PRECISION* fsr_flux,
                          FP_PRECISION* scratch_pad, FP_PRECISION direction[3]);
 
-  double getFluxByCoords(LocalCoords* coords, int group);
+  FP_PRECISION getFluxByCoords(LocalCoords* coords, int group);
   double* getLinearExpansionCoeffsBuffer();
   FP_PRECISION* getSourceConstantsBuffer();
 };

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -1738,7 +1738,7 @@ void CPUSolver::computeKeff() {
 #endif
   if (!_keff_from_fission_rates)
     /* Compute k-eff from fission, absorption, and leakage rates */
-    _k_eff *= rates[0] / (rates[1] + rates[2]);
+    _k_eff = rates[0] / (rates[1] + rates[2]);
   else
     _k_eff *= rates[0] / _num_FSRs;
 }

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -2219,11 +2219,11 @@ void Geometry::segmentizeExtruded(Track* flattened_track,
       std::string fsr_key = getFSRKey(&start);
 
       /* Get the coordinate of the extruded FSR */
-      LocalCoords* volatile retreived_coords = NULL;
+      LocalCoords* volatile retrieved_coords = NULL;
       do {
-        retreived_coords = _extruded_FSR_keys_map.at(fsr_key)->_coords;
-      } while (retreived_coords == NULL);
-      LocalCoords* ext_coords = retreived_coords;
+        retrieved_coords = _extruded_FSR_keys_map.at(fsr_key)->_coords;
+      } while (retrieved_coords == NULL);
+      LocalCoords* ext_coords = retrieved_coords;
 
       /* Create coordinate copies */
       ext_coords->copyCoords(&test_ext_coords);

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1846,7 +1846,7 @@ void Geometry::segmentize2D(Track* track, double z_coord) {
     log_printf(DEBUG, "segment start x = %f, y = %f; end x = %f, y = %f",
                start.getX(), start.getY(), end.getX(), end.getY());
 
-    /* Save indicies of CMFD Mesh surfaces that the Track segment crosses */
+    /* Save indices of CMFD Mesh surfaces that the Track segment crosses */
     if (_cmfd != NULL) {
 
       /* Find cmfd cell that segment lies in */
@@ -1898,6 +1898,7 @@ void Geometry::segmentize2D(Track* track, double z_coord) {
     }
 
     /* Calculate the local centroid of the segment if available */
+    //FIXME Consider reversing nudge
     Point* starting_point = start.getHighestLevel()->getPoint();
     new_segment->_starting_position[0] = starting_point->getX();
     new_segment->_starting_position[1] = starting_point->getY();
@@ -2027,7 +2028,7 @@ void Geometry::segmentize3D(Track3D* track, bool setup) {
                start.getX(), start.getY(), start.getZ(),
                end.getX(), end.getY(), end.getZ());
 
-    /* Save indicies of CMFD Mesh surfaces that the Track segment crosses */
+    /* Save indices of CMFD Mesh surfaces that the Track segment crosses */
     if (_cmfd != NULL && !setup) {
 
       /* Find cmfd cell that segment lies in */
@@ -2283,7 +2284,7 @@ void Geometry::segmentizeExtruded(Track* flattened_track,
     new_segment->_length = min_length;
     new_segment->_region_id = region_id;
 
-    /* Save indicies of CMFD Mesh surfaces that the Track segment crosses */
+    /* Save indices of CMFD Mesh surfaces that the Track segment crosses */
     if (_cmfd != NULL) {
 
       /* Find cmfd cell that segment lies in */

--- a/src/TrackGenerator3D.cpp
+++ b/src/TrackGenerator3D.cpp
@@ -1214,7 +1214,7 @@ void TrackGenerator3D::segmentizeExtruded() {
     _geometry->segmentizeExtruded(_tracks_2D_array[index], z_coords);
   }
 
-  /* Initialize 3D FSRs and their associated vectors*/
+  /* Initialize 3D FSRs and their associated vectors */
 #ifdef MPIx
   if (_geometry->isDomainDecomposed())
     MPI_Barrier(_geometry->getMPICart());

--- a/src/constants.h
+++ b/src/constants.h
@@ -72,16 +72,6 @@
 #define MIN_LINEAR_SOLVE_ITERATIONS 25
 #define MAX_LINEAR_SOLVE_ITERATIONS 10000
 
-#ifdef NVCC
-
-/** The maximum number of polar angles to reserve constant memory on GPU */
-#define MAX_POLAR_ANGLES_GPU 10
-
-/** The maximum number of azimuthal angles to reserve constant memory on GPU */
-#define MAX_AZIM_ANGLES_GPU 256
-
-#endif
-
 #ifdef MPIx
 #define TRACKS_PER_BUFFER 1000
 #define CMFD_BUFFER_SIZE 10000


### PR DESCRIPTION
The 2D linear source solver was broken during the development of the 3D solver. 

This PR shows once again that the test suite needs to be expanded and used.