### PR TITLE
fix the unsafe float equality comparing

### DIFF
--- a/config.py
+++ b/config.py
@@ -156,7 +156,7 @@ class configuration:
   compiler_flags = dict()
 
   compiler_flags['gcc'] = ['-c', '-O3', '-ffast-math', '-fopenmp',
-                           '-std=c++11', '-fpic', '-Wfloat-equal']
+                           '-std=c++11', '-fpic']
   compiler_flags['mpicc'] = ['-c', '-O3', '-ffast-math', '-fopenmp',
                            '-std=c++11', '-fpic']
   compiler_flags['clang'] = ['-c', '-O3', '-ffast-math', '-std=c++11',

--- a/config.py
+++ b/config.py
@@ -156,7 +156,7 @@ class configuration:
   compiler_flags = dict()
 
   compiler_flags['gcc'] = ['-c', '-O3', '-ffast-math', '-fopenmp',
-                           '-std=c++11', '-fpic']
+                           '-std=c++11', '-fpic', '-Wfloat-equal']
   compiler_flags['mpicc'] = ['-c', '-O3', '-ffast-math', '-fopenmp',
                            '-std=c++11', '-fpic']
   compiler_flags['clang'] = ['-c', '-O3', '-ffast-math', '-std=c++11',

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -161,7 +161,7 @@ void CPUSolver::setFixedSourceByFSR(long fsr_id, int group,
   }
 
   /* Warn the user if a fixed source has already been assigned to this FSR */
-  if (_fixed_sources(fsr_id,group-1) != 0.)
+  if (fabs(_fixed_sources(fsr_id,group-1)) > FLT_EPSILON)
     log_printf(WARNING, "Overriding fixed source %f in FSR ID=%d with %f",
                _fixed_sources(fsr_id,group-1), fsr_id, source);
 

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -1335,13 +1335,13 @@ void Cell::ringify(std::vector<Cell*>& subcells, double max_radius) {
     log_printf(NORMAL, "Unable to ringify Cell %d since it "
                "contains more than 2 ZCYLINDER Surfaces", _id);
 
-  if (x1 != x2 && num_zcylinders == 2)
+  if (fabs(x1 - x2) > FLT_EPSILON && num_zcylinders == 2)
     log_printf(ERROR, "Unable to ringify Cell %d since it contains "
                "ZCylinder %d centered at x=%f and ZCylinder %d at x=%f. "
                "Both ZCylinders must have the same center.",
                _id, zcylinder1->getId(), x1, zcylinder2->getId(), x2);
 
-  if (y1 != y2 && num_zcylinders == 2)
+  if (fabs(y1 - y2) > FLT_EPSILON && num_zcylinders == 2)
     log_printf(ERROR, "Unable to ringify Cell %d since it contains "
                "ZCylinder %d centered at y=%f and ZCylinder %d at y=%f. "
                "Both ZCylinders must have the same center.",
@@ -1368,7 +1368,8 @@ void Cell::ringify(std::vector<Cell*>& subcells, double max_radius) {
     increment = fabs(radius1 - radius2) / _num_rings;
   
     /* Heuristic to improve area-balancing for low number of rings */
-    if (halfspace1 == 0 && radius1 == max_radius && _num_rings < 3)
+    if (halfspace1 == 0 && fabs(radius1 - max_radius) < FLT_EPSILON
+        && _num_rings < 3)
       increment = 1.5 * (radius1 - radius2) / _num_rings;
   }
 

--- a/src/ExpEvaluator.cpp
+++ b/src/ExpEvaluator.cpp
@@ -355,7 +355,7 @@ void ExpEvaluator::initialize(int azim_index, int polar_index, bool solve_3D) {
  */
 FP_PRECISION ExpEvaluator::computeExponentialG2(FP_PRECISION tau) {
 
-  if (tau == 0.0)
+  if (fabs(tau) < FLT_EPSILON)
     return 0.0;
 
   if (tau < 0.01)

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1845,7 +1845,8 @@ void Geometry::segmentize2D(Track* track, double z_coord) {
     curr = findNextCell(&end, phi);
 
     /* Checks that segment does not have the same start and end Points */
-    if (start.getX() == end.getX() && start.getY() == end.getY())
+    if (fabs(start.getX() - end.getX()) < FLT_EPSILON
+        && fabs(start.getY() - end.getY()) < FLT_EPSILON)
       log_printf(ERROR, "Created segment with same start and end "
                  "point: x = %f, y = %f", start.getX(), start.getY());
 
@@ -2005,10 +2006,9 @@ void Geometry::segmentize3D(Track3D* track, bool setup) {
 
     /* Checks to make sure that new Segment does not have the same start
      * and end Points */
-    if (start.getX() == end.getX() &&
-        start.getY() == end.getY() &&
-        start.getZ() == end.getZ()) {
-
+    if (fabs(start.getX() - end.getX()) < FLT_EPSILON &&
+        fabs(start.getY() - end.getY()) < FLT_EPSILON &&
+        fabs(start.getZ() - end.getZ()) < FLT_EPSILON) {
       log_printf(ERROR, "Created a Track3D segment with the same start and end "
                  "point: x = %f, y = %f, z = %f", start.getX(),
                  start.getY(), start.getZ());
@@ -2205,7 +2205,8 @@ void Geometry::segmentizeExtruded(Track* flattened_track,
       curr = findNextCell(&end, phi);
 
       /* Checks that segment does not have the same start and end Points */
-      if (start.getX() == end.getX() && start.getY() == end.getY())
+      if (fabs(start.getX() - end.getX()) <FLT_EPSILON && 
+          fabs(start.getY() - end.getY()) < FLT_EPSILON)
         log_printf(ERROR, "Created segment with same start and end "
                    "point: x = %f, y = %f", start.getX(), start.getY());
 
@@ -3316,10 +3317,10 @@ std::vector<double> Geometry::getUniqueZHeights(bool include_overlaid_mesh) {
             double D = plane->getD();
 
             /* Check if there is a z-component */
-            if (C != 0) {
+            if (fabs(C) > FLT_EPSILON) {
 
               /* Check if plane has a continuous varying slope */
-              if (A != 0 || B != 0)
+              if (fabs(A) > FLT_EPSILON || fabs(B) > FLT_EPSILON)
                 log_printf(ERROR, "Continuous axial variation found in the "
                           "Geometry during axial on-the-fly ray tracing. "
                           "Axial on-the-fly ray tracing only supports "

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -2205,7 +2205,7 @@ void Geometry::segmentizeExtruded(Track* flattened_track,
       curr = findNextCell(&end, phi);
 
       /* Checks that segment does not have the same start and end Points */
-      if (fabs(start.getX() - end.getX()) <FLT_EPSILON && 
+      if (fabs(start.getX() - end.getX()) < FLT_EPSILON && 
           fabs(start.getY() - end.getY()) < FLT_EPSILON)
         log_printf(ERROR, "Created segment with same start and end "
                    "point: x = %f, y = %f", start.getX(), start.getY());

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -868,7 +868,7 @@ void Material::setChi(double* xs, int num_groups) {
     chi_sum += xs[i];
 
   for (int i=0; i < _num_groups; i++) {
-    if (chi_sum == 0)
+    if (fabs(chi_sum) < FLT_EPSILON)
       _chi[i] = xs[i];
     else
       _chi[i] = xs[i] / chi_sum;

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -205,7 +205,7 @@ void Matrix::convertToCSR() {
   for (int row=0; row < _num_rows; row++) {
     _IA[row] = j;
     for (iter = _LIL[row].begin(); iter != _LIL[row].end(); ++iter) {
-      if (iter->second != 0.0) {
+      if (fabs(iter->second) > FLT_EPSILON) {
         _JA[j] = iter->first;
         _A[j] = iter->second;
 
@@ -380,7 +380,7 @@ int Matrix::getNNZ() {
   std::map<int, CMFD_PRECISION>::iterator iter;
   for (int row=0; row < _num_rows; row++) {
     for (iter = _LIL[row].begin(); iter != _LIL[row].end(); ++iter) {
-      if (iter->second != 0.0)
+      if (fabs(iter->second) > FLT_EPSILON)
         NNZ++;
     }
   }

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <iomanip>
 #include "log.h"
+#include "constants.h"
 #endif
 
 

--- a/src/Progress.cpp
+++ b/src/Progress.cpp
@@ -42,7 +42,7 @@ void Progress::incrementCounter() {
     while (_curr_interval < _intervals.size()) {
       if (curr_count != _intervals.at(_curr_interval))
         break;
-      double count = curr_count;
+      int count = curr_count;
       if (count != 0)
         count += 1;
       double num_iters = _num_iterations;

--- a/src/Quadrature.cpp
+++ b/src/Quadrature.cpp
@@ -1297,7 +1297,7 @@ std::vector <double> GLPolarQuad::getLegendreRoots(int n) {
         for (int j=0; j <= (n+1)/2; ++j) {
           if (j != i) {
             double diff = (roots[i] - roots[j]);
-            if (diff != 0.0) {
+            if (fabs(diff) > FLT_EPSILON) {
               sum1 += 1 / diff;
               sum2 += -1 / (diff*diff);
             }
@@ -1310,7 +1310,7 @@ std::vector <double> GLPolarQuad::getLegendreRoots(int n) {
         /* householder method 2 Halley */
         double denom = (s1_tilde[i]*s1_tilde[i] - s2_tilde[i]);
         double u_new = 0.0;
-        if (denom != 0)
+        if (fabs(denom) > FLT_EPSILON)
           u_new = roots[i] - 2*s1_tilde[i] / denom;
 
         double u_old = roots[i];

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -855,7 +855,7 @@ int ZCylinder::intersection(Point* point, double azim, double polar, Point* poin
       return 0;
 
     /* There is one intersection (ie on the Surface) */
-    else if (discr == 0) {
+    else if (fabs(discr) < FLT_EPSILON) {
       double xcurr = x0;
       double ycurr = -b / 2;
       double interior = pow(ycurr - y0, 2.0) + pow(xcurr - x0, 2.0);
@@ -958,7 +958,7 @@ int ZCylinder::intersection(Point* point, double azim, double polar, Point* poin
       return 0;
 
     /* There is one intersection (ie on the Surface) */
-    else if (discr == 0) {
+    else if (fabs(discr) < FLT_EPSILON) {
       double interior = pow(ycurr - y0, 2.0) + pow(xcurr - x0, 2.0);
       if (interior < 0.0)
         interior = 0.0;

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -326,7 +326,7 @@ FP_PRECISION* TrackGenerator::getFSRVolumes() {
 
   /* Check to ensure all FSRs are crossed by at least one track */
   for (long i=0; i < num_FSRs; i++) {
-    if (_FSR_volumes[i] == 0.0) {
+    if (fabs(_FSR_volumes[i]) < FLT_EPSILON) {
       log_printf(ERROR, "Zero volume calculated for FSR %d, point (%f, %f, %f)",
                  i, _geometry->getFSRPoint(i)->getX(),
                  _geometry->getFSRPoint(i)->getY(),

--- a/src/TrackGenerator3D.cpp
+++ b/src/TrackGenerator3D.cpp
@@ -994,7 +994,7 @@ int TrackGenerator3D::getFirst2DTrackLinkIndex(TrackChainIndexes* tci,
   /* If the start point is on a double reflection, nudge it to avoid track
    * with the same start and end points */
   bool nudged = false;
-  if (l_start != 0.0) {
+  if (fabs(l_start) > FLT_EPSILON) {
     if (fabs(int(round(x_ext / width_x)) * width_x - x_ext) < TINY_MOVE ||
         fabs(int(round(y_ext / width_y)) * width_y - y_ext) < TINY_MOVE) {
       l_start += TINY_MOVE * 10;

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1606,7 +1606,7 @@ double Lattice::minSurfaceDist(Point* point, double azim, double polar) {
 
   /* Get the min distance for X PLANE  */
   double dist_x;
-  if (u_x != 0.0) {
+  if (fabs(u_x) > FLT_EPSILON) {
     double plane_x = lat_x * _width_x - _width_x*_num_x/2 + _offset.getX();
     dist_x = (plane_x - point->getX()) / u_x;
   }
@@ -1616,7 +1616,7 @@ double Lattice::minSurfaceDist(Point* point, double azim, double polar) {
 
   /* Get the min distance for Y PLANE  */
   double dist_y;
-  if (u_y != 0.0) {
+  if (fabs(u_y) > FLT_EPSILON) {
     double plane_y = lat_y * _width_y - _width_y*_num_y/2 + _offset.getY();
     dist_y = (plane_y - point->getY()) / u_y;
   }
@@ -1626,7 +1626,8 @@ double Lattice::minSurfaceDist(Point* point, double azim, double polar) {
 
   /* Get the min distance for Z PLANE  */
   double dist_z;
-  if (u_z != 0 && _width_z != std::numeric_limits<double>::infinity()) {
+  if (fabs(u_z) > FLT_EPSILON && 
+      _width_z != std::numeric_limits<double>::infinity()) {
     double plane_z = lat_z * _width_z - _width_z*_num_z/2 + _offset.getZ();
     dist_z = (plane_z - point->getZ()) / u_z;
   }

--- a/src/constants.h
+++ b/src/constants.h
@@ -8,6 +8,8 @@
 #ifndef CONSTANTS_H_
 #define CONSTANTS_H_
 
+/** Threshold to determine if a float equals to 0.0 */
+#define FLT_EPSILON 1.0E-50
 
 /* The single line width permissible for timer / memory logger reports */
 #define REPORT_WIDTH 53

--- a/src/linalg.cpp
+++ b/src/linalg.cpp
@@ -262,7 +262,7 @@ bool linearSolve(Matrix* A, Matrix* M, Vector* X, Vector* B, double tol,
               int row = row_start + g;
               x[row] = (1.0 - SOR_factor) * x[row];
 
-              if (DIAG[row] == 0)
+              if (fabs(DIAG[row]) < FLT_EPSILON )
                   log_printf(ERROR, "A zero has been found on the diagonal of "
                              "the CMFD matrix");
 
@@ -583,7 +583,7 @@ double computeRMSE(Vector* X, Vector* Y, bool integrated, int it,
         new_source += X->getValue(i, g);
         old_source += Y->getValue(i, g);
       }
-      if (old_source != 0.0)
+    if (fabs(old_source) > FLT_EPSILON)
         residual.setValue(i, 0, pow((new_source - old_source) / old_source, 2));
     }
     sum_residuals = residual.getSum();
@@ -597,7 +597,7 @@ double computeRMSE(Vector* X, Vector* Y, bool integrated, int it,
 #pragma omp parallel for
     for (int i = 0; i < num_x*num_y*num_z; i++) {
       for (int g = 0; g < num_groups; g++) {
-        if (X->getValue(i, g) != 0.0)
+        if (fabs(X->getValue(i, g)) > FLT_EPSILON)
           residual.setValue(i, g, pow((X->getValue(i, g) - Y->getValue(i, g)) /
                                       X->getValue(i, g), 2));
       }
@@ -853,41 +853,41 @@ bool ddLinearSolve(Matrix* A, Matrix* M, Vector* X, Vector* B, double tol,
 
   /* Loop over cells */
   for (int color = 0; color < 2; color++) {
-		int offset = 0;
+    int offset = 0;
 #ifdef MPIx
-		getCouplingTerms(comm, color, coupling_sizes, coupling_indexes,
-										 coupling_coeffs, coupling_fluxes, x, offset);
+    getCouplingTerms(comm, color, coupling_sizes, coupling_indexes,
+                     coupling_coeffs, coupling_fluxes, x, offset);
 #endif
 #pragma omp parallel for collapse(2)
-		for (int iz=0; iz < num_z; iz++) {
-			for (int iy=0; iy < num_y; iy++) {
-				for (int ix=(iy+iz+color+offset)%2; ix < num_x; ix+=2) {
+    for (int iz=0; iz < num_z; iz++) {
+      for (int iy=0; iy < num_y; iy++) {
+        for (int ix=(iy+iz+color+offset)%2; ix < num_x; ix+=2) {
 
-					int cell = (iz*num_y + iy)*num_x + ix;
+          int cell = (iz*num_y + iy)*num_x + ix;
 
-					/* Determine whether each group's row is diagonally dominant */
-					for (int e = 0; e < num_groups; e++) {
+          /* Determine whether each group's row is diagonally dominant */
+          for (int e = 0; e < num_groups; e++) {
 
-						int row = cell * num_groups + e;
+            int row = cell * num_groups + e;
 
-						/* Add local off-diagonal elements */
-						double row_sum = 0.0;
-						int diag_ind = -1;
-						for (int idx = IA[row]; idx < IA[row+1]; idx++) {
-							if (JA[idx] != row)
-								row_sum += fabs(a[idx]);
-							else
-								diag_ind = idx;
-						}
+            /* Add local off-diagonal elements */
+            double row_sum = 0.0;
+            int diag_ind = -1;
+            for (int idx = IA[row]; idx < IA[row+1]; idx++) {
+              if (JA[idx] != row)
+                row_sum += fabs(a[idx]);
+              else
+                diag_ind = idx;
+            }
 
-						/* Add off-node off-diagonal elements */
+            /* Add off-node off-diagonal elements */
 #ifdef MPIx
-						if (comm != NULL) {
-							int* coupling_sizes = comm->num_connections[color];
-							CMFD_PRECISION** coupling_coeffs = comm->coupling_coeffs[color];
-							for (int idx = 0; idx < coupling_sizes[row]; idx++)
-								row_sum += fabs(coupling_coeffs[row][idx]);
-						}
+            if (comm != NULL) {
+              int* coupling_sizes = comm->num_connections[color];
+              CMFD_PRECISION** coupling_coeffs = comm->coupling_coeffs[color];
+              for (int idx = 0; idx < coupling_sizes[row]; idx++)
+                row_sum += fabs(coupling_coeffs[row][idx]);
+            }
 #endif
 
             /* Check for diagonal dominance */

--- a/src/linalg.cpp
+++ b/src/linalg.cpp
@@ -583,7 +583,7 @@ double computeRMSE(Vector* X, Vector* Y, bool integrated, int it,
         new_source += X->getValue(i, g);
         old_source += Y->getValue(i, g);
       }
-    if (fabs(old_source) > FLT_EPSILON)
+      if (fabs(old_source) > FLT_EPSILON)
         residual.setValue(i, 0, pow((new_source - old_source) / old_source, 2));
     }
     sum_residuals = residual.getSum();


### PR DESCRIPTION
Comparing floating point with == or != is unsafe. With -Wfloat-equal option, gcc figures out all the unsafe expressions.