### PR TITLE
Enabling single precision + deletion of virtual status of functions + style fixes + logs

### DIFF
--- a/profile/Makefile
+++ b/profile/Makefile
@@ -2,13 +2,13 @@
 # User Options
 #===============================================================================
 
-COMPILER    	 ?= mpi
-OPENMP      	 ?= yes
-OPTIMIZE    	 ?= yes
-DEBUG       	 ?= no
-PROFILE     	 ?= no
-PRECISION   	 ?= double
-CMFD_PRECISION ?= double
+COMPILER       ?= gnu
+OPENMP         ?= yes
+OPTIMIZE       ?= yes
+DEBUG          ?= no
+PROFILE        ?= no
+PRECISION      ?= single
+CMFD_PRECISION ?= single
 
 #===============================================================================
 # Source Code List
@@ -27,7 +27,8 @@ CMFD_PRECISION ?= double
 #case = models/simple-lattice/simple-lattice-3d.cpp
 #case = models/homogeneous/homogeneous.cpp
 #case = models/non-uniform-lattice/non-uniform-lattice.cpp
-case ?= models/run_time_standard/run_time_standard.cpp
+#case ?= models/run_time_standard/run_time_standard.cpp
+case ?= models/assembly_5/load-assembly.cpp
 
 source = \
 Cell.cpp \

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -2,7 +2,7 @@
 # User Options
 #===============================================================================
 
-COMPILER       ?= gnu
+COMPILER       ?= mpi
 OPENMP         ?= yes
 OPTIMIZE       ?= yes
 DEBUG          ?= no
@@ -183,10 +183,10 @@ CFLAGS += -DVEC_ALIGNMENT=16
 # Optimization Flags
 ifeq ($(OPTIMIZE),yes)
 ifeq ($(COMPILER),gnu)
-  CFLAGS += -O3 -ffast-math -fpic
+  CFLAGS += -O3 -ffast-math -fpic -march=native
 endif
 ifeq ($(COMPILER),mpi)
-  CFLAGS += -O3 -ffast-math -fpic
+  CFLAGS += -O3 -ffast-math -fpic -march=native
 endif
 ifeq ($(COMPILER),intel)
   CFLAGS += -O3 -xhost -fast -ansi-alias -no-prec-div -ipo
@@ -243,25 +243,25 @@ program = $(case:.cpp=)
 default: folder $(addsuffix .o, $(program)) $(program)
 
 $(programs): $(obj)  $(headers) $(addsuffix .o, $(program))
-	$(CC) $(CFLAGS) $(obj) $(addsuffix .o, $@) -o $@ $(LDFLAGS)
+    $(CC) $(CFLAGS) $(obj) $(addsuffix .o, $@) -o $@ $(LDFLAGS)
 
 obj/%.o: ../src/%.cpp Makefile
-	$(CC) $(CFLAGS) -c $< -o $@
+    $(CC) $(CFLAGS) -c $< -o $@
 
 %.o: %.cpp Makefile
-	$(CC) $(CFLAGS) -c $< -o $@
+    $(CC) $(CFLAGS) -c $< -o $@
 
 folder:
-	mkdir -p obj
+    mkdir -p obj
 
 all: folder $(addsuffix .o, $(programs)) $(programs)
 
 clean:
-	rm -rf $(program) $(obj) $(addsuffix .o, $(programs))
+    rm -rf $(program) $(obj) $(addsuffix .o, $(programs))
 
 edit:
-	vim -p $(case) $(cases)
+    vim -p $(case) $(cases)
 
 run:
-	./$(program)
-	#mpirun -np 2 ./$(program)
+    ./$(program)
+    #mpirun -np 2 ./$(program)

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -29,6 +29,7 @@ CMFD_PRECISION ?= single
 #case = models/non-uniform-lattice/non-uniform-lattice.cpp
 #case ?= models/run_time_standard/run_time_standard.cpp
 case ?= models/assembly_5/load-assembly.cpp
+#case ?= models/core_2/load-core.cpp
 
 source = \
 Cell.cpp \

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -243,25 +243,25 @@ program = $(case:.cpp=)
 default: folder $(addsuffix .o, $(program)) $(program)
 
 $(programs): $(obj)  $(headers) $(addsuffix .o, $(program))
-    $(CC) $(CFLAGS) $(obj) $(addsuffix .o, $@) -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $(obj) $(addsuffix .o, $@) -o $@ $(LDFLAGS)
 
 obj/%.o: ../src/%.cpp Makefile
-    $(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 %.o: %.cpp Makefile
-    $(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 folder:
-    mkdir -p obj
+	mkdir -p obj
 
 all: folder $(addsuffix .o, $(programs)) $(programs)
 
 clean:
-    rm -rf $(program) $(obj) $(addsuffix .o, $(programs))
+	rm -rf $(program) $(obj) $(addsuffix .o, $(programs))
 
 edit:
-    vim -p $(case) $(cases)
+	vim -p $(case) $(cases)
 
 run:
-    ./$(program)
-    #mpirun -np 2 ./$(program)
+	./$(program)
+	#mpirun -np 2 ./$(program)

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -595,7 +595,7 @@ void CPUSolver::setupMPIBuffers() {
           int neighbor = neighbor_connections.at(domains[d]);
 
           long slot;
-#pragma omp critical
+#pragma omp atomic capture
           {
             slot = num_tracks[neighbor];
             num_tracks[neighbor]++;

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -12,10 +12,7 @@
 CPUSolver::CPUSolver(TrackGenerator* track_generator)
   : Solver(track_generator) {
 
-  /* Initialize number of threads to 1, set later with setNumThreads() */
-  _num_threads = 1;
-  omp_set_num_threads(1);
-
+  setNumThreads(1);
   _FSR_locks = NULL;
   _source_type = "Flat";
 #ifdef MPIx
@@ -146,14 +143,14 @@ void CPUSolver::setNumThreads(int num_threads) {
                "be at least MPI_THREAD_SERIALIZED.");
 #endif
 
-  if (_track_generator != NULL)
+  if (_track_generator != NULL && num_threads > 1)
     if ((_track_generator->getSegmentFormation() == OTF_STACKS ||
        _track_generator->getSegmentFormation() == OTF_TRACKS) &&
        _track_generator->getNumThreads() != num_threads)
       log_printf(WARNING, "The number of threads used in track generation (%d)"
-               "should match the number of threads used in the solver (%d) for OTF "
-               "ray-tracing methods, as threaded buffers are shared.",
-               _track_generator->getNumThreads(), num_threads);
+                 "should match the number of threads used in the solver (%d) "
+                 "for OTF ray-tracing methods, as threaded buffers are shared.",
+                 _track_generator->getNumThreads(), num_threads);
 
   /* Set the number of threads for OpenMP */
   _num_threads = num_threads;

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -12,7 +12,10 @@
 CPUSolver::CPUSolver(TrackGenerator* track_generator)
   : Solver(track_generator) {
 
-  setNumThreads(1);
+  /* Initialize number of threads to 1, set later with setNumThreads() */
+  _num_threads = 1;
+  omp_set_num_threads(1);
+
   _FSR_locks = NULL;
   _source_type = "Flat";
 #ifdef MPIx
@@ -147,9 +150,10 @@ void CPUSolver::setNumThreads(int num_threads) {
     if ((_track_generator->getSegmentFormation() == OTF_STACKS ||
        _track_generator->getSegmentFormation() == OTF_TRACKS) &&
        _track_generator->getNumThreads() != num_threads)
-      log_printf(WARNING, "The number of threads used in track generation "
-               "should match the number of threads used in the solver for OTF "
-               "ray-tracing methods, as threaded buffers are shared.");
+      log_printf(WARNING, "The number of threads used in track generation (%d)"
+               "should match the number of threads used in the solver (%d) for OTF "
+               "ray-tracing methods, as threaded buffers are shared.",
+               _track_generator->getNumThreads(), num_threads);
 
   /* Set the number of threads for OpenMP */
   _num_threads = num_threads;

--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -101,11 +101,11 @@ protected:
   void boundaryFluxChecker();
 #endif
   virtual void flattenFSRFluxes(FP_PRECISION value);
-  virtual void flattenFSRFluxesChiSpectrum();
+  void flattenFSRFluxesChiSpectrum();
   void storeFSRFluxes();
   virtual double normalizeFluxes();
   virtual void computeFSRSources(int iteration);
-  virtual void transportSweep();
+  void transportSweep();
   virtual void computeStabilizingFlux();
   virtual void stabilizeFlux();
   virtual void addSourceToScalarFlux();
@@ -118,23 +118,23 @@ public:
 
   int getNumThreads();
   void setNumThreads(int num_threads);
-  virtual void setFixedSourceByFSR(long fsr_id, int group, FP_PRECISION source);
+  void setFixedSourceByFSR(long fsr_id, int group, FP_PRECISION source);
   void computeFSRFissionRates(double* fission_rates, long num_FSRs);
-  virtual void printInputParamsSummary();
+  void printInputParamsSummary();
 
-  virtual void tallyScalarFlux(segment* curr_segment, int azim_index,
+  void tallyScalarFlux(segment* curr_segment, int azim_index,
                                int polar_index, float* track_flux,
                                FP_PRECISION* fsr_flux);
 
-  virtual void tallyCurrent(segment* curr_segment, int azim_index,
+  void tallyCurrent(segment* curr_segment, int azim_index,
                             int polar_index, float* track_flux,
                             bool fwd);
 
-  virtual void transferBoundaryFlux(Track* track, int azim_index,
+  void transferBoundaryFlux(Track* track, int azim_index,
                                     int polar_index, bool direction,
                                     float* track_flux);
 
-  virtual void getFluxes(FP_PRECISION* out_fluxes, int num_fluxes);
+  void getFluxes(FP_PRECISION* out_fluxes, int num_fluxes);
 
   void initializeFixedSources();
 

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -1283,7 +1283,7 @@ void Cell::sectorize(std::vector<Cell*>& subcells) {
   /* A container for each of the bounding planes for the sector Cells */
   std::vector<Plane*> planes;
 
-  log_printf(NORMAL, "Sectorizing Cell %d with %d sectors",_id, _num_sectors);
+  log_printf(DEBUG, "Sectorizing Cell %d with %d sectors", _id, _num_sectors);
 
   /* Create each of the bounding planes for the sector Cells */
   for (int i=0; i < _num_sectors; i++) {

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -1283,7 +1283,7 @@ void Cell::sectorize(std::vector<Cell*>& subcells) {
   /* A container for each of the bounding planes for the sector Cells */
   std::vector<Plane*> planes;
 
-  log_printf(DEBUG, "Sectorizing Cell %d with %d sectors",_id, _num_sectors);
+  log_printf(NORMAL, "Sectorizing Cell %d with %d sectors",_id, _num_sectors);
 
   /* Create each of the bounding planes for the sector Cells */
   for (int i=0; i < _num_sectors; i++) {
@@ -1316,7 +1316,7 @@ void Cell::sectorize(std::vector<Cell*>& subcells) {
     if (_num_sectors != 2) {
       /* Add new bounding planar Surfaces to the clone */
       sector->addSurface(+1, planes.at(i));
-      
+
       if (i+1 < _num_sectors)
         sector->addSurface(-1, planes.at(i+1));
       else
@@ -1631,7 +1631,7 @@ std::string Cell::toString() {
   std::map<int, Halfspace*> _surfaces = getSurfaces();
   string << ", Surfaces: ";
   for (iter = _surfaces.begin(); iter != _surfaces.end(); ++iter)
-    string <<  std::showpos << "\nhalfspace = " << iter->second->_halfspace 
+    string << std::showpos << "\nhalfspace = " << iter->second->_halfspace 
            << ", " << iter->second->_surface->toString();
 
   return string.str();

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -2351,8 +2351,9 @@ void Cmfd::useAxialInterpolation(int interpolate) {
                " meaning No interpolation, FSR axially averaged value or"
                " centroid z-coordinate evaluted value");
   if(interpolate==1 || interpolate==2)
-    log_printf(WARNING, "Axial interpolation CMFD prolongation may only"
+    log_printf(NORMAL, "WARNING: Axial interpolation CMFD prolongation may only"
                " be effective when all the FSRs are axially homogeneous");
+  //FIXME Use a log level that prints the warning once for all nodes, without NORMAL
   _use_axial_interpolation = interpolate;
 }
 

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -2351,7 +2351,7 @@ void Cmfd::useAxialInterpolation(int interpolate) {
                " meaning No interpolation, FSR axially averaged value or"
                " centroid z-coordinate evaluted value");
   if(interpolate==1 || interpolate==2)
-    log_printf(NORMAL, "WARNING: Axial interpolation CMFD prolongation may only"
+    log_printf(WARNING, "Axial interpolation CMFD prolongation may only"
                " be effective when all the FSRs are axially homogeneous");
   _use_axial_interpolation = interpolate;
 }
@@ -2512,39 +2512,39 @@ void Cmfd::generateKNearestStencils() {
   std::vector<long>::iterator fsr_iter;
   Point* centroid;
   long fsr_id;
-  
+
   if (_centroid_update_on){
     /* Number of cells in stencil */
     int num_cells_in_stencil = 9;
-  
+
     /* Loop over mesh cells */
     for (int i = 0; i < _local_num_xn*_local_num_yn*_local_num_zn; i++) {
-  
+
       int global_ind = getGlobalCMFDCell(i);
-  
+
       /* Loop over FRSs in mesh cell */
       for (fsr_iter = _cell_fsrs.at(i).begin();
           fsr_iter != _cell_fsrs.at(i).end(); ++fsr_iter) {
-  
+
         fsr_id = *fsr_iter;
-  
+
         /* Get centroid */
         centroid = _geometry->getFSRCentroid(fsr_id);
-  
+
         /* Create new stencil */
         _k_nearest_stencils[fsr_id] =
           std::vector< std::pair<int, double> >();
-  
+
         /* Get distance to all cells that touch current cell */
         for (int j=0; j < num_cells_in_stencil; j++)
           _k_nearest_stencils[fsr_id]
             .push_back(std::make_pair<int, double>
                       (int(j), getDistanceToCentroid(centroid, global_ind, j)));
-  
+
         /* Sort the distances */
         std::sort(_k_nearest_stencils[fsr_id].begin(),
                   _k_nearest_stencils[fsr_id].end(), stencilCompare);
-  
+
         /* Remove ghost cells that are outside the geometry boundaries */
         stencil_iter = _k_nearest_stencils[fsr_id].begin();
         while (stencil_iter != _k_nearest_stencils[fsr_id].end()) {
@@ -2559,7 +2559,7 @@ void Cmfd::generateKNearestStencils() {
           (std::min(_k_nearest, int(_k_nearest_stencils[fsr_id].size())));
       }
     }
-  
+
     /* Precompute (1.0 - cell distance / total distance) of each FSR centroid to
     * its k-nearest CMFD cells */
     double total_distance;
@@ -2590,7 +2590,7 @@ void Cmfd::generateKNearestStencils() {
     for (long r=0; r < _num_FSRs; r++) {
       _axial_interpolants.at(r) = new double[3]();
     }
-    
+
     /* Loop over mesh cells */
     for (int i = 0; i < _local_num_xn*_local_num_yn*_local_num_zn; i++) {
 
@@ -2598,16 +2598,16 @@ void Cmfd::generateKNearestStencils() {
       int z_start = 0;
       if(_domain_communicator != NULL)
         z_start = _accumulate_lmz[_domain_communicator->_domain_idx_z];
-      
+
       /* Calculate the CMFD cell z-coordinate */
       int z_ind = i / (_local_num_xn * _local_num_yn);
-      
+
       /* The heights of neighboring three CMFD meshes for quadratic fit */
       double h0, h1, h2; 
-      
+
       /* The z coordinate of the mesh center of the middle-CMFD cell  */
       double z_cmfd;
-      
+
       if(z_ind == 0) {
         h0 = _cell_widths_z[z_start + z_ind];
         h1 = _cell_widths_z[z_start + z_ind + 1];
@@ -2626,7 +2626,7 @@ void Cmfd::generateKNearestStencils() {
         h2 = _cell_widths_z[z_start + z_ind + 1];
         z_cmfd = _accumulate_z[z_start + z_ind] + h1/2. + _lattice->getMinZ();
       }
-    
+
       /* Start and end relative z-coordinate of an FSR */
       double zs, ze;
 
@@ -2639,7 +2639,7 @@ void Cmfd::generateKNearestStencils() {
         fsr_id = *fsr_iter;
         Point* centroid = _geometry->getFSRCentroid(fsr_id);
         Point* feature_point = _geometry->getFSRPoint(fsr_id);
-        
+
         double zc = (centroid->getZ() - z_cmfd) / h1;
         zs = (feature_point->getZ() - z_cmfd) / h1;
         ze = 2*zc - zs;
@@ -2650,19 +2650,19 @@ void Cmfd::generateKNearestStencils() {
           _axial_interpolants.at(fsr_id)[0] = (h1*(h1+h1*zc*4.0+h2*zc*8.0-
             h1*(zc*zc)*1.6E1-h1*(zs*zs)*4.0+h1*zc*zs*8.0)*(-1.0/4.0))
                                               /((h0+h1)*(h0+h1+h2));
-          
-  
+
+
           _axial_interpolants.at(fsr_id)[1] = (h1+h2-h1*zc*2.0)/(h1+h2)+(h1*(h1+
           h1*zc*4.0+h2*zc*8.0-h1*(zc*zc)*1.6E1-h1*(zs*zs)*4.0+h1*zc*zs*8.0)*
           (1.0/4.0))/(h2*(h0+h1))-((h1*h1)*(h1+h1*zc*4.0+h2*zc*8.0-h1*(zc*zc)*
           1.6E1-h1*(zs*zs)*4.0+h1*zc*zs*8.0)*(1.0/4.0))/(h2*(h1+h2)*(h0+h1+h2));
-          
-  
+
+
           _axial_interpolants.at(fsr_id)[2] = (h1*(-h1+h0*zc*8.0+h1*zc*4.0+
             h1*(zc*zc)*1.6E1+h1*(zs*zs)*4.0-h1*zc*zs*8.0)*(1.0/4.0))
                                               /((h1+h2)*(h0+h1+h2));
-          
-          
+
+
           log_printf(DEBUG, "CMFD-ID: %d, FSR-ID: %ld, c0= %10.6f, c1= %10.6f,"
                      " c2= %10.6f", i, fsr_id, _axial_interpolants.at(fsr_id)[0],
                      _axial_interpolants.at(fsr_id)[1],
@@ -2674,19 +2674,19 @@ void Cmfd::generateKNearestStencils() {
         else if(_use_axial_interpolation == 2) {
           _axial_interpolants.at(fsr_id)[0] = -(h1*(h1+h1*zc*4.0+h2*zc*8.0-h1*
           (zc*zc)*1.2E1))/((h0*4.0+h1*4.0)*(h0+h1+h2));
-            
-          
+
+
           _axial_interpolants.at(fsr_id)[1] = (-zc*(h0*(h1*h1)*1.2E1+(h0*h0)*h1*
           8.0-h1*(h2*h2)*8.0-(h1*h1)*h2*1.2E1)+h0*(h1*h1)*9.0+(h0*h0)*h1*4.0+h0*
           (h2*h2)*4.0+(h0*h0)*h2*4.0+h1*(h2*h2)*4.0+(h1*h1)*h2*9.0+(h1*h1*h1)*6.0
           -(zc*zc)*(h0*(h1*h1)*1.2E1+(h1*h1)*h2*1.2E1+(h1*h1*h1)*2.4E1)+h0*h1*h2
           *1.2E1)/((h1+h2)*(h0*4.0+h1*4.0)*(h0+h1+h2));
-            
-            
+
+
          _axial_interpolants.at(fsr_id)[2] = (h1*(-h1+h0*zc*8.0+h1*zc*4.0+h1*
          (zc*zc)*1.2E1))/((h1*4.0+h2*4.0)*(h0+h1+h2));
-         
-         
+
+
          log_printf(DEBUG, "CMFD-ID: %d, FSR-ID: %ld, c0= %10.6f, c1= %10.6f,"
                     " c2= %10.6f", i, fsr_id, _axial_interpolants.at(fsr_id)[0],
                     _axial_interpolants.at(fsr_id)[1],
@@ -2929,7 +2929,7 @@ double Cmfd::getDistanceToCentroid(Point* centroid, int cell_id,
   bool found = false;
   double centroid_x = centroid->getX();
   double centroid_y = centroid->getY();
-  
+
   /* The center of geometry is not always at (0,0,0), then relative coordinates
      should be used. */
   double dx = centroid_x - _lattice->getMinX();
@@ -3312,7 +3312,7 @@ void Cmfd::initialize() {
       int y_end = y_start + _local_num_yn;
       int z_start = _accumulate_lmz[_domain_communicator->_domain_idx_z];
       int z_end = z_start + _local_num_zn;
-      
+
       _boundary_index_map.resize(NUM_FACES);
 
       /* Map connecting cells on x-surfaces */
@@ -3395,11 +3395,11 @@ void Cmfd::initializeLattice(Point* offset) {
     _cell_width_x = _width_x / _num_x;
     _cell_width_y = _width_y / _num_y;
     _cell_width_z = _width_z / _num_z;
-    
+
     /* 2D case, set the axial width 1.0 */
     if(_width_z == std::numeric_limits<double>::infinity())
       _cell_width_z = 1.0;
-    
+
     _cell_widths_x.resize(_num_x,_cell_width_x);
     _cell_widths_y.resize(_num_y,_cell_width_y);
     _cell_widths_z.resize(_num_z,_cell_width_z);
@@ -3416,16 +3416,16 @@ void Cmfd::initializeLattice(Point* offset) {
   _accumulate_x.resize(_num_x+1,0.0);
   _accumulate_y.resize(_num_y+1,0.0);
   _accumulate_z.resize(_num_z+1,0.0);
-  
+
   for(int i=0; i<_num_x; i++)
     _accumulate_x[i+1] = _accumulate_x[i] + _cell_widths_x[i];
-    
+
   for(int i=0; i<_num_y; i++)
     _accumulate_y[i+1] = _accumulate_y[i] + _cell_widths_y[i];  
-    
+
   for(int i=0; i<_num_z; i++)
     _accumulate_z[i+1] = _accumulate_z[i] + _cell_widths_z[i];
-  
+
   if(fabs(_width_x - _accumulate_x[_num_x]) > FLT_EPSILON ||
      fabs(_width_y - _accumulate_y[_num_y]) > FLT_EPSILON ||
      fabs(_width_z - _accumulate_z[_num_z]) > FLT_EPSILON)
@@ -3448,19 +3448,19 @@ void Cmfd::initializeLattice(Point* offset) {
   _lattice->setNumX(_num_x);
   _lattice->setNumY(_num_y);
   _lattice->setNumZ(_num_z);
-  
-  if(_non_uniform)
+
+  if (_non_uniform)
     _lattice->setWidths(_cell_widths_x, _cell_widths_y, _cell_widths_z);
   else {
-    if(is_2D)
+    if (is_2D)
       _lattice->setWidth(_cell_width_x, _cell_width_y, 
                          std::numeric_limits<double>::infinity());
     else
       _lattice->setWidth(_cell_width_x, _cell_width_y, _cell_width_z);
   }
-  
+
   _lattice->setOffset(offset->getX(), offset->getY(), offset->getZ());
-  
+
   _lattice->computeSizes();
 }
 
@@ -3631,11 +3631,11 @@ void Cmfd::copyCurrentsToBackup() {
 CMFD_PRECISION Cmfd::getSurfaceWidth(int surface, int global_ind) {
 
   CMFD_PRECISION width;
-  
+
   int ix = global_ind % _num_x;
   int iy = (global_ind % (_num_x * _num_y)) / _num_x;
   int iz = global_ind / (_num_x * _num_y);
-  
+
   if (surface == SURFACE_X_MIN || surface == SURFACE_X_MAX)
     return _cell_widths_y[iy] * _cell_widths_z[iz];
   else if (surface == SURFACE_Y_MIN || surface == SURFACE_Y_MAX)
@@ -3655,7 +3655,7 @@ CMFD_PRECISION Cmfd::getPerpendicularSurfaceWidth(int surface, int global_ind) {
   int ix = global_ind % _num_x;
   int iy = (global_ind % (_num_x * _num_y)) / _num_x;
   int iz = global_ind / (_num_x * _num_y);
-  
+
   if (surface == SURFACE_X_MIN || surface == SURFACE_X_MAX)
     return _cell_widths_x[ix];
   else if (surface == SURFACE_Y_MIN || surface == SURFACE_Y_MAX)
@@ -4948,14 +4948,14 @@ void Cmfd::recordNetCurrents() {
  * @param widths A vector of 3 vectors for the x y z sizes of non-uniform meshes
  */
 void Cmfd::setWidths(std::vector< std::vector<double> > widths) {
-  
+
   if(widths.size() == 3) 
     _cell_widths_z = widths[2];
   else if(widths.size() == 2)
     _cell_widths_z.push_back(1.0);
   else  
     log_printf(ERROR, "widths must have dimension 2 or 3");
-  
+
   _non_uniform = true;
   _cell_widths_x = widths[0];
   _cell_widths_y = widths[1];

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -771,7 +771,9 @@ CMFD_PRECISION Cmfd::getDiffusionCoefficient(int cmfd_cell, int group) {
  *         (\f$ \tilde{D} \f$)
  */
 void Cmfd::getSurfaceDiffusionCoefficient(int cmfd_cell, int surface,
-    int group, int moc_iteration,double& dif_surf, double& dif_surf_corr) {
+                                          int group, int moc_iteration,
+                                          CMFD_PRECISION& dif_surf, 
+                                          CMFD_PRECISION& dif_surf_corr) {
 
   FP_PRECISION current, current_out, current_in;
   CMFD_PRECISION flux_next;

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -365,7 +365,8 @@ private:
   double getDistanceToCentroid(Point* centroid, int cell_id,
                                      int stencil_index);
   void getSurfaceDiffusionCoefficient(int cmfd_cell, int surface,
-        int group, int moc_iteration,double& dif_surf, double& dif_surf_corr);
+        int group, int moc_iteration, CMFD_PRECISION& dif_surf,
+        CMFD_PRECISION& dif_surf_corr);
   CMFD_PRECISION getDiffusionCoefficient(int cmfd_cell, int group);
   CMFD_PRECISION getSurfaceWidth(int surface, int global_ind);
   CMFD_PRECISION getPerpendicularSurfaceWidth(int surface, int global_ind);

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -3656,7 +3656,6 @@ void Geometry::dumpToFile(std::string filename, bool non_uniform_lattice) {
     int num_sectors = cell->getNumSectors();
     fwrite(&num_rings, sizeof(int), 1, out);
     fwrite(&num_sectors, sizeof(int), 1, out);
-    log_printf(NORMAL, "Printing sectors %d", num_sectors);
 
     /* Print parent cell */
     bool has_parent = cell->hasParent();
@@ -4024,7 +4023,6 @@ void Geometry::loadFromFile(std::string filename, bool non_uniform_lattice,
     ret = twiddleRead(&num_sectors, sizeof(int), 1, in);
     all_cells[key]->setNumRings(num_rings);
     all_cells[key]->setNumSectors(num_sectors);
-    log_printf(NORMAL, "Reading sectors %d", num_sectors);
 
     /* Read parent cell */
     bool has_parent;
@@ -4150,7 +4148,7 @@ void Geometry::loadFromFile(std::string filename, bool non_uniform_lattice,
         ret = twiddleRead(&widths_y[0], sizeof(double), num_y, in);
         ret = twiddleRead(&widths_z[0], sizeof(double), num_z, in);
       }
-     
+
       /* Create lattice */
       Lattice* new_lattice = new Lattice(id, name);
       all_universes[key] = new_lattice;
@@ -4163,7 +4161,7 @@ void Geometry::loadFromFile(std::string filename, bool non_uniform_lattice,
       }
       else
         new_lattice->setWidth(width_x, width_y, width_z);
-      
+
       new_lattice->setNonUniform(non_uniform);
       new_lattice->setOffset(offset[0], offset[1], offset[2]);
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -2465,13 +2465,6 @@ void Geometry::initializeAxialFSRs(std::vector<double> global_z_mesh) {
 
       /* Shoot vertical track through the geometry to initialize 3D FSRs */
       segmentize3D(&track, true);
-      //log_printf(NORMAL, "number of fsrs here %d", _FSR_keys_map.size());
-      //if (_FSR_keys_map.size() < 500) {
-      //  for (long r=0; r < _FSR_keys_map.size(); r++) {
-          //Cell* cell = findCellContainingFSR(r);
-          //log_printf(NORMAL, "fsr %d : cell %d %s", r, cell->getId(), cell->getName());
-      //  }
-      //}
 
       /* Extract segments from track */
       int num_segments = track.getNumSegments();
@@ -2508,7 +2501,6 @@ void Geometry::initializeAxialFSRs(std::vector<double> global_z_mesh) {
 
   /* Re-order FSR IDs so they are sequential in the axial direction */
   reorderFSRIDs();
-  log_printf(NORMAL, "number of fsrs here %d", _FSR_keys_map.size());
   log_printf(NORMAL, "Finished initializing 3D FSRs");
 }
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -2829,8 +2829,7 @@ std::string Geometry::toString() {
  *          Surfaces, Cell, Universes and Lattices contained by the Geometry.
  */
 void Geometry::printString() {
-  std::string geom_string = toString();
-  log_printf(RESULT, "%s", geom_string);
+  log_printf(RESULT, "%s", toString().c_str());
 }
 
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1779,7 +1779,7 @@ void Geometry::subdivideCells() {
 void Geometry::initializeFlatSourceRegions() {
 
   log_printf(NORMAL, "Initializing flat source regions...");
-    
+
   /* Subdivide Cells into sectors and rings */
   subdivideCells();
 
@@ -2465,6 +2465,13 @@ void Geometry::initializeAxialFSRs(std::vector<double> global_z_mesh) {
 
       /* Shoot vertical track through the geometry to initialize 3D FSRs */
       segmentize3D(&track, true);
+      //log_printf(NORMAL, "number of fsrs here %d", _FSR_keys_map.size());
+      //if (_FSR_keys_map.size() < 500) {
+      //  for (long r=0; r < _FSR_keys_map.size(); r++) {
+          //Cell* cell = findCellContainingFSR(r);
+          //log_printf(NORMAL, "fsr %d : cell %d %s", r, cell->getId(), cell->getName());
+      //  }
+      //}
 
       /* Extract segments from track */
       int num_segments = track.getNumSegments();
@@ -2501,7 +2508,7 @@ void Geometry::initializeAxialFSRs(std::vector<double> global_z_mesh) {
 
   /* Re-order FSR IDs so they are sequential in the axial direction */
   reorderFSRIDs();
-
+  log_printf(NORMAL, "number of fsrs here %d", _FSR_keys_map.size());
   log_printf(NORMAL, "Finished initializing 3D FSRs");
 }
 
@@ -2822,9 +2829,10 @@ std::string Geometry::toString() {
  *          Surfaces, Cell, Universes and Lattices contained by the Geometry.
  */
 void Geometry::printString() {
-  log_printf(RESULT, toString().c_str());
+  std::string geom_string = toString();
+  log_printf(RESULT, "%s", geom_string);
 }
-  
+
 
 /**
  * @brief Prints FSR layout to file
@@ -3648,6 +3656,7 @@ void Geometry::dumpToFile(std::string filename, bool non_uniform_lattice) {
     int num_sectors = cell->getNumSectors();
     fwrite(&num_rings, sizeof(int), 1, out);
     fwrite(&num_sectors, sizeof(int), 1, out);
+    log_printf(NORMAL, "Printing sectors %d", num_sectors);
 
     /* Print parent cell */
     bool has_parent = cell->hasParent();
@@ -4015,6 +4024,7 @@ void Geometry::loadFromFile(std::string filename, bool non_uniform_lattice,
     ret = twiddleRead(&num_sectors, sizeof(int), 1, in);
     all_cells[key]->setNumRings(num_rings);
     all_cells[key]->setNumSectors(num_sectors);
+    log_printf(NORMAL, "Reading sectors %d", num_sectors);
 
     /* Read parent cell */
     bool has_parent;

--- a/src/ParallelHashMap.h
+++ b/src/ParallelHashMap.h
@@ -298,7 +298,7 @@ long FixedHashMap<K,V>::insert_and_get_count(K key, V value) {
 
   /* increment counter and return number */
   size_t N;
-#pragma omp critical (node_incr)
+#pragma omp atomic capture
     N = _N++;
 
   return (long) N;

--- a/src/Progress.cpp
+++ b/src/Progress.cpp
@@ -1,6 +1,9 @@
 #include "Progress.h"
 #include "Geometry.h"
 
+/**
+ * @brief Constructor for Progress.
+ */
 Progress::Progress(int num_iterations, std::string name, double interval,
                    Geometry* geometry, bool mpi_comm) {
 
@@ -16,6 +19,9 @@ Progress::Progress(int num_iterations, std::string name, double interval,
   _name = name;
   _counter = 0;
   _curr_interval = 0;
+
+  /* Based on interval fraction, set an integer number of intervals, and save 
+   * each interval value in _intervals */
   int num_intervals = 1. / interval + 1;
   _intervals.resize(num_intervals);
   int interval_stride = interval * num_iterations;
@@ -24,14 +30,19 @@ Progress::Progress(int num_iterations, std::string name, double interval,
   for (int i=0; i < num_intervals; i++)
     _intervals.at(i) = std::min(i * interval_stride, num_iterations-1);
   _intervals.at(num_intervals-1) = num_iterations-1;
-
 }
 
 
+/**
+ * @brief Destructor for Progress.
+ */
 Progress::~Progress() {
 }
 
 
+/**
+ * @brief Increment the counter, print log if it has reached an interval bound.
+ */
 void Progress::incrementCounter() {
 
   int curr_count;
@@ -48,6 +59,8 @@ void Progress::incrementCounter() {
       double num_iters = _num_iterations;
       double percent = count / num_iters * 100.0;
 #ifdef MPIx
+      //FIXME This barrier is making every node synchronize at every interval,
+      // so currently ten times per routine tracked by a Progress.
       if (_mpi_comm)
         MPI_Barrier(_geometry->getMPICart());
 #endif
@@ -57,11 +70,13 @@ void Progress::incrementCounter() {
       if (_curr_interval >= _intervals.size())
         break;
     }
-#pragma omp flush (_counter, _curr_interval)
   }
 }
 
 
+/**
+ * @brief Reset the counter.
+ */
 void Progress::reset() {
   _counter = 0;
   _curr_interval = 0;

--- a/src/Quadrature.cpp
+++ b/src/Quadrature.cpp
@@ -784,7 +784,7 @@ void Quadrature::precomputeWeights(bool solve_3D) {
 
   /* Create uncorrected weights if no angles have been set yet */
   if (_phis == NULL) {
-    log_printf(WARNING, "Using uncorrected angles for weights");
+    log_printf(NORMAL, "WARNING: Using uncorrected angles for weights");
     double phi = M_PI / _num_azim;
     for (int a = 0; a < _num_azim/4; a++) {
       setPhi(phi, a);

--- a/src/Quadrature.cpp
+++ b/src/Quadrature.cpp
@@ -784,7 +784,7 @@ void Quadrature::precomputeWeights(bool solve_3D) {
 
   /* Create uncorrected weights if no angles have been set yet */
   if (_phis == NULL) {
-    log_printf(NORMAL, "WARNING: Using uncorrected angles for weights");
+    log_printf(WARNING, "Using uncorrected angles for weights");
     double phi = M_PI / _num_azim;
     for (int a = 0; a < _num_azim/4; a++) {
       setPhi(phi, a);

--- a/src/Region.cpp
+++ b/src/Region.cpp
@@ -282,7 +282,7 @@ double Region::getMinZ() {
   else if(_region_type == UNION)
     min_z = +std::numeric_limits<double>::infinity();
   else if(_region_type == COMPLEMENT) {
-    log_printf(WARNING, "getMinZ() is not implemented for complement regions,"
+    log_printf(DEBUG, "getMinZ() is not implemented for complement regions,"
                " min z of region complemented returned.");
     min_z = -std::numeric_limits<double>::infinity();
   }
@@ -313,7 +313,7 @@ double Region::getMaxZ() {
   else if(_region_type == UNION)
     max_z = -std::numeric_limits<double>::infinity();
   else if(_region_type == COMPLEMENT) {
-    log_printf(WARNING, "getMaxZ() is not implemented for complement regions,"
+    log_printf(DEBUG, "getMaxZ() is not implemented for complement regions,"
                " max z of region complemented returned.");
     max_z = +std::numeric_limits<double>::infinity();
   }

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1634,7 +1634,7 @@ void Solver::printTimerReport() {
       _num_iterations;
   double time_per_integration = (transport_sweep / num_integrations * 
                                  (omp_get_max_threads() * num_ranks));
-  msg_string = "Integration time per segment by thread";
+  msg_string = "Integration time per segment-group by thread";
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), time_per_integration);
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1622,10 +1622,19 @@ void Solver::printTimerReport() {
   }
 #endif
 
+  int num_ranks = 1;
+#ifdef MPIx
+  if (_geometry->isDomainDecomposed()) {
+    MPI_Comm MPI_cart = _geometry->getMPICart();
+    MPI_Comm_size(MPI_cart, &num_ranks);
+  }
+#endif
+
   long num_integrations = 2 * _fluxes_per_track * total_num_segments *
       _num_iterations;
-  double time_per_integration = (transport_sweep / num_integrations);
-  msg_string = "Integration time per segment integration";
+  double time_per_integration = (transport_sweep / num_integrations * 
+                                 (omp_get_max_threads() * num_ranks));
+  msg_string = "Integration time per segment by thread";
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), time_per_integration);
 

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -404,7 +404,7 @@ public:
   Solver(TrackGenerator* track_generator=NULL);
   virtual ~Solver();
 
-  virtual void setGeometry(Geometry* geometry);
+  void setGeometry(Geometry* geometry);
 
   Geometry* getGeometry();
   TrackGenerator* getTrackGenerator();
@@ -429,12 +429,12 @@ public:
   void loadInitialFSRFluxes(std::string fname);
   void loadFSRFluxes(std::string fname, bool assign_k_eff=false, double tolerance=0.01);
 
-  virtual double getFlux(long fsr_id, int group);
+  double getFlux(long fsr_id, int group);
   virtual void getFluxes(FP_PRECISION* out_fluxes, int num_fluxes) = 0;
   double getFSRSource(long fsr_id, int group);
 
-  virtual void setTrackGenerator(TrackGenerator* track_generator);
-  virtual void setConvergenceThreshold(double threshold);
+  void setTrackGenerator(TrackGenerator* track_generator);
+  void setConvergenceThreshold(double threshold);
   virtual void setFixedSourceByFSR(long fsr_id, int group, double source);
   void setFixedSourceByCell(Cell* cell, int group, double source);
   void setFixedSourceByMaterial(Material* material, int group,
@@ -493,7 +493,7 @@ public:
   void limitXS();
   void setLimitingXSMaterials(std::vector<int> material_ids,
                               int reset_iteration);
-  virtual void checkLimitXS(int iteration);
+  void checkLimitXS(int iteration);
 
 
   /**

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -496,7 +496,7 @@ std::string Plane::toString() {
   string << "Surface ID = " << _id
          << ", name = " << _name
          << ", type = PLANE "
-         << ", A = " << _A << ", B = " << _B << ", C = " << _C << ", D = " << _D;;
+         << ", A = " << _A << ", B = " << _B << ", C = " << _C << ", D = " << _D;
 
   return string.str();
 }

--- a/src/Track.h
+++ b/src/Track.h
@@ -27,7 +27,7 @@
 struct segment {
 
   /** The length of the segment (cm) */
-  FP_PRECISION _length;
+  double _length;
 
   /** A pointer to the material in which this segment resides */
   Material* _material;

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -708,7 +708,7 @@ void TrackGenerator::checkBoundaryConditions() {
  *          Points, azimuthal angle, and azimuthal angle quadrature weight.
  */
 void TrackGenerator::generateTracks() {
-    
+
   /* Start recording track generation time */
   _timer->startTimer();
 
@@ -769,12 +769,6 @@ void TrackGenerator::generateTracks() {
     log_printf(NORMAL, "Total number of FSRs %ld", total_num_FSRs);
     log_printf(DEBUG, "Number of FSRs in domain %ld", num_FSRs);
 
-    for (long r=0; r < num_FSRs; r++) {
-      Cell* cell = _geometry->findCellContainingFSR(r);
-      //log_printf(NORMAL, "fsr %d : cell %d %s", r, cell->getId(), cell->getName());
-    }
-
-
     /* Loop over all FSRs to initialize OpenMP locks */
 #pragma omp parallel for schedule(guided)
     for (long r=0; r < num_FSRs; r++)
@@ -788,7 +782,7 @@ void TrackGenerator::generateTracks() {
     log_printf(ERROR, "Unable to allocate memory needed to generate "
                "Tracks. Backtrace:\n%s", e.what());
   }
-  
+
   /* Stop recording track generation time and print */
 #ifdef MPIx
   if (_geometry->isDomainDecomposed())

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -769,6 +769,12 @@ void TrackGenerator::generateTracks() {
     log_printf(NORMAL, "Total number of FSRs %ld", total_num_FSRs);
     log_printf(DEBUG, "Number of FSRs in domain %ld", num_FSRs);
 
+    for (long r=0; r < num_FSRs; r++) {
+      Cell* cell = _geometry->findCellContainingFSR(r);
+      //log_printf(NORMAL, "fsr %d : cell %d %s", r, cell->getId(), cell->getName());
+    }
+
+
     /* Loop over all FSRs to initialize OpenMP locks */
 #pragma omp parallel for schedule(guided)
     for (long r=0; r < num_FSRs; r++)

--- a/src/TrackGenerator.h
+++ b/src/TrackGenerator.h
@@ -127,7 +127,7 @@ protected:
 
   /** Private class methods */
   virtual void initializeTracks();
-  virtual void initializeTrackReflections();
+  void initializeTrackReflections();
   virtual void segmentize();
   virtual void setContainsSegments(bool contains_segments);
   virtual void allocateTemporarySegments();
@@ -153,7 +153,7 @@ public:
   void countSegments();
   bool getPeriodic();
   Track** get2DTracksArray();
-  virtual Track** getTracksArray();
+  Track** getTracksArray();
   Track** get2DTracks();
   FP_PRECISION getMaxOpticalLength();
   int getMaxNumSegments();
@@ -179,7 +179,7 @@ public:
   void setNumThreads(int num_threads);
   void setNumAzim(int num_azim);
   void setDesiredAzimSpacing(double spacing);
-  virtual void setGeometry(Geometry* geometry);
+  void setGeometry(Geometry* geometry);
   void setZCoord(double z_coord);
   void setQuadrature(Quadrature* quadrature);
   void setMaxOpticalLength(FP_PRECISION tau);
@@ -198,7 +198,7 @@ public:
   void dumpSegmentsToFile();
   bool readSegmentsFromFile();
   void initializeTrackFileDirectory();
-  virtual void initializeTracksArray();
+  void initializeTracksArray();
   virtual void checkBoundaryConditions();
 };
 

--- a/src/TrackGenerator3D.cpp
+++ b/src/TrackGenerator3D.cpp
@@ -1216,7 +1216,7 @@ void TrackGenerator3D::segmentizeExtruded() {
 
   log_printf(NORMAL, "Ray tracing for axially extruded track segmentation...");
 
-  /* Get all unique z-coords at which 2D radial segementation is performed */
+  /* Get all unique z-coords at which 2D radial segmentation is performed */
   std::vector<double> z_coords;
   if (_contains_segmentation_heights)
     z_coords = _segmentation_heights;

--- a/src/TrackGenerator3D.cpp
+++ b/src/TrackGenerator3D.cpp
@@ -1223,6 +1223,8 @@ void TrackGenerator3D::segmentizeExtruded() {
   else
     z_coords = _geometry->getUniqueZPlanes();
 
+  log_printf(NORMAL, "Number of unique Z-planes %d", z_coords.size());
+
   /* Loop over all extruded Tracks */
   Progress progress(_num_2D_tracks, "Segmenting 2D Tracks", 0.1, _geometry,
                     true);
@@ -1245,7 +1247,7 @@ void TrackGenerator3D::segmentizeExtruded() {
   _geometry->initializeAxialFSRs(_global_z_mesh);
   _geometry->initializeFSRVectors();
   _contains_2D_segments = true;
-   
+
   /* Count the number of segments in each track */
   countSegments();
 }

--- a/src/TrackGenerator3D.cpp
+++ b/src/TrackGenerator3D.cpp
@@ -1223,7 +1223,20 @@ void TrackGenerator3D::segmentizeExtruded() {
   else
     z_coords = _geometry->getUniqueZPlanes();
 
-  log_printf(NORMAL, "Number of unique Z-planes %d", z_coords.size());
+  /* Print number of unique Z planes */
+  int num_Z_planes = z_coords.size();
+  int _num_Z_planes = num_Z_planes - 1;
+  int max_num_Z_planes = num_Z_planes;
+#ifdef MPIx
+  if (_geometry->isDomainDecomposed()) {
+    MPI_Allreduce(&num_Z_planes, &_num_Z_planes, 1, MPI_INT, MPI_SUM,
+                  _geometry->getMPICart());
+    MPI_Allreduce(&num_Z_planes, &max_num_Z_planes, 1, MPI_INT, MPI_MAX,
+                  _geometry->getMPICart());
+  }
+#endif
+  log_printf(NORMAL, "Max / total number of unique Z-planes %d / %d",
+             max_num_Z_planes, _num_Z_planes + 1);
 
   /* Loop over all extruded Tracks */
   Progress progress(_num_2D_tracks, "Segmenting 2D Tracks", 0.1, _geometry,

--- a/src/TrackGenerator3D.cpp
+++ b/src/TrackGenerator3D.cpp
@@ -1223,21 +1223,6 @@ void TrackGenerator3D::segmentizeExtruded() {
   else
     z_coords = _geometry->getUniqueZPlanes();
 
-  /* Print number of unique Z planes */
-  int num_Z_planes = z_coords.size();
-  int _num_Z_planes = num_Z_planes - 1;
-  int max_num_Z_planes = num_Z_planes;
-#ifdef MPIx
-  if (_geometry->isDomainDecomposed()) {
-    MPI_Allreduce(&num_Z_planes, &_num_Z_planes, 1, MPI_INT, MPI_SUM,
-                  _geometry->getMPICart());
-    MPI_Allreduce(&num_Z_planes, &max_num_Z_planes, 1, MPI_INT, MPI_MAX,
-                  _geometry->getMPICart());
-  }
-#endif
-  log_printf(NORMAL, "Max / total number of unique Z-planes %d / %d",
-             max_num_Z_planes, _num_Z_planes + 1);
-
   /* Loop over all extruded Tracks */
   Progress progress(_num_2D_tracks, "Segmenting 2D Tracks", 0.1, _geometry,
                     true);

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -130,7 +130,7 @@ void SegmentCounter::onTrack(Track* track, segment* segments) {
     _max_num_segments = std::max(_max_num_segments, track->getNumSegments());
   }
   if (_count_total_segments) {
-#pragma omp critical
+#pragma omp atommic update
     _total_num_segments += track->getNumSegments();
   }
 }

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -130,7 +130,7 @@ void SegmentCounter::onTrack(Track* track, segment* segments) {
     _max_num_segments = std::max(_max_num_segments, track->getNumSegments());
   }
   if (_count_total_segments) {
-#pragma omp atommic update
+#pragma omp atomic update
     _total_num_segments += track->getNumSegments();
   }
 }

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -573,7 +573,7 @@ Cell* Universe::findCell(LocalCoords* coords) {
  */
 void Universe::subdivideCells(double max_radius) {
 
-  log_printf(DEBUG, "Subdividing Cells for Universe ID=%d "
+  log_printf(NORMAL, "Subdividing Cells for Universe ID=%d "
              "with max radius %f", _id, max_radius);
 
   std::map<int, Cell*>::iterator iter;
@@ -977,7 +977,7 @@ Lattice::Lattice(const int id, const char* name): Universe(id, name) {
   _width_x = 0;
   _width_y = 0;
   _width_z = 0;
-  
+
   _non_uniform = false;
 }
 
@@ -1578,7 +1578,7 @@ void Lattice::removeUniverse(Universe* universe) {
  */
 void Lattice::subdivideCells(double max_radius) {
 
-  log_printf(DEBUG, "Subdividing Cells for Lattice ID=%d "
+  log_printf(NORMAL, "Subdividing Cells for Lattice ID=%d "
              "with max radius %f", _id, max_radius);
 
   std::map<int, Universe*>::iterator iter;
@@ -1589,9 +1589,9 @@ void Lattice::subdivideCells(double max_radius) {
 
   /* Subdivide all Cells */
   for (iter = universes.begin(); iter != universes.end(); ++iter) {
-    log_printf(DEBUG, "univ_ID: %d, radius: %f, max_radius: %f", 
+    log_printf(NORMAL, "univ_ID: %d, radius: %f, max_radius: %f", 
                iter->first, unique_radius[iter->first], max_radius);
-    
+
     /* If the  local universe equivalent radius is smaller than max_radius 
        parameter, over-ride it*/
     iter->second->subdivideCells(std::min(unique_radius[iter->first], 
@@ -1709,8 +1709,8 @@ Cell* Lattice::findCell(LocalCoords* coords) {
   double next_z = coords->getZ()
                   - (getMinZ() + _widths_z[lat_z]/2. + _accumulate_z[lat_z]);
 
-  /* Check for 2D problem */
-  if (_width_z == std::numeric_limits<double>::infinity())
+  /* Check for 2D problem or 2D lattice */
+  if (_width_z > FLT_INFINITY)
     next_z = coords->getZ();
 
   /* Create a new LocalCoords object for the next level Universe */
@@ -1921,8 +1921,8 @@ std::string Lattice::toString() {
          << ", # cells along x = " << _num_x
          << ", # cells along y = " << _num_y
          << ", # cells along z = " << _num_z;
-  
-  if(_non_uniform) {
+
+  if (_non_uniform) {
     string << "This lattice is non-uniform.\nx widths: ";
     for(int i=0; i<_num_x; i++)
       string << _widths_x[i] << "  ";
@@ -2239,11 +2239,11 @@ void Lattice::setWidths(std::vector<double> widths_x,
 
 /**
  * @brief Set _widths_x, _widths_y, _widths_z for uniform case, compute 
- *        accumulate variavles.
+ *        accumulate variables.
  */
 void Lattice::computeSizes(){
-  if(_non_uniform) {
-    if(_widths_x.size() != _num_x || _widths_y.size() != _num_y ||
+  if (_non_uniform) {
+    if (_widths_x.size() != _num_x || _widths_y.size() != _num_y ||
         _widths_z.size() != _num_z)
       log_printf(ERROR,"The sizes of non-uniform mesh widths are not consistent"
                  " with the sizes of filling Universes into Lattice");
@@ -2254,17 +2254,17 @@ void Lattice::computeSizes(){
     _widths_z.resize(_num_z, _width_z);
   }
 
-  
+  /* Compute the accumulate lengths along each axis */
   _accumulate_x.resize(_num_x+1,0.0);
   _accumulate_y.resize(_num_y+1,0.0);
   _accumulate_z.resize(_num_z+1,0.0);
-  
+
   for(int i=0; i<_num_x; i++)
     _accumulate_x[i+1] = _accumulate_x[i] + _widths_x[i];
-  
+
   for(int i=0; i<_num_y; i++)
     _accumulate_y[i+1] = _accumulate_y[i] + _widths_y[i];  
-  
+
   for(int i=0; i<_num_z; i++)
     _accumulate_z[i+1] = _accumulate_z[i] + _widths_z[i];  
 }

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1591,7 +1591,7 @@ void Lattice::subdivideCells(double max_radius) {
 
   /* Subdivide all Cells */
   for (iter = universes.begin(); iter != universes.end(); ++iter) {
-    log_printf(NORMAL, "univ_ID: %d, radius: %f, max_radius: %f", 
+    log_printf(DEBUG, "univ_ID: %d, radius: %f, max_radius: %f", 
                iter->first, unique_radius[iter->first], max_radius);
 
     /* If the  local universe equivalent radius is smaller than max_radius 

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -67,7 +67,7 @@ Universe::Universe(const int id, const char* name) {
 
   _uid = _n;
   _n++;
-  
+
   /* Add the ID to the used set */
   used_ids.insert(_id);
 
@@ -573,7 +573,7 @@ Cell* Universe::findCell(LocalCoords* coords) {
  */
 void Universe::subdivideCells(double max_radius) {
 
-  log_printf(NORMAL, "Subdividing Cells for Universe ID=%d "
+  log_printf(DEBUG, "Subdividing Cells for Universe ID=%d "
              "with max radius %f", _id, max_radius);
 
   std::map<int, Cell*>::iterator iter;
@@ -704,7 +704,7 @@ void Universe::calculateBoundaries() {
   * reachable x-coordinate in the Universe and store it in _min_x_bound
   */
   _min_x_bound = BOUNDARY_NONE;
-  
+
   /* Check if the universe contains a cell with an x-min boundary */
   for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
     std::map<int, Halfspace*> surfs = c_iter->second->getSurfaces();
@@ -826,7 +826,7 @@ void Universe::calculateBoundaries() {
   /* Calculate the maximum reachable y-coordinate in the geometry and store it
    * in _max_y */
   double max_y = -std::numeric_limits<double>::infinity();
-  
+
   /* Calculate the boundary condition at the maximum
   * reachable y-coordinate in the Universe and store it in _max_y_bound
   */
@@ -841,7 +841,7 @@ void Universe::calculateBoundaries() {
     for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
       surf = s_iter->second->_surface;
       halfspace = s_iter->second->_halfspace;
-      
+
       if (surf->getSurfaceType() == YPLANE && halfspace == -1 &&
         surf->getBoundaryType() != BOUNDARY_NONE) {
         if(surf->getMaxY(halfspace) < cell_max_y) {
@@ -914,7 +914,7 @@ void Universe::calculateBoundaries() {
   /* Calculate the boundary condition at the maximum
   * reachable z-coordinate in the Universe and store it in _max_z_bound */
   _max_z_bound = BOUNDARY_NONE;
-  
+
   /* Check if the universe contains a cell with an y-max boundary */
   for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
     std::map<int, Halfspace*>surfs = c_iter->second->getSurfaces();
@@ -924,7 +924,7 @@ void Universe::calculateBoundaries() {
     for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
       surf = s_iter->second->_surface;
       halfspace = s_iter->second->_halfspace;
-      
+
       if (surf->getSurfaceType() == ZPLANE && halfspace == -1 &&
           surf->getBoundaryType() != BOUNDARY_NONE) {
         if(surf->getMaxZ(halfspace) < cell_max_z) {
@@ -950,6 +950,7 @@ void Universe::calculateBoundaries() {
 
   _boundaries_inspected = true;
 }
+
 
 /**
   * @brief  sets _boundaries_not_updated to true so boundaries will be
@@ -1447,6 +1448,7 @@ void Lattice::setAccumulateZ(std::vector<double> accumulatez) {
   _accumulate_z = accumulatez;
 }
 
+
 /**
  * @brief Sets the array of Universe pointers filling each Lattice cell.
  * @details This is a helper method for SWIG to allow users to assign Universes
@@ -1578,7 +1580,7 @@ void Lattice::removeUniverse(Universe* universe) {
  */
 void Lattice::subdivideCells(double max_radius) {
 
-  log_printf(NORMAL, "Subdividing Cells for Lattice ID=%d "
+  log_printf(DEBUG, "Subdividing Cells for Lattice ID=%d "
              "with max radius %f", _id, max_radius);
 
   std::map<int, Universe*>::iterator iter;
@@ -1863,7 +1865,7 @@ int Lattice::getLatY(Point* point) {
     log_printf(ERROR, "Trying to get lattice y index for point(y = %f) that is "
                "outside lattice bounds. dist_to_bottom = %f is not within "
              "[0.0, %f]", point->getY(), dist_to_bottom, _accumulate_y[_num_y]);
-  
+
   return lat_y;
 }
 
@@ -2254,7 +2256,7 @@ void Lattice::computeSizes(){
     _widths_z.resize(_num_z, _width_z);
   }
 
-  /* Compute the accumulate lengths along each axis */
+  /* Compute the accumulated lengths along each axis */
   _accumulate_x.resize(_num_x+1,0.0);
   _accumulate_y.resize(_num_y+1,0.0);
   _accumulate_z.resize(_num_z+1,0.0);
@@ -2289,7 +2291,7 @@ void Lattice::printLatticeSizes() {
   for(i=0; i<_num_z; i++)
     printf("i=%d, %f; ",i, _widths_z[i]);
   printf("\n");
-  
+
   printf("accumulates_XYZ:\n");
   for(i=0; i<_num_x+1; i++)
     printf("i=%d, %f; ",i, _accumulate_x[i]);

--- a/src/constants.h
+++ b/src/constants.h
@@ -11,6 +11,9 @@
 /** Threshold to determine if a float equals to 0.0 */
 #define FLT_EPSILON 1.0E-12
 
+/** Threshold to determine if a float is equal to infinity */
+#define FLT_INFINITY 1.0E300
+
 /* The single line width permissible for timer / memory logger reports */
 #define REPORT_WIDTH 53
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -12,7 +12,7 @@
 #define FLT_EPSILON 1.0E-12
 
 /** Threshold to determine if a float is equal to infinity */
-#define FLT_INFINITY 1.0E300
+#define FLT_INFINITY 1.0E308
 
 /* The single line width permissible for timer / memory logger reports */
 #define REPORT_WIDTH 53

--- a/src/constants.h
+++ b/src/constants.h
@@ -12,7 +12,7 @@
 #define FLT_EPSILON 1.0E-12
 
 /** Threshold to determine if a float is equal to infinity */
-#define FLT_INFINITY 1.0E308
+#define FLT_INFINITY 1.0E300
 
 /* The single line width permissible for timer / memory logger reports */
 #define REPORT_WIDTH 53

--- a/src/linalg.cpp
+++ b/src/linalg.cpp
@@ -967,7 +967,7 @@ bool ddLinearSolve(Matrix* A, Matrix* M, Vector* X, Vector* B, double tol,
 
     // Check for going off the rails
     if (residual > 1e3 * min_residual && min_residual > 1e-10) {
-      log_printf(NORMAL, "WARNING: inner linear solve divergent.");
+      log_printf(WARNING, "Inner linear solve divergent.");
       log_printf(NORMAL, "Residual = %6.4e, Min Res = %6.4e", residual, min_residual);
       return false;
     }


### PR DESCRIPTION
A lot of little things in this PR

This PR enables running 3D BEAVRS assemblies in linear source with single floating point precision, by simply setting the segment lengths to be doubles all the time.
This improves the accuracy of the centroids, which helps converging the linear source.

By making the volumes double precision (not done here), the centroid accuracy is further improved, so if anyone runs into issues with single precision and (linear source) that disappear with double precision, this is a place to start at.