### PR TITLE
Few concurrency bug fixes, massive clean up, MPI fix for exception handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -87,7 +87,7 @@ class configuration:
 
     # The vector alignment used in the VectorizedSolver class when allocating
     # aligned data structures using MM_MALLOC and MM_FREE
-    vector_alignment = 16
+    vector_alignment = 32
 
     # List of C/C++/CUDA distutils.extension objects which are created based
     # on which flags are specified at compile time.

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -186,13 +186,13 @@ ifeq ($(OPTIMIZE),yes)
   endif
   ifeq ($(COMPILER),clang)
     CFLAGS += -O3 -ffast-math -fvectorize -fpic
-endif
+  endif
   # Set the number of groups at compile time
   #CFLAGS += -DNGROUPS=70
   # Set the source to linear source at compile time
   #CFLAGS += -DLINEARSOURCE
   # Set the dimension to 3D at compile time
-  #CLFAGS += -DTHREED
+  #CFLAGS += -DTHREED
 endif
 
 # Optimization report flags

--- a/src/CPULSSolver.h
+++ b/src/CPULSSolver.h
@@ -79,7 +79,7 @@ public:
                                     FP_PRECISION direction[3]);
   void accumulateLinearFluxContribution(long fsr_id, FP_PRECISION* fsr_flux);
   void addSourceToScalarFlux();
-  
+
   /* Transport stabilization routines */
   void computeStabilizingFlux();
   void stabilizeFlux();

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -411,7 +411,7 @@ void CPUSolver::copyBoundaryFluxes() {
 //FIXME: make suitable for 2D
 void CPUSolver::tallyStartingCurrents() {
 
-#pragma omp parallel for schedule(guided)
+#pragma omp parallel for schedule(static)
   for (long t=0; t < _tot_num_tracks; t++) {
 
     /* Get 3D Track data */
@@ -1470,7 +1470,7 @@ void CPUSolver::computeFSRSources(int iteration) {
   long num_negative_sources = 0;
 
   /* For all FSRs, find the source */
-#pragma omp parallel for schedule(guided)
+#pragma omp parallel for schedule(static)
   for (long r=0; r < _num_FSRs; r++) {
 
     int tid = omp_get_thread_num();
@@ -1583,7 +1583,8 @@ double CPUSolver::computeResidual(residualType res_type) {
     FP_PRECISION* nu_sigma_f;
     Material* material;
 
-#pragma omp parallel for schedule(static)
+#pragma omp parallel for private(new_fission_source, old_fission_source,\
+     material, nu_sigma_f) schedule(static)
     for (long r=0; r < _num_FSRs; r++) {
       new_fission_source = 0.;
       old_fission_source = 0.;
@@ -1613,7 +1614,8 @@ double CPUSolver::computeResidual(residualType res_type) {
     FP_PRECISION* nu_sigma_f;
     Material* material;
 
-#pragma omp parallel for schedule(static)
+#pragma omp parallel for private(new_total_source, old_total_source,\
+     material, nu_sigma_f) schedule(static)
     for (long r=0; r < _num_FSRs; r++) {
       new_total_source = 0.;
       old_total_source = 0.;

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -2030,7 +2030,7 @@ void CPUSolver::addSourceToScalarFlux() {
       _scalar_flux(r, e) += FOUR_PI * _reduced_sources(r, e) / sigma_t[e];
       if (_scalar_flux(r, e) < 0.0) {
         _scalar_flux(r, e) = 1.0e-20;
-#pragma omp atomic
+#pragma omp atomic update
         num_negative_fluxes++;
       }
     }

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -881,6 +881,10 @@ void CPUSolver::transferAllInterfaceFluxes() {
     bool communication_complete = true;
     for (int i=0; i < num_domains; i++) {
 
+      /* Initialize MPI request */
+      _MPI_requests[i*2] = MPI_REQUEST_NULL;
+      _MPI_requests[i*2+1] = MPI_REQUEST_NULL;
+
       /* Get the communicating neighbor domain */
       int domain = _neighbor_domains.at(i);
 

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -854,7 +854,7 @@ void CPUSolver::transferAllInterfaceFluxes() {
   _timer->stopTimer();
   _timer->recordSplit("Idle time");
 
-  /* Initialize timer for total function cost */
+  /* Initialize timer for total transfer cost */
   _timer->startTimer();
 
   /* Create bookkeeping vectors */
@@ -915,30 +915,7 @@ void CPUSolver::transferAllInterfaceFluxes() {
     }
 
     /* Block for communication round to complete */
-    bool round_complete = false;
-    while (!round_complete) {
-
-      round_complete = true;
-      int flag;
-
-      /* Check forward and backward send/receive messages */
-      for (int i=0; i < num_domains; i++) {
-
-        /* Wait for send to complete */
-        if (_MPI_sends[i] == true) {
-          MPI_Test(&_MPI_requests[i*2], &flag, &stat);
-          if (flag == 0)
-            round_complete = false;
-        }
-
-        /* Wait for receive to complete */
-        if (_MPI_receives[i] == true) {
-          MPI_Test(&_MPI_requests[i*2+1], &flag, &stat);
-          if (flag == 0)
-            round_complete = false;
-        }
-      }
-    }
+    MPI_Waitall(2 * num_domains, _MPI_requests, MPI_STATUSES_IGNORE);
 
     /* Reset status for next communication round and copy fluxes */
     for (int i=0; i < num_domains; i++) {

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -105,7 +105,7 @@ Cell::~Cell() {
   if (_region != NULL)
     delete _region;
   /* Materials are deleted separately from cells, since multiple cells
-      can share a same material */
+      can share the same material */
   /* Universes are also deleted separately, since Universes can have been
      defined in your input scripts, rather than loaded from a Geometry file */
 }
@@ -130,7 +130,7 @@ int Cell::getId() const {
 
 
 /**
- * @brief Return the user-defined name of the Cell
+ * @brief Return the user-defined name of the Cell.
  * @return the Cell name
  */
 char* Cell::getName() const {
@@ -967,7 +967,7 @@ void Cell::setNumRings(int num_rings) {
   if (num_rings < 0)
     log_printf(ERROR, "Unable to give %d rings to Cell %d since this is "
                "a negative number", num_rings, _id);
-  
+
   if (num_rings == 1)
     _num_rings = 0;
   else
@@ -1069,9 +1069,9 @@ void Cell::removeSurface(Surface* surface) {
 
 
  /**
-  * @brief Insert a logical node (intersection or union) into the cell region
+  * @brief Insert a logical node (intersection or union) into the cell region.
   * @details This method creates a node in a tree of regions. The leaves, or the
-  *          nodes at the very bottom of the tree, are haflspaces. The region
+  *          nodes at the very bottom of the tree, are halfspaces. The region
              is defined by that tree.
   * @param region_type the logical operation
   */

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -14,8 +14,8 @@ static std::set<int> used_ids;
  *          OpenMOC input files. The method makes use of a static Cell
  *          ID which is incremented each time the method is called to enable
  *          unique generation of monotonically increasing IDs. The method's
- *          first ID begins at 10000. Hence, user-defined Cell IDs greater
- *          than or equal to 10000 are prohibited.
+ *          first ID begins at 1,000,000. Hence, user-defined Cell IDs greater
+ *          than or equal to 1,000,000 are prohibited.
  */
 int cell_id() {
   int id = auto_id;
@@ -29,7 +29,7 @@ int cell_id() {
 
 
 /**
- * @brief Resets the auto-generated unique Cell ID counter to 10000.
+ * @brief Resets the auto-generated unique Cell ID counter to 1,000,000.
  */
 void reset_cell_id() {
   auto_id = DEFAULT_INIT_ID;

--- a/src/Cell.h
+++ b/src/Cell.h
@@ -137,7 +137,7 @@ public:
   double* getRotationMatrix();
   double* getTranslation();
   void retrieveRotation(double* rotations, int num_axes,
-			std::string units="degrees");
+                        std::string units="degrees");
   void retrieveTranslation(double* translations, int num_axes);
   int getNumRings();
   int getNumSectors();

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -1200,9 +1200,14 @@ void Cmfd::updateMOCFlux() {
         if (update_ratio < 0.05)
           update_ratio = 0.05;
 
-        if (_convergence_data != NULL)
-          if (std::abs(log(update_ratio)) > std::abs(log(_convergence_data->pf)))
-            _convergence_data->pf = update_ratio;
+        if (_convergence_data != NULL) {
+#pragma omp critical
+          {
+            if (std::abs(log(update_ratio)) > 
+                std::abs(log(_convergence_data->pf)))
+              _convergence_data->pf = update_ratio;
+          }
+        }
 
         for (int h = _group_indices[e]; h < _group_indices[e + 1]; h++) {
 

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -3,7 +3,7 @@
 /**
  * @brief Constructor initializes boundaries and variables that describe
  *          the CMFD object.
- * @details The construcor initializes the many variables that describe
+ * @details The constructor initializes the many variables that describe
  *          the CMFD mesh and are used to solve the nonlinear diffusion
  *          acceleration problem.
  */
@@ -49,7 +49,7 @@ Cmfd::Cmfd() {
   _old_dif_surf_valid = false;
 
   _non_uniform = false;
-  
+
   /* Energy group and polar angle problem parameters */
   _num_moc_groups = 0;
   _num_cmfd_groups = 0;
@@ -161,7 +161,7 @@ Cmfd::~Cmfd() {
 
   /* Delete CMFD materials array */
   if (_materials != NULL) {
-    for (int i=0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++)
+    for (int i=0; i < _local_num_x * _local_num_y * _local_num_z; i++)
       delete _materials[i];
     delete [] _materials;
   }
@@ -177,7 +177,7 @@ Cmfd::~Cmfd() {
   _cell_fsrs.clear();
 
   /* Clear the _k_nearest_stencils map of vectors */
-  std::map<int, std::vector< std::pair<int, double> > >::iterator iter2;
+  std::map<long, std::vector< std::pair<int, double> > >::iterator iter2;
   for (iter2 = _k_nearest_stencils.begin(); iter2 != _k_nearest_stencils.end();
        ++iter2)
     iter2->second.clear();
@@ -201,7 +201,7 @@ Cmfd::~Cmfd() {
   }
 
   /* De-allocate domain communicator */
-  int num_cells_local = _local_num_xn * _local_num_yn * _local_num_zn;
+  int num_cells_local = _local_num_x * _local_num_y * _local_num_z;
   if (_domain_communicator != NULL) {
     if(_domain_communicator_allocated) {
       for (int rb=0; rb<2; rb++) {
@@ -263,14 +263,13 @@ void Cmfd::setNumX(int num_x) {
 
   _num_x = num_x;
   _local_num_x = _num_x;
-  _local_num_xn = _local_num_x;
   if (_domain_communicator != NULL)
     _local_num_x = _num_x / _domain_communicator->_num_domains_x;
 }
 
 
 /**
- * @brief Set the number of Mesh cells in a column
+ * @brief Set the number of Mesh cells in a column.
  * @param number of Mesh cells in a column
  */
 void Cmfd::setNumY(int num_y) {
@@ -281,15 +280,14 @@ void Cmfd::setNumY(int num_y) {
 
   _num_y = num_y;
   _local_num_y = _num_y;
-  _local_num_yn = _local_num_y;
   if (_domain_communicator != NULL)
     _local_num_y = _num_y / _domain_communicator->_num_domains_y;
 }
 
 
 /**
- * @brief Set the number of Mesh cells in a column
- * @param number of Mesh cells in a column
+ * @brief Set the number of Mesh cells in the z-direction.
+ * @param number of Mesh cells in the z direction
  */
 void Cmfd::setNumZ(int num_z) {
 
@@ -299,7 +297,6 @@ void Cmfd::setNumZ(int num_z) {
 
   _num_z = num_z;
   _local_num_z = _num_z;
-  _local_num_zn = _local_num_z;
   if (_domain_communicator != NULL)
     _local_num_z = _num_z / _domain_communicator->_num_domains_z;
 }
@@ -334,7 +331,7 @@ int Cmfd::getNumZ() {
 
 /**
  * @brief Get the Vector of surface currents.
- * @return pointer to a vector containing the surface currents.
+ * @return pointer to a vector containing the surface currents
  */
 Vector* Cmfd::getLocalCurrents() {
   return _surface_currents;
@@ -343,7 +340,7 @@ Vector* Cmfd::getLocalCurrents() {
 
 /**
  * @brief Get the array of surface currents on the boundaries.
- * @return 3D array containing the boundary surface currents.
+ * @return 3D array containing the boundary surface currents
  */
 CMFD_PRECISION*** Cmfd::getBoundarySurfaceCurrents() {
   return _boundary_surface_currents;
@@ -394,11 +391,11 @@ void Cmfd::setNumDomains(int num_x, int num_y, int num_z) {
   _domain_communicator->_num_domains_x = num_x;
   _domain_communicator->_num_domains_y = num_y;
   _domain_communicator->_num_domains_z = num_z;
-  
+
   _accumulate_lmx.resize(num_x + 1, 0);
   _accumulate_lmy.resize(num_y + 1, 0);
   _accumulate_lmz.resize(num_z + 1, 0);
-  
+
   /* To check the position of domain decomposition interfaces in non-uniform 
      CMFD mesh interfaces. x direction */
   int j;
@@ -428,7 +425,7 @@ void Cmfd::setNumDomains(int num_x, int num_y, int num_z) {
     }
     if(j == _num_y+1) {
       log_printf(ERROR, "The domain decomposition interface y[%d] = %f is NOT "
-                 "among the CMFD mesh division in the y direction", i, coord);
+                 "among the CMFD mesh divisions in the y direction", i, coord);
     }
   }
 
@@ -444,14 +441,9 @@ void Cmfd::setNumDomains(int num_x, int num_y, int num_z) {
     }
     if(j == _num_z+1) {
       log_printf(ERROR, "The domain decomposition interface z[%d] = %f is NOT "
-                 "among the CMFD mesh division in the z direction", i, coord);
+                 "among the CMFD mesh divisions in the z direction", i, coord);
     }
   }
-
-//The next three sentences would be deleted when done.
-  _local_num_x = _num_x / num_x;
-  _local_num_y = _num_y / num_y;
-  _local_num_z = _num_z / num_z;
 }
 
 
@@ -468,12 +460,10 @@ void Cmfd::setDomainIndexes(int idx_x, int idx_y, int idx_z) {
   _domain_communicator->_domain_idx_x = idx_x;
   _domain_communicator->_domain_idx_y = idx_y;
   _domain_communicator->_domain_idx_z = idx_z;
-  
-  _local_num_xn = _accumulate_lmx[idx_x + 1] - _accumulate_lmx[idx_x];
-  _local_num_yn = _accumulate_lmy[idx_y + 1] - _accumulate_lmy[idx_y];
-  _local_num_zn = _accumulate_lmz[idx_z + 1] - _accumulate_lmz[idx_z];
-  //log_printf(NODAL, "_local_num_xn=%d, _local_num_yn=%d, _local_num_zn=%d,%d, %d, %d",
-   //          _local_num_xn, _local_num_yn, _local_num_zn, idx_x, idx_y, idx_z);
+
+  _local_num_x = _accumulate_lmx[idx_x + 1] - _accumulate_lmx[idx_x];
+  _local_num_y = _accumulate_lmy[idx_y + 1] - _accumulate_lmy[idx_y];
+  _local_num_z = _accumulate_lmz[idx_z + 1] - _accumulate_lmz[idx_z];
 }
 #endif
 
@@ -482,7 +472,7 @@ void Cmfd::setDomainIndexes(int idx_x, int idx_y, int idx_z) {
  * @brief Collapse cross-sections and fluxes for each CMFD cell by
  *        energy condensing and volume averaging cross sections from
  *        the MOC sweep.
- * @details This method performs a cell-wise energy condensation and volume
+ * @details This method performs a cell-wise energy condensation and flux-volume
  *          average of the cross sections of the fine, unstructured FSR mesh.
  *          The cross sections are condensed such that all reaction rates and
  *          the neutron production rate from fission are conserved. It is
@@ -523,9 +513,9 @@ void Cmfd::collapseXS() {
     FP_PRECISION tot, nu_fis, chi;
     FP_PRECISION* scat;
 
-    //TODO Optimize : use groupwise scratches rather than allocate array
-    double* scat_tally = new double[_num_cmfd_groups]();
-    double* chi_tally = new double[_num_cmfd_groups]();
+    /* Allocate arrays for tallies on the stack */
+    double scat_tally[_num_cmfd_groups] = {0.0};
+    double chi_tally[_num_cmfd_groups] = {0.0};
 
     /* Pointers to material objects */
     Material* fsr_material;
@@ -533,7 +523,7 @@ void Cmfd::collapseXS() {
 
     /* Loop over CMFD cells */
 #pragma omp for
-    for (int i = 0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++) {
+    for (int i = 0; i < _local_num_x * _local_num_y * _local_num_z; i++) {
 
       std::vector<long>::iterator iter;
       cell_material = _materials[i];
@@ -572,7 +562,7 @@ void Cmfd::collapseXS() {
       /* Set chi */
       if (fabs(neutron_production_tally) > FLT_EPSILON) {
 
-        /* Calculate group-wise fission contriubtions */
+        /* Calculate group-wise fission contributions */
         for (int e=0; e < _num_cmfd_groups; e++)
           cell_material->setChiByGroup(chi_tally[e] / neutron_production_tally,
                                        e + 1);
@@ -666,9 +656,6 @@ void Cmfd::collapseXS() {
         }
       }
     }
-    
-    delete[] chi_tally;
-    delete[] scat_tally;
   }
 
 #ifdef MPIx
@@ -690,7 +677,7 @@ void Cmfd::collapseXS() {
 
   /* Calculate (local) old fluxes and set volumes */
 #pragma omp parallel for
-  for (int i = 0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++) {
+  for (int i = 0; i < _local_num_x * _local_num_y * _local_num_z; i++) {
 
     /* Loop over CMFD coarse energy groups */
     for (int e = 0; e < _num_cmfd_groups; e++) {
@@ -759,16 +746,13 @@ CMFD_PRECISION Cmfd::getDiffusionCoefficient(int cmfd_cell, int group) {
  *          cell surface, and CMFD energy group. If the MOC iteration is zero,
  *          (\f$ \tilde{D} \f$) is returned as zero. Since (\f$ \hat{D} \f$) and
  *          (\f$ \tilde{D} \f$) are dependent on each other, they must be
- *          computed together; therefore, the boolean correction is used to
- *          indicate which value is to be returned.
+ *          computed together.
  * @param cmfd_cell A CMFD cell
  * @param surface A surface of the CMFD cell
  * @param group A CMFD energy group
  * @param moc_iteration MOC iteration number
- * @param correction Boolean indicating whether (\f$ \hat{D} \f$) or
- *                   (\f$ \tilde{D} \f$) is to be returned
- * @return The surface diffusion coefficient, (\f$ \hat{D} \f$) or
- *         (\f$ \tilde{D} \f$)
+ * @param dif_surf the surface diffusion coefficient \f$ \hat{D} \f$
+ * @param dif_surf_corr the correction diffusion coefficient \f$ \tilde{D} \f$
  */
 void Cmfd::getSurfaceDiffusionCoefficient(int cmfd_cell, int surface,
                                           int group, int moc_iteration,
@@ -785,7 +769,7 @@ void Cmfd::getSurfaceDiffusionCoefficient(int cmfd_cell, int surface,
   CMFD_PRECISION flux = _old_flux->getValue(cmfd_cell, group);
   CMFD_PRECISION delta_interface = getSurfaceWidth(surface, global_cmfd_cell);
   CMFD_PRECISION delta = getPerpendicularSurfaceWidth(surface, global_cmfd_cell);
-  
+
   CMFD_PRECISION delta_next = 0.0;
   if(global_cmfd_cell_next != -1) 
     delta_next = getPerpendicularSurfaceWidth(surface, global_cmfd_cell_next);
@@ -1062,7 +1046,7 @@ void Cmfd::constructMatrices(int moc_iteration) {
 
   /* Zero the number of connections */
   if (_domain_communicator != NULL) {
-    int num_local_cells = _local_num_xn * _local_num_yn * _local_num_zn;
+    int num_local_cells = _local_num_x * _local_num_y * _local_num_z;
     for (int c=0; c<2; c++) {
       for (int ncg=0; ncg < num_local_cells * _num_cmfd_groups; ncg++) {
         _domain_communicator->num_connections[c][ncg] = 0;
@@ -1086,17 +1070,17 @@ void Cmfd::constructMatrices(int moc_iteration) {
     if (_geometry->isDomainDecomposed()) {
       if (_domain_communicator != NULL) {
         x_start = _accumulate_lmx[_domain_communicator->_domain_idx_x];
-        x_end = x_start + _local_num_xn;
+        x_end = x_start + _local_num_x;
         y_start = _accumulate_lmy[_domain_communicator->_domain_idx_y];
-        y_end = y_start + _local_num_yn;
+        y_end = y_start + _local_num_y;
         z_start = _accumulate_lmz[_domain_communicator->_domain_idx_z];
-        z_end = z_start + _local_num_zn;
+        z_end = z_start + _local_num_z;
       }
     }
 
     /* Loop over cells */
 #pragma omp for
-    for (int i = 0; i < _local_num_xn*_local_num_yn*_local_num_zn; i++) {
+    for (int i = 0; i < _local_num_x*_local_num_y*_local_num_z; i++) {
 
       int global_ind = getGlobalCMFDCell(i);
       int color = getCellColor(global_ind);
@@ -1196,7 +1180,7 @@ void Cmfd::updateMOCFlux() {
 
   /* Loop over mesh cells */
 #pragma omp parallel for
-  for (int i = 0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++) {
+  for (int i = 0; i < _local_num_x * _local_num_y * _local_num_z; i++) {
 
     std::vector<long>::iterator iter;
 
@@ -1308,7 +1292,7 @@ CMFD_PRECISION Cmfd::computeLarsensEDCFactor(CMFD_PRECISION dif_coef,
 
 /**
  * @brief Set the FSR materials array pointer.
- * @param pointer to FSR_materials array
+ * @param FSR_materials pointer to FSR_materials array
  */
 void Cmfd::setFSRMaterials(Material** FSR_materials) {
   _FSR_materials = FSR_materials;
@@ -1317,7 +1301,7 @@ void Cmfd::setFSRMaterials(Material** FSR_materials) {
 
 /**
  * @brief Set the pointer to the array of FSR_volumes.
- * @param array of FSR volumes
+ * @param FSR_volumes array of FSR volumes
  */
 void Cmfd::setFSRVolumes(FP_PRECISION* FSR_volumes) {
   _FSR_volumes = FSR_volumes;
@@ -1326,7 +1310,7 @@ void Cmfd::setFSRVolumes(FP_PRECISION* FSR_volumes) {
 
 /**
  * @brief Set pointer to FSR flux array.
- * @param pointer to FSR flux array
+ * @param scalar_flux pointer to FSR flux array
  */
 void Cmfd::setFSRFluxes(FP_PRECISION* scalar_flux) {
   _FSR_fluxes = scalar_flux;
@@ -1335,7 +1319,7 @@ void Cmfd::setFSRFluxes(FP_PRECISION* scalar_flux) {
 
 /**
  * @brief Set pointer to FSR source array.
- * @param pointer to FSR source array
+ * @param sources pointer to FSR source array
  */
 void Cmfd::setFSRSources(FP_PRECISION* sources) {
   _FSR_sources = sources;
@@ -1343,8 +1327,8 @@ void Cmfd::setFSRSources(FP_PRECISION* sources) {
 
 
 /**
- * @brief Set pointer to source region flux moments array
- * @param pointer to source region flux moments array
+ * @brief Set pointer to source region flux moments array.
+ * @param flux_moments pointer to source region flux moments array
  */
 void Cmfd::setFluxMoments(FP_PRECISION* flux_moments) {
   _flux_moments = flux_moments;
@@ -1354,7 +1338,7 @@ void Cmfd::setFluxMoments(FP_PRECISION* flux_moments) {
 
 /**
  * @brief Set successive over-relaxation relaxation factor.
- * @param over-relaxation factor
+ * @param SOR_factor over-relaxation factor
  */
 void Cmfd::setSORRelaxationFactor(double SOR_factor) {
 
@@ -1367,8 +1351,8 @@ void Cmfd::setSORRelaxationFactor(double SOR_factor) {
 
 
 /**
- * @brief Set the CMFD relaxation factor applied to diffusion coefficients
- * @param CMFD relaxation factor
+ * @brief Set the CMFD relaxation factor applied to diffusion coefficients.
+ * @param relaxation_factor CMFD relaxation factor
  */
 void Cmfd::setCMFDRelaxationFactor(double relaxation_factor) {
 
@@ -1382,7 +1366,7 @@ void Cmfd::setCMFDRelaxationFactor(double relaxation_factor) {
 
 
 /**
- * @brief Forces CMFD to check neutron balance on every solve
+ * @brief Forces CMFD to check neutron balance on every solve.
  */
 void Cmfd::checkBalance() {
   _check_neutron_balance = true;
@@ -1457,24 +1441,24 @@ void Cmfd::initializeMaterials() {
 
   /* Delete old CMFD surface currents vector if it exists */
   if (_materials != NULL){
-    for (int i=0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++)
+    for (int i=0; i < _local_num_x * _local_num_y * _local_num_z; i++)
       delete _materials[i];
     delete [] _materials;
   }
 
   /* Compute and log size in memory of Material array */
   double size = (double) (_num_cmfd_groups + 4) * _num_cmfd_groups *
-              _local_num_xn * _local_num_yn * _local_num_zn * 
+              _local_num_x * _local_num_y * _local_num_z * 
               sizeof(FP_PRECISION) / (double) 1e6;
   log_printf(NORMAL, "CMFD material storage per domain = %6.2f MB", size);
 
   try {
-    _materials = new Material*[_local_num_xn*_local_num_yn*_local_num_zn];
-    for (int z = 0; z < _local_num_zn; z++) {
-      for (int y = 0; y < _local_num_yn; y++) {
-        for (int x = 0; x < _local_num_xn; x++) {
-          int ind = z*_local_num_xn*_local_num_yn + y*_local_num_xn + x;
-          material = new Material(ind); //ind might be greater than DEFAULT_INIT_ID, dangerous.
+    _materials = new Material*[_local_num_x*_local_num_y*_local_num_z];
+    for (int z = 0; z < _local_num_z; z++) {
+      for (int y = 0; y < _local_num_y; y++) {
+        for (int x = 0; x < _local_num_x; x++) {
+          int ind = z*_local_num_x*_local_num_y + y*_local_num_x + x;
+          material = new Material(ind);
           material->setNumEnergyGroups(_num_cmfd_groups);
           _materials[ind] = material;
         }
@@ -1498,17 +1482,17 @@ void Cmfd::initializeCurrents() {
     delete _surface_currents;
 
   /* Allocate memory for the CMFD Mesh surface and corner currents Vectors */
-  _surface_currents = new Vector(_cell_locks, _local_num_xn, _local_num_yn,
-                                 _local_num_zn, _num_cmfd_groups * NUM_FACES);
+  _surface_currents = new Vector(_cell_locks, _local_num_x, _local_num_y,
+                                 _local_num_z, _num_cmfd_groups * NUM_FACES);
 
   if (_balance_sigma_t) {
     /* Allocate memory for the actual starting currents on boundary CMFD cells */
-    _starting_currents = new Vector(_cell_locks, _local_num_xn, _local_num_yn,
-                                    _local_num_zn, _num_cmfd_groups);
+    _starting_currents = new Vector(_cell_locks, _local_num_x, _local_num_y,
+                                    _local_num_z, _num_cmfd_groups);
 
     /* Allocate memory for the net currents of all CMFD cells */
-    _net_currents = new Vector(_cell_locks, _local_num_xn, _local_num_yn,
-                               _local_num_zn, _num_cmfd_groups);
+    _net_currents = new Vector(_cell_locks, _local_num_x, _local_num_y,
+                               _local_num_z, _num_cmfd_groups);
   }
 }
 
@@ -1523,9 +1507,9 @@ void Cmfd::initializeCurrents() {
 void Cmfd::initializeCellMap() {
 
   /* Allocate memory for mesh cell FSR vectors */
-  for (int z = 0; z < _local_num_zn; z++) {
-    for (int y = 0; y < _local_num_yn; y++) {
-      for (int x = 0; x < _local_num_xn; x++)
+  for (int z = 0; z < _local_num_z; z++) {
+    for (int y = 0; y < _local_num_y; y++) {
+      for (int x = 0; x < _local_num_x; x++)
         _cell_fsrs.push_back(std::vector<long>());
     }
   }
@@ -1550,7 +1534,7 @@ void Cmfd::allocateTallies() {
 
   /* Determine tally sizes */
   int num_cells = _num_x * _num_y * _num_z;
-  int local_num_cells = _local_num_xn * _local_num_yn * _local_num_zn;
+  int local_num_cells = _local_num_x * _local_num_y * _local_num_z;
   int tally_size = local_num_cells * _num_cmfd_groups;
   _total_tally_size = 3 * tally_size;
   _tally_memory = new CMFD_PRECISION[_total_tally_size];
@@ -1624,14 +1608,14 @@ void Cmfd::initializeGroupMap() {
  * @brief Find the CMFD surface that a LocalCoords object lies on.
  * @details If the coords is not on a surface, -1 is returned. Otherwise,
  *          the surface ID is returned.
- * @param The CMFD cell ID that the local coords is in.
- * @param The coords being evaluated.
+ * @param cell the CMFD cell ID that the local coords is in.
+ * @param coords the coords being evaluated.
  * @return The surface ID.
  */
 int Cmfd::findCmfdSurface(int cell, LocalCoords* coords) {
   Point* point = coords->getHighestLevel()->getPoint();
-  
-  /* If domain decomposition, compute the global CMFD cell ID*/
+
+  /* If domain decomposition, compute the global CMFD cell ID */
   if (_geometry->isDomainDecomposed())
     cell = getGlobalCMFDCell(cell);
   return _lattice->getLatticeSurface(cell, point);
@@ -1640,13 +1624,13 @@ int Cmfd::findCmfdSurface(int cell, LocalCoords* coords) {
 
 /**
  * @brief Find the CMFD cell that a LocalCoords object is in.
- * @param The coords being evaluated.
+ * @param coords the coords being evaluated.
  * @return The CMFD cell ID.
  */
 int Cmfd::findCmfdCell(LocalCoords* coords) {
   Point* point = coords->getHighestLevel()->getPoint();
   int global_cmfd_cell = _lattice->getLatticeCell(point);
-  
+
   /* If domain decomposition, compute the local CMFD cell ID*/ 
   if (_geometry->isDomainDecomposed()) {
     int local_cmfd_cell = getLocalCMFDCell(global_cmfd_cell);
@@ -1782,7 +1766,7 @@ void Cmfd::splitVertexCurrents() {
 
 
 #pragma omp for
-    for (int i=0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++) {
+    for (int i=0; i < _local_num_x * _local_num_y * _local_num_z; i++) {
 
       int global_id = getGlobalCMFDCell(i);
 
@@ -1903,7 +1887,7 @@ void Cmfd::splitEdgeCurrents() {
     int cell, surface;
 
 #pragma omp for
-    for (int i=0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++) {
+    for (int i=0; i < _local_num_x * _local_num_y * _local_num_z; i++) {
 
       int global_id = getGlobalCMFDCell(i);
 
@@ -2140,15 +2124,15 @@ int Cmfd::getCellNext(int cell, int surface_id, bool global, bool neighbor) {
     nz = _num_z;
   }
   else {
-    x = (cell % (_local_num_xn * _local_num_yn)) % _local_num_xn;
-    y = (cell % (_local_num_xn * _local_num_yn)) / _local_num_xn;
-    z = cell / (_local_num_xn * _local_num_yn);
+    x = (cell % (_local_num_x * _local_num_y)) % _local_num_x;
+    y = (cell % (_local_num_x * _local_num_y)) / _local_num_x;
+    z = cell / (_local_num_x * _local_num_y);
     x_global = x + _accumulate_lmx[_domain_communicator->_domain_idx_x];
     y_global = y + _accumulate_lmy[_domain_communicator->_domain_idx_y];
     z_global = z + _accumulate_lmz[_domain_communicator->_domain_idx_z];
-    nx = _local_num_xn;
-    ny = _local_num_yn;
-    nz = _local_num_zn;
+    nx = _local_num_x;
+    ny = _local_num_y;
+    nz = _local_num_z;
   }
 
   /* Find the cell on the other side of the surface */
@@ -2156,7 +2140,7 @@ int Cmfd::getCellNext(int cell, int surface_id, bool global, bool neighbor) {
     if (x != 0)
       cell_next = cell - 1;
     else if (neighbor && !global && x_global != 0)
-      cell_next = z * _local_num_yn + y;
+      cell_next = z * _local_num_y + y;
     else if (_boundaries[SURFACE_X_MIN] == PERIODIC)
       cell_next = cell + (_num_x-1);
   }
@@ -2165,7 +2149,7 @@ int Cmfd::getCellNext(int cell, int surface_id, bool global, bool neighbor) {
     if (y != 0)
       cell_next = cell - nx;
     else if (neighbor && !global && y_global != 0)
-      cell_next = z * _local_num_xn + x;
+      cell_next = z * _local_num_x + x;
     else if (_boundaries[SURFACE_Y_MIN] == PERIODIC)
       cell_next = cell + _num_x*(_num_y-1);
   }
@@ -2174,7 +2158,7 @@ int Cmfd::getCellNext(int cell, int surface_id, bool global, bool neighbor) {
     if (z != 0)
       cell_next = cell - nx*ny;
     else if (neighbor && !global && z_global != 0)
-      cell_next = y * _local_num_xn + x;
+      cell_next = y * _local_num_x + x;
     else if (_boundaries[SURFACE_Z_MIN] == PERIODIC)
       cell_next = cell + _num_x*_num_y*(_num_z-1);
   }
@@ -2183,7 +2167,7 @@ int Cmfd::getCellNext(int cell, int surface_id, bool global, bool neighbor) {
     if (x != nx - 1)
       cell_next = cell + 1;
     else if (neighbor && !global && x_global != _num_x - 1)
-      cell_next = z * _local_num_yn + y;
+      cell_next = z * _local_num_y + y;
     else if (_boundaries[SURFACE_X_MAX] == PERIODIC)
       cell_next = cell - (_num_x-1);
   }
@@ -2192,7 +2176,7 @@ int Cmfd::getCellNext(int cell, int surface_id, bool global, bool neighbor) {
     if (y != ny - 1)
       cell_next = cell + nx;
     else if (neighbor && !global && y_global != _num_y - 1)
-      cell_next = z * _local_num_xn + x;
+      cell_next = z * _local_num_x + x;
     else if (_boundaries[SURFACE_Y_MAX] == PERIODIC)
       cell_next = cell - _num_x*(_num_y-1);
   }
@@ -2201,7 +2185,7 @@ int Cmfd::getCellNext(int cell, int surface_id, bool global, bool neighbor) {
     if (z != nz - 1)
       cell_next = cell + nx*ny;
     else if (neighbor && !global && z_global != _num_z - 1)
-      cell_next = y * _local_num_xn + x;
+      cell_next = y * _local_num_x + x;
     else if (_boundaries[SURFACE_Z_MAX] == PERIODIC)
       cell_next = cell - _num_x*_num_y*(_num_z-1);
   }
@@ -2250,7 +2234,7 @@ int Cmfd::getBoundary(int side) {
 int Cmfd::convertFSRIdToCmfdCell(long fsr_id) {
 
   std::vector<long>::iterator iter;
-  for (int cell_id=0; cell_id < _local_num_xn*_local_num_yn*_local_num_zn;
+  for (int cell_id=0; cell_id < _local_num_x*_local_num_y*_local_num_z;
       cell_id++) {
     for (iter = _cell_fsrs.at(cell_id).begin();
          iter != _cell_fsrs.at(cell_id).end(); ++iter) {
@@ -2309,9 +2293,9 @@ std::vector< std::vector<long> >* Cmfd::getCellFSRs() {
 
 
 /**
- * @brief Set the vector of vectors that contains.
- *        the FSRs that lie in each cell.
- * @param Vector of vectors containing FSR IDs in each cell.
+ * @brief Set the vector of vectors that contains the FSRs that lie in each 
+ *        cell.
+ * @param cell_fsrs vector of vectors containing FSR IDs in each cell.
  */
 void Cmfd::setCellFSRs(std::vector< std::vector<long> >* cell_fsrs) {
 
@@ -2336,7 +2320,7 @@ void Cmfd::setFluxUpdateOn(bool flux_update_on) {
 
 
 /**
- * @brief Sets the a ConvergenceData object to record diagnostics
+ * @brief Sets the a ConvergenceData object to record diagnostics.
  * @details The ConvergenceData object records the number of fission source
  *          and flux iterations for the CMFD solver as well as the maximum
  *          magnitude prolongation factor
@@ -2349,12 +2333,12 @@ void Cmfd::setConvergenceData(ConvergenceData* convergence_data) {
 
 /**
  * @brief Set the flag indicating whether to use quadratic axial interpolation 
- *        for update ratios
+ *        for update ratios.
  * @param interpolate flag meaning No interpolation(0), FSR axially averaged 
-          value(1) or centroid z-coordinate evaluted value(2)
+          value(1) or centroid z-coordinate evaluated value(2)
  */
 void Cmfd::useAxialInterpolation(int interpolate) {
-  
+
   if(interpolate<0 || interpolate>2)
     log_printf(ERROR, "interpolate can only has value 0, 1, or 2, respectively"
                " meaning No interpolation, FSR axially averaged value or"
@@ -2368,7 +2352,7 @@ void Cmfd::useAxialInterpolation(int interpolate) {
 
 
 /**
- * @brief Turns on the flux limiting condition
+ * @brief Turns on the flux limiting condition.
  * @details If the CMFD correction diffusion coefficient is larger than the 
  *          diffusion coefficient, recompute the diffusion coefficient as the 
  *          ratio of current to twice the flux, and re-compute a correction
@@ -2430,7 +2414,7 @@ void Cmfd::enforceBalanceOnDiagonal(int cmfd_cell, int group) {
 
 /**
  * @brief Rebalances the total cross section to be consistent with the MOC
- *        solution on every sweep
+ *        solution on every sweep.
  * @param balance_sigma_t Wheter to compute the rebalanced total cross-section
  */
 void Cmfd::rebalanceSigmaT(bool balance_sigma_t) {
@@ -2439,7 +2423,7 @@ void Cmfd::rebalanceSigmaT(bool balance_sigma_t) {
 
 
 /**
- * @brief Returns a flag indicating whether the sigma-t rebalance is on
+ * @brief Returns a flag indicating whether the sigma-t rebalance is on.
  * @return A flag indicating whether the rebalance is on
  */
 bool Cmfd::isSigmaTRebalanceOn() {
@@ -2449,7 +2433,7 @@ bool Cmfd::isSigmaTRebalanceOn() {
 
 /**
  * @brief Get flag indicating whether to update the MOC flux.
- * @return Flag saying whether to update MOC flux.
+ * @return Flag saying whether to update MOC flux
  */
 bool Cmfd::isFluxUpdateOn() {
  return _flux_update_on;
@@ -2460,7 +2444,7 @@ bool Cmfd::isFluxUpdateOn() {
  * @brief Set flag indicating whether to use FSR centroids to update
  *        the MOC flux.
  * @param centroid_update_on Flag saying whether to use centroids to
- *        update MOC flux.
+ *        update MOC flux
  */
 void Cmfd::setCentroidUpdateOn(bool centroid_update_on) {
   _centroid_update_on = centroid_update_on;
@@ -2470,7 +2454,7 @@ void Cmfd::setCentroidUpdateOn(bool centroid_update_on) {
 /**
  * @brief Get flag indicating whether to use FSR centroids to update
  *        the MOC flux.
- * @return Flag saying whether to use centroids to update MOC flux.
+ * @return Flag saying whether to use centroids to update MOC flux
  */
 bool Cmfd::isCentroidUpdateOn() {
   return _centroid_update_on;
@@ -2478,8 +2462,8 @@ bool Cmfd::isCentroidUpdateOn() {
 
 
 /**
- * @brief Sets the threshold for CMFD source convergence (>0)
- * @param the threshold for source convergence
+ * @brief Sets the threshold for CMFD source convergence (>0).
+ * @param source_thresh the threshold for source convergence
  */
 void Cmfd::setSourceConvergenceThreshold(double source_thresh) {
 
@@ -2492,8 +2476,8 @@ void Cmfd::setSourceConvergenceThreshold(double source_thresh) {
 
 
 /**
- * @brief Sets the PolarQuad object in use by the MOC Solver.
- * @param quadrature a PolarQuad object pointer from the Solver
+ * @brief Sets the Quadrature object in use by the MOC Solver.
+ * @param quadrature a Quadrature object pointer from the Solver
  */
 void Cmfd::setQuadrature(Quadrature* quadrature) {
   _quadrature = quadrature;
@@ -2528,7 +2512,7 @@ void Cmfd::generateKNearestStencils() {
     int num_cells_in_stencil = 9;
 
     /* Loop over mesh cells */
-    for (int i = 0; i < _local_num_xn*_local_num_yn*_local_num_zn; i++) {
+    for (int i = 0; i < _local_num_x*_local_num_y*_local_num_z; i++) {
 
       int global_ind = getGlobalCMFDCell(i);
 
@@ -2563,7 +2547,7 @@ void Cmfd::generateKNearestStencils() {
           else
             ++stencil_iter;
         }
-  
+
         /* Resize stencil to be of size <= _k_nearest */
         _k_nearest_stencils[fsr_id].resize
           (std::min(_k_nearest, int(_k_nearest_stencils[fsr_id].size())));
@@ -2575,13 +2559,13 @@ void Cmfd::generateKNearestStencils() {
     double total_distance;
     for (long i=0; i < _num_FSRs; i++) {
       total_distance = 1.e-10;
-  
+
       /* Compute the total distance of each FSR centroid to its k-nearest CMFD
       * cells */
       for (stencil_iter = _k_nearest_stencils[i].begin();
           stencil_iter < _k_nearest_stencils[i].end(); ++stencil_iter)
         total_distance += stencil_iter->second;
-  
+
       /* Reset the second stencil value to
       * (1.0 - cell_distance / total_distance) */
       for (stencil_iter = _k_nearest_stencils[i].begin();
@@ -2593,7 +2577,7 @@ void Cmfd::generateKNearestStencils() {
 
 
   /* Compute axial quadratic interpolation values if requested */
-  if (_use_axial_interpolation && _local_num_zn >= 3) {
+  if (_use_axial_interpolation && _local_num_z >= 3) {
 
     /* Initialize axial quadratic interpolant values */
     _axial_interpolants.resize(_num_FSRs);
@@ -2602,7 +2586,7 @@ void Cmfd::generateKNearestStencils() {
     }
 
     /* Loop over mesh cells */
-    for (int i = 0; i < _local_num_xn*_local_num_yn*_local_num_zn; i++) {
+    for (int i = 0; i < _local_num_x*_local_num_y*_local_num_z; i++) {
 
       /* Starting z number of CMFD mesh in this domain */
       int z_start = 0;
@@ -2610,7 +2594,7 @@ void Cmfd::generateKNearestStencils() {
         z_start = _accumulate_lmz[_domain_communicator->_domain_idx_z];
 
       /* Calculate the CMFD cell z-coordinate */
-      int z_ind = i / (_local_num_xn * _local_num_yn);
+      int z_ind = i / (_local_num_x * _local_num_y);
 
       /* The heights of neighboring three CMFD meshes for quadratic fit */
       double h0, h1, h2; 
@@ -2624,7 +2608,7 @@ void Cmfd::generateKNearestStencils() {
         h2 = _cell_widths_z[z_start + z_ind + 2];
         z_cmfd = _accumulate_z[z_start + z_ind+1] + h1/2. + _lattice->getMinZ();
       }
-      else if(z_ind == _local_num_zn - 1) {
+      else if(z_ind == _local_num_z - 1) {
         h0 = _cell_widths_z[z_start + z_ind - 2];
         h1 = _cell_widths_z[z_start + z_ind - 1];
         h2 = _cell_widths_z[z_start + z_ind];
@@ -2655,7 +2639,7 @@ void Cmfd::generateKNearestStencils() {
         ze = 2*zc - zs;
 
         /* Calculate components for quadratic interpolation of the FSR axially 
-           averaged value*/
+           averaged value */
         if(_use_axial_interpolation ==1) {
           _axial_interpolants.at(fsr_id)[0] = (h1*(h1+h1*zc*4.0+h2*zc*8.0-
             h1*(zc*zc)*1.6E1-h1*(zs*zs)*4.0+h1*zc*zs*8.0)*(-1.0/4.0))
@@ -2703,7 +2687,7 @@ void Cmfd::generateKNearestStencils() {
                     _axial_interpolants.at(fsr_id)[2]);
         }
         /* Calculate components for quadratic interpolation of the centroid  
-           z-coordinate evaluted value. For uniform CMFD*/
+           z-coordinate evaluted value. For uniform CMFD */
         /*_axial_interpolants.at(fsr_id)[0] = zc * zc/2.0 - zc/2.0 - 1.0/24.0;
         _axial_interpolants.at(fsr_id)[1] = -zc * zc + 26.0/24.0;
         _axial_interpolants.at(fsr_id)[2] = zc * zc/2.0 + zc/2.0 - 1.0/24.0;*/
@@ -2732,51 +2716,51 @@ void Cmfd::generateKNearestStencils() {
 int Cmfd::getCellByStencil(int cell_id, int stencil_id) {
 
   int cell_next_id = -1;
-  int x = (cell_id % (_local_num_xn * _local_num_yn)) % _local_num_xn;
-  int y = (cell_id % (_local_num_xn * _local_num_yn)) / _local_num_xn;
+  int x = (cell_id % (_local_num_x * _local_num_y)) % _local_num_x;
+  int y = (cell_id % (_local_num_x * _local_num_y)) / _local_num_x;
 
   if (stencil_id == 0) {
     if (x != 0 && y != 0)
-      cell_next_id = cell_id - _local_num_xn - 1;
+      cell_next_id = cell_id - _local_num_x - 1;
   }
   else if (stencil_id == 1) {
     if (y != 0)
-      cell_next_id = cell_id - _local_num_xn;
+      cell_next_id = cell_id - _local_num_x;
     else if (_boundaries[SURFACE_Y_MIN] == PERIODIC)
-      cell_next_id = cell_id + _local_num_xn * (_local_num_yn - 1);
+      cell_next_id = cell_id + _local_num_x * (_local_num_y - 1);
   }
   else if (stencil_id == 2) {
-    if (x != _local_num_xn - 1 && y != 0)
-      cell_next_id = cell_id - _local_num_xn + 1;
+    if (x != _local_num_x - 1 && y != 0)
+      cell_next_id = cell_id - _local_num_x + 1;
   }
   else if (stencil_id == 3) {
     if (x != 0)
       cell_next_id = cell_id - 1;
     else if (_boundaries[SURFACE_X_MIN] == PERIODIC)
-      cell_next_id = cell_id + (_local_num_xn - 1);
+      cell_next_id = cell_id + (_local_num_x - 1);
   }
   else if (stencil_id == 4) {
     cell_next_id = cell_id;
   }
   else if (stencil_id == 5) {
-    if (x != _local_num_xn - 1)
+    if (x != _local_num_x - 1)
       cell_next_id = cell_id + 1;
     else if (_boundaries[SURFACE_X_MAX] == PERIODIC)
-      cell_next_id = cell_id - (_local_num_xn - 1);
+      cell_next_id = cell_id - (_local_num_x - 1);
   }
   else if (stencil_id == 6) {
-    if (x != 0 && y != _local_num_yn - 1)
-      cell_next_id = cell_id + _local_num_xn - 1;
+    if (x != 0 && y != _local_num_y - 1)
+      cell_next_id = cell_id + _local_num_x - 1;
   }
   else if (stencil_id == 7) {
-    if (y != _local_num_yn - 1)
-      cell_next_id = cell_id + _local_num_xn;
+    if (y != _local_num_y - 1)
+      cell_next_id = cell_id + _local_num_x;
     else if (_boundaries[SURFACE_Y_MAX] == PERIODIC)
-      cell_next_id = cell_id - _local_num_xn * (_local_num_yn - 1);
+      cell_next_id = cell_id - _local_num_x * (_local_num_y - 1);
   }
   else if (stencil_id == 8) {
-    if (x != _local_num_xn - 1 && y != _local_num_yn - 1)
-      cell_next_id = cell_id + _local_num_xn + 1;
+    if (x != _local_num_x - 1 && y != _local_num_y - 1)
+      cell_next_id = cell_id + _local_num_x + 1;
   }
 
   return cell_next_id;
@@ -2805,7 +2789,7 @@ int Cmfd::getCellByStencil(int cell_id, int stencil_id) {
  * @param fsr The fsr being updated.
  * @return the ratio used to update the FSR flux.
  */
-CMFD_PRECISION Cmfd::getUpdateRatio(int cell_id, int group, int fsr) {
+CMFD_PRECISION Cmfd::getUpdateRatio(int cell_id, int group, long fsr) {
 
   CMFD_PRECISION ratio = 0.0;
   std::vector< std::pair<int, double> >::iterator iter;
@@ -2849,26 +2833,26 @@ CMFD_PRECISION Cmfd::getUpdateRatio(int cell_id, int group, int fsr) {
  * @param fsr The fsr being updated.
  * @return the ratio of CMFD fluxes
  */
-CMFD_PRECISION Cmfd::getFluxRatio(int cell_id, int group, int fsr) {
+CMFD_PRECISION Cmfd::getFluxRatio(int cell_id, int group, long fsr) {
 
   double* interpolants;
   double ratio = 1.0;
   if (_use_axial_interpolation)
     interpolants = _axial_interpolants.at(fsr);
-  if (_use_axial_interpolation && _local_num_zn >= 3) {
-    int z_ind = cell_id / (_local_num_xn * _local_num_yn);
+  if (_use_axial_interpolation && _local_num_z >= 3) {
+    int z_ind = cell_id / (_local_num_x * _local_num_y);
     int cell_mid = cell_id;
 
     /* Shift up or down one cell if at top/bottom, interpolants corrects
        for the shift in cells */
     if (z_ind == 0)
-      cell_mid += _local_num_xn * _local_num_yn;
-    else if (z_ind == _local_num_zn - 1)
-      cell_mid -= _local_num_xn * _local_num_yn;
+      cell_mid += _local_num_x * _local_num_y;
+    else if (z_ind == _local_num_z - 1)
+      cell_mid -= _local_num_x * _local_num_y;
 
     /* Get cell index above and below current CMFD cell */
-    int cell_prev = cell_mid - _local_num_xn * _local_num_yn;
-    int cell_next = cell_mid + _local_num_xn * _local_num_yn;
+    int cell_prev = cell_mid - _local_num_x * _local_num_y;
+    int cell_next = cell_mid + _local_num_x * _local_num_y;
 
     /* Get new and old fluxes in bottom/mid/top cells */
     double old_flux_prev = _old_flux->getValue(cell_prev, group);
@@ -3015,7 +2999,8 @@ double Cmfd::getDistanceToCentroid(Point* centroid, int cell_id,
 }
 
 
-/** @brief Set a pointer to the Geometry.
+/** 
+ * @brief Set a pointer to the Geometry.
  * @param goemetry A pointer to a Geometry object.
  */
 void Cmfd::setGeometry(Geometry* geometry) {
@@ -3023,7 +3008,8 @@ void Cmfd::setGeometry(Geometry* geometry) {
 }
 
 
-/** @brief Set a number of k-nearest neighbor cells to use in updating
+/** 
+ * @brief Set a number of k-nearest neighbor cells to use in updating
  *         the FSR flux.
  * @param k_nearest The number of nearest neighbor CMFD cells.
  */
@@ -3049,27 +3035,27 @@ void Cmfd::zeroCurrents() {
     _net_currents->clear();
   }
 
-  // Clear boundary currents
+  /* Clear boundary currents */
 #ifdef MPIx
   if (_geometry->isDomainDecomposed()) {
 #pragma omp parallel for
     for (int s=0; s < NUM_FACES; s++) {
 
-      // Loop over all CMFD cells on the current surface
+      /* Loop over all CMFD cells on the current surface */
       std::map<int, int>::iterator it;
       for (it=_boundary_index_map.at(s).begin();
           it != _boundary_index_map.at(s).end(); ++it) {
 
         int idx = it->second;
 
-        // Loop over CMFD coarse energy groups
+        /* Loop over CMFD coarse energy groups */
         for (int e = 0; e < _num_cmfd_groups; e++) {
 
-          // Loop over cell faces
+          /* Loop over cell faces */
           for (int f=0; f < NUM_FACES; f++)
             _boundary_surface_currents[s][idx][f*_num_cmfd_groups+e] = 0.0;
 
-          // Loop over all cell faces and edges
+          /* Loop over all cell faces and edges */
           for (int fe=0; fe < NUM_FACES + NUM_EDGES; fe++) {
             _off_domain_split_currents[s][idx][fe*_num_cmfd_groups+e] = 0.0;
             _received_split_currents[s][idx][fe*_num_cmfd_groups+e] = 0.0;
@@ -3109,7 +3095,7 @@ void Cmfd::initialize() {
     delete [] _cell_locks;
 
   /* Calculate the number of elements */
-  int num_cells = _local_num_xn * _local_num_yn * _local_num_zn;
+  int num_cells = _local_num_x * _local_num_y * _local_num_z;
   int ncg = _num_cmfd_groups;
 
   try {
@@ -3130,8 +3116,8 @@ void Cmfd::initialize() {
     omp_init_lock(&_edge_corner_lock);
 
     /* Compute and log size in memory of CMFD matrices */
-    int num_rows = _num_cmfd_groups * _local_num_xn * _local_num_yn *
-                   _local_num_zn * 2; 
+    int num_rows = _num_cmfd_groups * _local_num_x * _local_num_y *
+                   _local_num_z * 2; 
     // A matrix is duplicated as list of list and CSR form (allocated before
     // each transport iteration's CMFD solve)
 
@@ -3143,23 +3129,23 @@ void Cmfd::initialize() {
                size);
 
     /* Allocate memory for matrix and vector objects */
-    _M = new Matrix(_cell_locks, _local_num_xn, _local_num_yn, _local_num_zn,
+    _M = new Matrix(_cell_locks, _local_num_x, _local_num_y, _local_num_z,
                     ncg);
-    _A = new Matrix(_cell_locks, _local_num_xn, _local_num_yn, _local_num_zn,
+    _A = new Matrix(_cell_locks, _local_num_x, _local_num_y, _local_num_z,
                     ncg);
-    _old_source = new Vector(_cell_locks, _local_num_xn, _local_num_yn,
-                             _local_num_zn, ncg);
-    _new_source = new Vector(_cell_locks, _local_num_xn, _local_num_yn,
-                             _local_num_zn, ncg);
-    _old_flux = new Vector(_cell_locks, _local_num_xn, _local_num_yn,
-                           _local_num_zn, ncg);
-    _new_flux = new Vector(_cell_locks, _local_num_xn, _local_num_yn,
-                           _local_num_zn, ncg);
-    _old_dif_surf_corr = new Vector(_cell_locks, _local_num_xn, _local_num_yn,
-                                    _local_num_zn, NUM_FACES * ncg);
+    _old_source = new Vector(_cell_locks, _local_num_x, _local_num_y,
+                             _local_num_z, ncg);
+    _new_source = new Vector(_cell_locks, _local_num_x, _local_num_y,
+                             _local_num_z, ncg);
+    _old_flux = new Vector(_cell_locks, _local_num_x, _local_num_y,
+                           _local_num_z, ncg);
+    _new_flux = new Vector(_cell_locks, _local_num_x, _local_num_y,
+                           _local_num_z, ncg);
+    _old_dif_surf_corr = new Vector(_cell_locks, _local_num_x, _local_num_y,
+                                    _local_num_z, NUM_FACES * ncg);
     _old_dif_surf_corr->setAll(0.0);
-    _volumes = new Vector(_cell_locks, _local_num_xn, _local_num_yn, 
-                          _local_num_zn, 1);
+    _volumes = new Vector(_cell_locks, _local_num_x, _local_num_y, 
+                          _local_num_z, 1);
 
     /* Initialize k-nearest stencils, currents, flux, materials and tallies */
     generateKNearestStencils();
@@ -3174,19 +3160,19 @@ void Cmfd::initialize() {
                    _accumulate_lmy[_domain_communicator->_domain_idx_y] +
                    _accumulate_lmz[_domain_communicator->_domain_idx_z];
       _domain_communicator->_offset = offset;
-      _domain_communicator->_local_num_x = _local_num_xn;
-      _domain_communicator->_local_num_y = _local_num_yn;
-      _domain_communicator->_local_num_z = _local_num_zn;
+      _domain_communicator->_local_num_x = _local_num_x;
+      _domain_communicator->_local_num_y = _local_num_y;
+      _domain_communicator->_local_num_z = _local_num_z;
       _domain_communicator->num_groups = ncg;
 
-      int dir_sizes[3] = {num_cells / _local_num_xn,  num_cells / _local_num_yn,
-                          num_cells / _local_num_zn};
+      int dir_sizes[3] = {num_cells / _local_num_x,  num_cells / _local_num_y,
+                          num_cells / _local_num_z};
 
       /* Allocate arrays to contain information about the domain's neighbors */
       _domain_communicator->num_connections = new int*[2];
       _domain_communicator->indexes = new int**[2];
       _domain_communicator->domains = new int**[2];
-      
+
       /* Arrays to contain data to communicate to/receive from other domains */
       _domain_communicator->fluxes = new CMFD_PRECISION**[2];
       _domain_communicator->coupling_coeffs = new CMFD_PRECISION**[2];
@@ -3219,9 +3205,9 @@ void Cmfd::initialize() {
       }
 
       int storage_per_cell = ((2 + NUM_FACES) * ncg + 1);
-      int num_per_side[3] = {_local_num_yn * _local_num_zn,
-                          _local_num_xn * _local_num_zn,
-                          _local_num_xn * _local_num_yn};
+      int num_per_side[3] = {_local_num_y * _local_num_z,
+                          _local_num_x * _local_num_z,
+                          _local_num_x * _local_num_y};
 
       /* Count total number of cells at all faces of the domain */
       int num_boundary_cells = 0;
@@ -3330,65 +3316,65 @@ void Cmfd::initialize() {
 
       /* Calculate the starting and ending indexes of on-domain CMFD cells */
       int x_start = _accumulate_lmx[_domain_communicator->_domain_idx_x];
-      int x_end = x_start + _local_num_xn;
+      int x_end = x_start + _local_num_x;
       int y_start = _accumulate_lmy[_domain_communicator->_domain_idx_y];
-      int y_end = y_start + _local_num_yn;
+      int y_end = y_start + _local_num_y;
       int z_start = _accumulate_lmz[_domain_communicator->_domain_idx_z];
-      int z_end = z_start + _local_num_zn;
+      int z_end = z_start + _local_num_z;
 
       _boundary_index_map.resize(NUM_FACES);
 
       /* Map connecting cells on x-surfaces */
       int global_ind;
-      for (int y=0; y < _local_num_yn; y++) {
-        for (int z=0; z < _local_num_zn; z++) {
+      for (int y=0; y < _local_num_y; y++) {
+        for (int z=0; z < _local_num_z; z++) {
           if (x_start > 0) {
             global_ind = ((z_start + z) * _num_y + y + y_start) *
                             _num_x + x_start - 1;
-            _boundary_index_map.at(SURFACE_X_MIN)[global_ind] = z * _local_num_yn
+            _boundary_index_map.at(SURFACE_X_MIN)[global_ind] = z * _local_num_y
                                                               + y;
           }
           if (x_end < _num_x) {
             global_ind = ((z_start + z) * _num_y + y + y_start) *
                             _num_x + x_end;
 
-            _boundary_index_map.at(SURFACE_X_MAX)[global_ind] = z * _local_num_yn
+            _boundary_index_map.at(SURFACE_X_MAX)[global_ind] = z * _local_num_y
                                                                 + y;
           }
         }
       }
 
       /* Map connecting cells on y-surfaces */
-      for (int x=0; x < _local_num_xn; x++) {
-        for (int z=0; z < _local_num_zn; z++) {
+      for (int x=0; x < _local_num_x; x++) {
+        for (int z=0; z < _local_num_z; z++) {
           if (y_start > 0) {
             global_ind = ((z_start + z) * _num_y + y_start-1) *
                             _num_x + x + x_start;
-            _boundary_index_map.at(SURFACE_Y_MIN)[global_ind] = z * _local_num_xn
+            _boundary_index_map.at(SURFACE_Y_MIN)[global_ind] = z * _local_num_x
                                                                 + x;
           }
           if (y_end < _num_y) {
             global_ind = ((z_start + z) * _num_y + y_end)
                           * _num_x + x + x_start;
-            _boundary_index_map.at(SURFACE_Y_MAX)[global_ind] = z * _local_num_xn
+            _boundary_index_map.at(SURFACE_Y_MAX)[global_ind] = z * _local_num_x
                                                                 + x;
           }
         }
       }
 
       /* Map connecting cells on z-surfaces */
-      for (int x=0; x < _local_num_xn; x++) {
-        for (int y=0; y < _local_num_yn; y++) {
+      for (int x=0; x < _local_num_x; x++) {
+        for (int y=0; y < _local_num_y; y++) {
           if (z_start > 0) {
             global_ind = ((z_start-1) * _num_y + y + y_start) *
                           _num_x + x + x_start;
-            _boundary_index_map.at(SURFACE_Z_MIN)[global_ind] = y * _local_num_xn
+            _boundary_index_map.at(SURFACE_Z_MIN)[global_ind] = y * _local_num_x
                                                                 + x;
           }
           if (z_end < _num_z) {
             global_ind = (z_end * _num_y + y + y_start) *
                             _num_x + x + x_start;
-            _boundary_index_map.at(SURFACE_Z_MAX)[global_ind] = y * _local_num_xn
+            _boundary_index_map.at(SURFACE_Z_MAX)[global_ind] = y * _local_num_x
                                                                 + x;
           }
         }
@@ -3593,7 +3579,7 @@ void Cmfd::copyCurrentsToBackup() {
 
   /* Copy on-node surface currents */
 #pragma omp parallel for
-  for (int i=0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++) {
+  for (int i=0; i < _local_num_x * _local_num_y * _local_num_z; i++) {
 
     for (int f=0; f < NUM_FACES; f++) {
 
@@ -3837,19 +3823,19 @@ void Cmfd::printTimerReport() {
 
   /* Get the total XS collapse time */
   double xs_collapse_time = _timer->getSplit("Total collapse time");
-  msg_string = "Total XS collapse time";
+  msg_string = "  XS collapse time";
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), xs_collapse_time);
 
   /* Get the MPI communication time */
   double comm_time = _timer->getSplit("CMFD MPI communication time");
-  msg_string = "CMFD MPI communication time";
+  msg_string = "  MPI communication time";
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), comm_time);
 
   /* Get the total solver time */
   double solver_time = _timer->getSplit("Total solver time");
-  msg_string = "Total CMFD solver time";
+  msg_string = "  Total CMFD solver time";
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), solver_time);
 }
@@ -3865,15 +3851,15 @@ void Cmfd::copyFullSurfaceCurrents() {
 
   /* Allocate full surface currents if necessary */
   if (_full_surface_currents == NULL)
-    _full_surface_currents = new Vector(_cell_locks, _local_num_xn,
-                                        _local_num_yn, _local_num_zn,
+    _full_surface_currents = new Vector(_cell_locks, _local_num_x,
+                                        _local_num_y, _local_num_z,
                                         _num_cmfd_groups * NUM_SURFACES);
 
   /* Clear the currently saved surface currents */
   _full_surface_currents->clear();
 
   /* Copy surface currents from surface faces */
-  for (int i=0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++) {
+  for (int i=0; i < _local_num_x * _local_num_y * _local_num_z; i++) {
     for (int s=0; s < NUM_FACES; s++) {
       for (int g=0; g < _num_cmfd_groups; g++) {
         FP_PRECISION current =
@@ -3937,10 +3923,10 @@ void Cmfd::checkNeutronBalance(bool pre_split) {
                      _old_flux->getArray(), offset);
 
 #pragma omp parallel for collapse(2)
-    for (int iz=0; iz < _local_num_zn; iz++) {
-      for (int iy=0; iy < _local_num_yn; iy++) {
-        for (int ix=(iy+iz+color+offset)%2; ix < _local_num_xn; ix+=2) {
-          int cell = (iz*_local_num_yn + iy)*_local_num_xn + ix;
+    for (int iz=0; iz < _local_num_z; iz++) {
+      for (int iy=0; iy < _local_num_y; iy++) {
+        for (int ix=(iy+iz+color+offset)%2; ix < _local_num_x; ix+=2) {
+          int cell = (iz*_local_num_y + iy)*_local_num_x + ix;
           for (int g=0; g < _num_cmfd_groups; g++) {
 
             int row = cell * _num_cmfd_groups + g;
@@ -3964,11 +3950,11 @@ void Cmfd::checkNeutronBalance(bool pre_split) {
 
   /* Compute MOC balance */
   /* Loop over CMFD cells */
-  for (int i = 0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++) {
+  for (int i = 0; i < _local_num_x * _local_num_y * _local_num_z; i++) {
 
-    int x = (i % (_local_num_xn * _local_num_yn)) % _local_num_xn;
-    int y = (i % (_local_num_xn * _local_num_yn)) / _local_num_xn;
-    int z = i / (_local_num_xn * _local_num_yn);
+    int x = (i % (_local_num_x * _local_num_y)) % _local_num_x;
+    int y = (i % (_local_num_x * _local_num_y)) / _local_num_x;
+    int z = i / (_local_num_x * _local_num_y);
 
     Material* cell_material = _materials[i];
 
@@ -4024,11 +4010,11 @@ void Cmfd::checkNeutronBalance(bool pre_split) {
       if (pre_split) {
 
         /* Create arrays of cell indexes and bounds */
-        int cell_limits[3] = {_local_num_xn, _local_num_yn, _local_num_zn};
+        int cell_limits[3] = {_local_num_x, _local_num_y, _local_num_z};
         int cell_ind[3];
-        cell_ind[0] = i % _local_num_xn;
-        cell_ind[1] = (i / _local_num_xn) % _local_num_yn;
-        cell_ind[2] = i / (_local_num_xn * _local_num_yn);
+        cell_ind[0] = i % _local_num_x;
+        cell_ind[1] = (i / _local_num_x) % _local_num_y;
+        cell_ind[2] = i / (_local_num_x * _local_num_y);
 
         /* Tally current from all surfaces including edges and corners */
         for (int s=0; s < NUM_SURFACES; s++) {
@@ -4044,8 +4030,8 @@ void Cmfd::checkNeutronBalance(bool pre_split) {
           for (int d=0; d < 3; d++)
             cell_next_ind[d] = cell_ind[d] + direction[d];
 
-          cmfd_cell_next = cell_next_ind[0] + cell_next_ind[1] * _local_num_xn
-                         + cell_next_ind[2] * (_local_num_xn * _local_num_yn);
+          cmfd_cell_next = cell_next_ind[0] + cell_next_ind[1] * _local_num_x
+                         + cell_next_ind[2] * (_local_num_x * _local_num_y);
 
           /* Compute the opposite direction vector */
           int op_direction[3];
@@ -4105,8 +4091,8 @@ void Cmfd::checkNeutronBalance(bool pre_split) {
               for (int d=0; d < 3; d++)
                 cell_next_ind[d] = cell_ind[d] + transmit_direction[d];
               cmfd_cell_next = cell_next_ind[0] + cell_next_ind[1] *
-                              _local_num_xn + cell_next_ind[2] *
-                              (_local_num_xn * _local_num_yn);
+                              _local_num_x + cell_next_ind[2] *
+                              (_local_num_x * _local_num_y);
             }
           }
 
@@ -4199,27 +4185,27 @@ void Cmfd::packBuffers() {
   int current_idx[6] = {0,0,0,0,0,0};
   bool found_surfaces[NUM_FACES];
 
-  for (int z=0; z < _local_num_zn; z++) {
-    for (int y=0; y < _local_num_yn; y++) {
-      for (int x=0; x < _local_num_xn; x++) {
+  for (int z=0; z < _local_num_z; z++) {
+    for (int y=0; y < _local_num_y; y++) {
+      for (int x=0; x < _local_num_x; x++) {
         for (int s=0; s < NUM_FACES; s++)
           found_surfaces[s] = false;
         if (x == 0)
           found_surfaces[SURFACE_X_MIN] = true;
-        if (x == _local_num_xn-1)
+        if (x == _local_num_x-1)
           found_surfaces[SURFACE_X_MAX] = true;
         if (y == 0)
           found_surfaces[SURFACE_Y_MIN] = true;
-        if (y == _local_num_yn-1)
+        if (y == _local_num_y-1)
           found_surfaces[SURFACE_Y_MAX] = true;
         if (z == 0)
           found_surfaces[SURFACE_Z_MIN] = true;
-        if (z == _local_num_zn-1)
+        if (z == _local_num_z-1)
           found_surfaces[SURFACE_Z_MAX] = true;
         for (int s=0; s < NUM_FACES; s++) {
           if (found_surfaces[s]) {
             int idx = current_idx[s];
-            int cell_id = ((z * _local_num_yn) + y) * _local_num_xn + x;
+            int cell_id = ((z * _local_num_y) + y) * _local_num_x + x;
             _send_volumes[s][idx][0] = _volume_tally[cell_id][0];
             for (int e=0; e < _num_cmfd_groups; e++) {
               _send_reaction[s][idx][e] = _reaction_tally[cell_id][e];
@@ -4278,22 +4264,22 @@ void Cmfd::ghostCellExchange() {
       // Figure out serialized buffer length for this face
       int size = 0;
       if (surf == SURFACE_X_MIN) {
-        size = _local_num_yn * _local_num_zn * storage_per_cell;
+        size = _local_num_y * _local_num_z * storage_per_cell;
       }
       else if (surf == SURFACE_X_MAX) {
-        size = _local_num_yn * _local_num_zn * storage_per_cell;
+        size = _local_num_y * _local_num_z * storage_per_cell;
       }
       else if (surf == SURFACE_Y_MIN) {
-        size = _local_num_xn * _local_num_zn * storage_per_cell;
+        size = _local_num_x * _local_num_z * storage_per_cell;
       }
       else if (surf == SURFACE_Y_MAX) {
-        size = _local_num_xn * _local_num_zn * storage_per_cell;
+        size = _local_num_x * _local_num_z * storage_per_cell;
       }
       else if (surf == SURFACE_Z_MIN) {
-        size = _local_num_xn * _local_num_yn * storage_per_cell;
+        size = _local_num_x * _local_num_y * storage_per_cell;
       }
       else if (surf == SURFACE_Z_MAX) {
-        size = _local_num_xn * _local_num_yn * storage_per_cell;
+        size = _local_num_x * _local_num_y * storage_per_cell;
       }
 
       sizes[surf] = size;
@@ -4373,22 +4359,22 @@ void Cmfd::communicateSplits(bool faces) {
       // Figure out serialized buffer length for this face
       int size = 0;
       if (surf == SURFACE_X_MIN) {
-        size = _local_num_yn * _local_num_zn * storage_per_cell;
+        size = _local_num_y * _local_num_z * storage_per_cell;
       }
       else if (surf == SURFACE_X_MAX) {
-        size = _local_num_yn * _local_num_zn * storage_per_cell;
+        size = _local_num_y * _local_num_z * storage_per_cell;
       }
       else if (surf == SURFACE_Y_MIN) {
-        size = _local_num_xn * _local_num_zn * storage_per_cell;
+        size = _local_num_x * _local_num_z * storage_per_cell;
       }
       else if (surf == SURFACE_Y_MAX) {
-        size = _local_num_xn * _local_num_zn * storage_per_cell;
+        size = _local_num_x * _local_num_z * storage_per_cell;
       }
       else if (surf == SURFACE_Z_MIN) {
-        size = _local_num_xn * _local_num_yn * storage_per_cell;
+        size = _local_num_x * _local_num_y * storage_per_cell;
       }
       else if (surf == SURFACE_Z_MAX) {
-        size = _local_num_xn * _local_num_yn * storage_per_cell;
+        size = _local_num_x * _local_num_y * storage_per_cell;
       }
 
       sizes[surf] = size;
@@ -4444,24 +4430,24 @@ void Cmfd::unpackSplitCurrents(bool faces) {
   bool found_surfaces[NUM_FACES];
 
   /* Loop over all CMFD cells */
-  for (int z=0; z < _local_num_zn; z++) {
-    for (int y=0; y < _local_num_yn; y++) {
-      for (int x=0; x < _local_num_xn; x++) {
+  for (int z=0; z < _local_num_z; z++) {
+    for (int y=0; y < _local_num_y; y++) {
+      for (int x=0; x < _local_num_x; x++) {
 
         /* Look for boundaries touching the CMFD cell */
         for (int s=0; s < NUM_FACES; s++)
           found_surfaces[s] = false;
         if (x == 0)
           found_surfaces[SURFACE_X_MIN] = true;
-        if (x == _local_num_xn-1)
+        if (x == _local_num_x-1)
           found_surfaces[SURFACE_X_MAX] = true;
         if (y == 0)
           found_surfaces[SURFACE_Y_MIN] = true;
-        if (y == _local_num_yn-1)
+        if (y == _local_num_y-1)
           found_surfaces[SURFACE_Y_MAX] = true;
         if (z == 0)
           found_surfaces[SURFACE_Z_MIN] = true;
-        if (z == _local_num_zn-1)
+        if (z == _local_num_z-1)
           found_surfaces[SURFACE_Z_MAX] = true;
 
         /* Handle all boundaries */
@@ -4469,7 +4455,7 @@ void Cmfd::unpackSplitCurrents(bool faces) {
           if (found_surfaces[s]) {
 
             /* Convert the (x,y,z) indexes to a cell ID and boundary index */
-            int cell_id = ((z * _local_num_yn) + y) * _local_num_xn + x;
+            int cell_id = ((z * _local_num_y) + y) * _local_num_x + x;
             int idx = current_idx[s];
 
             /* Copy the appropriate face or edge information */
@@ -4551,11 +4537,11 @@ int Cmfd::getLocalCMFDCell(int cmfd_cell) {
   if (_geometry->isDomainDecomposed()) {
     if (_domain_communicator != NULL) {
       x_start = _accumulate_lmx[_domain_communicator->_domain_idx_x];
-      x_end = x_start + _local_num_xn;
+      x_end = x_start + _local_num_x;
       y_start = _accumulate_lmy[_domain_communicator->_domain_idx_y];
-      y_end = y_start + _local_num_yn;
+      y_end = y_start + _local_num_y;
       z_start = _accumulate_lmz[_domain_communicator->_domain_idx_z];
-      z_end = z_start + _local_num_zn;
+      z_end = z_start + _local_num_z;
     }
   }
 
@@ -4568,8 +4554,8 @@ int Cmfd::getLocalCMFDCell(int cmfd_cell) {
       iz < z_start || iz >= z_end)
     local_cmfd_cell = -1;
   else
-    local_cmfd_cell = ((iz - z_start) * _local_num_yn + iy - y_start)
-                      * _local_num_xn + ix - x_start;
+    local_cmfd_cell = ((iz - z_start) * _local_num_y + iy - y_start)
+                      * _local_num_x + ix - x_start;
   return local_cmfd_cell;
 }
 
@@ -4592,9 +4578,9 @@ int Cmfd::getGlobalCMFDCell(int cmfd_cell) {
     }
   }
 
-  int ix = cmfd_cell % _local_num_xn;
-  int iy = (cmfd_cell % (_local_num_xn * _local_num_yn)) / _local_num_xn;
-  int iz = cmfd_cell / (_local_num_xn * _local_num_yn);
+  int ix = cmfd_cell % _local_num_x;
+  int iy = (cmfd_cell % (_local_num_x * _local_num_y)) / _local_num_x;
+  int iz = cmfd_cell / (_local_num_x * _local_num_y);
 
   return ((iz + z_start) * _num_y + iy + y_start) * _num_x
                 + ix + x_start;
@@ -4749,7 +4735,7 @@ void Cmfd::printProlongationFactors(int iteration) {
     double log_ratios[_num_x * _num_y * _num_z];
     for (int i = 0; i < _num_x * _num_y * _num_z; i++)
       log_ratios[i] = 0.0;
-    for (int i = 0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++) {
+    for (int i = 0; i < _local_num_x * _local_num_y * _local_num_z; i++) {
 
       double old_flux = _old_flux->getValue(i, e);
       double new_flux = _new_flux->getValue(i, e);
@@ -4842,14 +4828,14 @@ void Cmfd::tallyStartingCurrent(Point* point, double delta_x, double delta_y,
   if (cell == -1)
     log_printf(ERROR, "Failed to find starting CMFD cell for track start "
                "point");
-  int cell_x = cell % _local_num_xn;
-  int cell_y = (cell % (_local_num_xn * _local_num_yn)) / _local_num_xn;
-  int cell_z = cell / (_local_num_xn * _local_num_yn);
+  int cell_x = cell % _local_num_x;
+  int cell_y = (cell % (_local_num_x * _local_num_y)) / _local_num_x;
+  int cell_z = cell / (_local_num_x * _local_num_y);
   int bounds[3];
-  bool singular[3] = {_local_num_xn == 1, _local_num_yn == 1, _local_num_zn == 1};
-  bounds[0] = -1 * (cell_x == 0) + (cell_x == _local_num_xn-1);
-  bounds[1] = -1 * (cell_y == 0) + (cell_y == _local_num_yn-1);
-  bounds[2] = -1 * (cell_z == 0) + (cell_z == _local_num_zn-1);
+  bool singular[3] = {_local_num_x == 1, _local_num_y == 1, _local_num_z == 1};
+  bounds[0] = -1 * (cell_x == 0) + (cell_x == _local_num_x-1);
+  bounds[1] = -1 * (cell_y == 0) + (cell_y == _local_num_y-1);
+  bounds[2] = -1 * (cell_z == 0) + (cell_z == _local_num_z-1);
   if ((bounds[0] == 0 && !singular[0]) && (bounds[1] == 0 && !singular[1]) &&
       (bounds[2] == 0 && !singular[2]))
     log_printf(ERROR, "Track start point not on a boundary CMFD cell. "
@@ -4873,7 +4859,6 @@ void Cmfd::tallyStartingCurrent(Point* point, double delta_x, double delta_y,
     currents[cmfd_group] += track_flux[e] * weight;
   }
 
-
   /* Tally starting currents to cell */
   _starting_currents->incrementValues(cell, 0, _num_cmfd_groups - 1, currents);
 
@@ -4886,7 +4871,7 @@ void Cmfd::tallyStartingCurrent(Point* point, double delta_x, double delta_y,
 void Cmfd::recordNetCurrents() {
 
 #pragma omp parallel for
-  for (int i=0; i < _local_num_xn * _local_num_yn * _local_num_zn; i++) {
+  for (int i=0; i < _local_num_x * _local_num_y * _local_num_z; i++) {
 
     for (int e=0; e < _num_cmfd_groups; e++)
       _net_currents->incrementValue(i, e,
@@ -4894,9 +4879,9 @@ void Cmfd::recordNetCurrents() {
 
     /* Compute cell indexes */
     int cell_ind[3];
-    cell_ind[0] = i % _local_num_xn;
-    cell_ind[1] = (i / _local_num_xn) % _local_num_yn;
-    cell_ind[2] = i / (_local_num_xn * _local_num_yn);
+    cell_ind[0] = i % _local_num_x;
+    cell_ind[1] = (i / _local_num_x) % _local_num_y;
+    cell_ind[2] = i / (_local_num_x * _local_num_y);
 
     /* Tally current from all surfaces including edges and corners */
     for (int s=0; s < NUM_SURFACES; s++) {
@@ -4920,11 +4905,11 @@ void Cmfd::recordNetCurrents() {
       for (int d=0; d < 3; d++)
         cell_next_ind[d] = cell_ind[d] + direction[d];
 
-      cmfd_cell_next = cell_next_ind[0] + cell_next_ind[1] * _local_num_xn
-                     + cell_next_ind[2] * (_local_num_xn * _local_num_yn);
-      if (cell_next_ind[0] < 0 || cell_next_ind[0] >= _local_num_xn ||
-          cell_next_ind[1] < 0 || cell_next_ind[1] >= _local_num_yn ||
-          cell_next_ind[2] < 0 || cell_next_ind[2] >= _local_num_zn)
+      cmfd_cell_next = cell_next_ind[0] + cell_next_ind[1] * _local_num_x
+                     + cell_next_ind[2] * (_local_num_x * _local_num_y);
+      if (cell_next_ind[0] < 0 || cell_next_ind[0] >= _local_num_x ||
+          cell_next_ind[1] < 0 || cell_next_ind[1] >= _local_num_y ||
+          cell_next_ind[2] < 0 || cell_next_ind[2] >= _local_num_z)
         cmfd_cell_next = -1;
 
       /* Tally net currents */
@@ -4976,8 +4961,8 @@ void Cmfd::setWidths(std::vector< std::vector<double> > widths) {
     _cell_widths_z = widths[2];
   else if(widths.size() == 2)
     _cell_widths_z.push_back(1.0);
-  else  
-    log_printf(ERROR, "widths must have dimension 2 or 3");
+  else
+    log_printf(ERROR, "CMFD lattice widths must have dimension 2 or 3.");
 
   _non_uniform = true;
   _cell_widths_x = widths[0];
@@ -4986,7 +4971,8 @@ void Cmfd::setWidths(std::vector< std::vector<double> > widths) {
 
 
 /**
- * @brief For debug use.
+ * @brief Print information about CMFD cell dimensions.
+ * @details For debug use.
  */
 void Cmfd::printCmfdCellSizes() {
   int i;

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -514,8 +514,8 @@ void Cmfd::collapseXS() {
     FP_PRECISION* scat;
 
     /* Allocate arrays for tallies on the stack */
-    double scat_tally[_num_cmfd_groups] = {0.0};
-    double chi_tally[_num_cmfd_groups] = {0.0};
+    double scat_tally[_num_cmfd_groups];
+    double chi_tally[_num_cmfd_groups];
 
     /* Pointers to material objects */
     Material* fsr_material;
@@ -3822,25 +3822,25 @@ void Cmfd::printTimerReport() {
 
   /* Get the total CMFD time */
   double tot_time = _timer->getSplit("Total CMFD time");
-  msg_string = "Total CMFD computation time";
+  msg_string = "  Total CMFD computation time";
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), tot_time);
 
   /* Get the total XS collapse time */
   double xs_collapse_time = _timer->getSplit("Total collapse time");
-  msg_string = "  XS collapse time";
+  msg_string = "    XS collapse time";
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), xs_collapse_time);
 
   /* Get the MPI communication time */
   double comm_time = _timer->getSplit("CMFD MPI communication time");
-  msg_string = "  MPI communication time";
+  msg_string = "    MPI communication time";
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), comm_time);
 
   /* Get the total solver time */
   double solver_time = _timer->getSplit("Total solver time");
-  msg_string = "  Total CMFD solver time";
+  msg_string = "    Total CMFD solver time";
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), solver_time);
 }
@@ -4302,28 +4302,7 @@ void Cmfd::ghostCellExchange() {
   }
 
   // Block for communication round to complete
-  bool round_complete = false;
-  while (!round_complete) {
-
-    round_complete = true;
-    int flag;
-    MPI_Status send_stat;
-    MPI_Status recv_stat;
-
-    for (int coord=0; coord < 3; coord++) {
-      for (int d=0; d<2; d++) {
-        int surf = coord + 3*d;
-
-        MPI_Test(&requests[2*surf], &flag, &send_stat);
-        if (flag == 0)
-          round_complete = false;
-
-        MPI_Test(&requests[2*surf+1], &flag, &recv_stat);
-        if (flag == 0)
-          round_complete = false;
-      }
-    }
-  }
+  MPI_Waitall(12, requests, MPI_STATUSES_IGNORE);
 }
 
 

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -90,11 +90,11 @@ private:
   /* A tally buffer for threads to tally temporary surface currents */
   CMFD_PRECISION** _temporary_currents;
 
-  /** Vector representing the flux for each cmfd cell and cmfd enegy group at
+  /** Vector representing the flux for each cmfd cell and cmfd energy group at
    * the end of a CMFD solve */
   Vector* _new_flux;
 
-  /** Vector representing the flux for each cmfd cell and cmfd enegy group at
+  /** Vector representing the flux for each cmfd cell and cmfd energy group at
    * the beginning of a CMFD solve */
   Vector* _old_flux;
 
@@ -191,20 +191,20 @@ private:
   double _cell_width_x;
   double _cell_width_y;
   double _cell_width_z;
-  
+
   /** Physical dimensions of non-uniform CMFD meshes (for whole geometry) */
   std::vector<double> _cell_widths_x;
   std::vector<double> _cell_widths_y;
   std::vector<double> _cell_widths_z;
-  
+
   /** Distance of each mesh from the left-lower-bottom most point */
   std::vector<double> _accumulate_x;
   std::vector<double> _accumulate_y;
   std::vector<double> _accumulate_z;
-  
+
   /** True if the cmfd meshes are non-uniform */
   bool _non_uniform;
-  
+
   /** Array of geometry boundaries */
   boundaryType* _boundaries;
 
@@ -246,7 +246,7 @@ private:
   double _relaxation_factor;
 
   /** Map storing the k-nearest stencil for each fsr */
-  std::map<int, std::vector< std::pair<int, double> > >
+  std::map<long, std::vector< std::pair<int, double> > >
     _k_nearest_stencils;
 
   /** OpenMP mutual exclusion locks for atomic CMFD cell operations */
@@ -272,22 +272,22 @@ private:
 
   /* Structure to contain information about the convergence of the CMFD */
   ConvergenceData* _convergence_data;
-  
+
   /* MPI communicator to transfer buffers, mainly currents at interfaces */
   DomainCommunicator* _domain_communicator;
-  
+
   /* Buffer to contain received data */
   CMFD_PRECISION* _inter_domain_data;
-  
+
   /* Buffer to contain sent data from domain */
   CMFD_PRECISION* _send_domain_data;
-  
+ 
   /* For each face (1st dimension of the array), will contain data received */
   CMFD_PRECISION** _domain_data_by_surface;
 
   /* For each face (1st dimension of the array), will contain data to send */
   CMFD_PRECISION** _send_data_by_surface;
-  
+
   /* Map of the indexes to each boundary in the tally arrays */
   std::vector<std::map<int, int> > _boundary_index_map;
 
@@ -299,34 +299,29 @@ private:
 
   /* The number of on-domain cells in the z-direction */
   int _local_num_z;
-  
+
   std::vector<int> _accumulate_lmx;
   std::vector<int> _accumulate_lmy;
   std::vector<int> _accumulate_lmz;
-  
-  //for substitution of _local_num_x, _local_num_y, _local_num_y, checking the 
-  //code is completely and fully changed to non-uniform version. Cuz 
-  //_local_num_x, _local_num_y, _local_num_y is used too much in the code.
-  int _local_num_xn, _local_num_yn, _local_num_zn;
 
   /* Size of _tally_memory array */
   long _total_tally_size;
-  
+
   /* 1D array that contains all tallies (diffusion, reaction and volume) */
   CMFD_PRECISION* _tally_memory;
-  
+
   /* 2D array that contains reaction rates in each cell and group */
   CMFD_PRECISION** _reaction_tally;
 
   /* 2D array that contains volume tallies of each cell */
   CMFD_PRECISION** _volume_tally;
-  
+
   /* 2D array that contains diffusion tallies for each cell and groups */
   CMFD_PRECISION** _diffusion_tally;
-  
+
   /* Boolean to check if tallies are allocated */
   bool _tallies_allocated;
-  
+
   /* Boolean to check if the domain communicator (for domain decomposed CMFD)
    * has been allocated */
   bool _domain_communicator_allocated;
@@ -360,8 +355,8 @@ private:
   int getCellNext(int cell_id, int surface_id, bool global=true,
                   bool neighbor=false);
   int getCellByStencil(int cell_id, int stencil_id);
-  CMFD_PRECISION getFluxRatio(int cell_id, int group, int fsr);
-  CMFD_PRECISION getUpdateRatio(int cell_id, int moc_group, int fsr);
+  CMFD_PRECISION getFluxRatio(int cell_id, int group, long fsr);
+  CMFD_PRECISION getUpdateRatio(int cell_id, int moc_group, long fsr);
   double getDistanceToCentroid(Point* centroid, int cell_id,
                                      int stencil_index);
   void getSurfaceDiffusionCoefficient(int cmfd_cell, int surface,
@@ -463,7 +458,7 @@ public:
 #endif
   void setConvergenceData(ConvergenceData* convergence_data);
   void useAxialInterpolation(int interpolate);
-  
+
   /* Methods to try to fix stability issues */
   void useFluxLimiting(bool flux_limiting);
   void enforceBalanceOnDiagonal(int cmfd_cell, int group);
@@ -476,10 +471,10 @@ public:
   void setFSRSources(FP_PRECISION* sources);
   void setCellFSRs(std::vector< std::vector<long> >* cell_fsrs);
   void setFluxMoments(FP_PRECISION* flux_moments);
-  
+
   /* Set XYZ widths of non-uniform meshes */
   void setWidths(std::vector< std::vector<double> > widths);
-  
+
   /* For debug use */
   void printCmfdCellSizes();
 };
@@ -495,7 +490,7 @@ inline int Cmfd::getCmfdGroup(int group) {
 }
 
 
-/*
+/**
  * @brief Quickly finds a 3D CMFD surface given a cell, global coordinate, and
  *        2D CMFD surface. Intended for use in axial on-the-fly ray tracing.
  * @details If the coords is not on a surface, -1 is returned. If there is

--- a/src/ExpEvaluator.cpp
+++ b/src/ExpEvaluator.cpp
@@ -34,8 +34,8 @@ ExpEvaluator::~ExpEvaluator() {
 
 
 /**
- * @brief Set the PolarQuad to use when computing exponentials.
- * @param polar_quad a PolarQuad object pointer
+ * @brief Set the Quadrature to use when computing exponentials.
+ * @param polar_quad a Quadrature object pointer
  */
 void ExpEvaluator::setQuadrature(Quadrature* quadrature) {
   _quadrature = quadrature;
@@ -173,6 +173,9 @@ FP_PRECISION* ExpEvaluator::getExpTable() {
 
 /**
  * @brief If using linear interpolation, builds the table for each polar angle.
+ * @param azim_index the azimuthal index to get the adjusted polar angle in 3D
+ * @param polar_index the polar angle index
+ * @param solve_3D whether the geometry is 3D or not
  */
 void ExpEvaluator::initialize(int azim_index, int polar_index, bool solve_3D) {
 
@@ -295,7 +298,7 @@ void ExpEvaluator::initialize(int azim_index, int polar_index, bool solve_3D) {
         exp_const_3 = 0.5 / (tau_a * tau_a * tau_a) *
             (2.0 - exponential * (tau_m * tau_m + 2.0 * tau_m + 2.0));
       }
-      
+
       _exp_table[index] = exp_const_1;
       _exp_table[index+1] = exp_const_2;
       _exp_table[index+2] = exp_const_3;
@@ -315,7 +318,7 @@ void ExpEvaluator::initialize(int azim_index, int polar_index, bool solve_3D) {
           exp_const_3 = 0.5 * (2.0 * tau_m - 12.0 + exponential * (12.0 +
               tau_m * (10.0 + tau_m * (4.0 + tau_m)))) / (tau_a_2 * tau_a_2);
         }
-        
+
         _exp_table[index+3] = exp_const_1;
         _exp_table[index+4] = exp_const_2;
         _exp_table[index+5] = exp_const_3;

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -2766,11 +2766,11 @@ std::vector<long> Geometry::getSpatialDataOnGrid(std::vector<double> dim1,
 
       /* Find the Cell containing this point */
       if (strcmp(plane, "xy") == 0)
-        point = new LocalCoords(dim1[i], dim2[j], offset, false);
+        point = new LocalCoords(dim1[i], dim2[j], offset, true);
       else if (strcmp(plane, "xz") == 0)
-        point = new LocalCoords(dim1[i], offset, dim2[j], false);
+        point = new LocalCoords(dim1[i], offset, dim2[j], true);
       else if (strcmp(plane, "yz") == 0)
-        point = new LocalCoords(offset, dim1[i], dim2[j], false); 
+        point = new LocalCoords(offset, dim1[i], dim2[j], true); 
       else
         log_printf(ERROR, "Unable to extract spatial data for "
                           "unsupported plane %s", plane);
@@ -2794,6 +2794,7 @@ std::vector<long> Geometry::getSpatialDataOnGrid(std::vector<double> dim1,
       }
 
       /* Deallocate memory for LocalCoords */
+      point = point->getHighestLevel();
       delete point;
     }
   }

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -240,9 +240,9 @@ double Geometry::getMaxZ() {
 
 
 /**
- * @brief Returns the boundary conditions (REFLECTIVE or VACUUM) at the
- *        minimum x-coordinate in the Geometry.
- * @return the boundary conditions for the minimum x-coordinate in the Geometry
+ * @brief Returns the boundary conditions at the minimum x-coordinate in the 
+ *        Geometry / domain if the geometry is domain-decomposed.
+ * @return the boundary conditions for the minimum x-coordinate in the domain
  */
 boundaryType Geometry::getMinXBoundaryType() {
   if (_domain_decomposed && _domain_index_x > 0)
@@ -253,9 +253,9 @@ boundaryType Geometry::getMinXBoundaryType() {
 
 
 /**
- * @brief Returns the boundary conditions (REFLECTIVE or VACUUM) at the
- *        maximum x-coordinate in the Geometry.
- * @return the boundary conditions for the maximum z-coordinate in the Geometry
+ * @brief Returns the boundary conditions at the maximum x-coordinate in the 
+ *        Geometry / domain if the geometry is domain-decomposed.
+ * @return the boundary conditions for the maximum x-coordinate in the domain
  */
 boundaryType Geometry::getMaxXBoundaryType() {
   if (_domain_decomposed && _domain_index_x < _num_domains_x-1)
@@ -266,9 +266,9 @@ boundaryType Geometry::getMaxXBoundaryType() {
 
 
 /**
- * @brief Returns the boundary conditions (REFLECTIVE or VACUUM) at the
- *        minimum y-coordinate in the Geometry.
- * @return the boundary conditions for the minimum y-coordinate in the Geometry
+ * @brief Returns the boundary conditions at the minimum y-coordinate in the 
+ *        Geometry / domain if the geometry is domain-decomposed.
+ * @return the boundary conditions for the minimum y-coordinate in the domain
  */
 boundaryType Geometry::getMinYBoundaryType() {
   if (_domain_decomposed && _domain_index_y > 0)
@@ -279,9 +279,9 @@ boundaryType Geometry::getMinYBoundaryType() {
 
 
 /**
- * @brief Returns the boundary conditions (REFLECTIVE or VACUUM) at the
- *        maximum y-coordinate in the Geometry.
- * @return the boundary conditions for the maximum y-coordinate in the Geometry
+ * @brief Returns the boundary conditions at the maximum y-coordinate in the 
+ *        Geometry / domain if the geometry is domain-decomposed.
+ * @return the boundary conditions for the maximum y-coordinate in the domain
  */
 boundaryType Geometry::getMaxYBoundaryType() {
   if (_domain_decomposed && _domain_index_y < _num_domains_y-1)
@@ -292,9 +292,9 @@ boundaryType Geometry::getMaxYBoundaryType() {
 
 
 /**
- * @brief Returns the boundary conditions (REFLECTIVE or VACUUM) at the
- *        minimum z-coordinate in the Geometry.
- * @return the boundary conditions for the minimum z-coordinate in the Geometry
+ * @brief Returns the boundary conditions at the minimum z-coordinate in the 
+ *        Geometry / domain if the geometry is domain-decomposed.
+ * @return the boundary conditions for the minimum z-coordinate in the domain
  */
 boundaryType Geometry::getMinZBoundaryType() {
   if (_domain_decomposed && _domain_index_z > 0)
@@ -305,9 +305,9 @@ boundaryType Geometry::getMinZBoundaryType() {
 
 
 /**
- * @brief Returns the boundary conditions (REFLECTIVE or VACUUM) at the
- *        maximum z-coordinate in the Geometry.
- * @return the boundary conditions for the maximum z-coordinate in the Geometry
+ * @brief Returns the boundary conditions at the maximum z-coordinate in the 
+ *        Geometry / domain if the geometry is domain-decomposed.
+ * @return the boundary conditions for the maximum z-coordinate in the domain
  */
 boundaryType Geometry::getMaxZBoundaryType() {
   if (_domain_decomposed && _domain_index_z < _num_domains_z-1)
@@ -318,7 +318,7 @@ boundaryType Geometry::getMaxZBoundaryType() {
 
 
 /**
- * @brief Returns the number of flat source regions in the Geometry domain.
+ * @brief Returns the number of source regions in the Geometry domain.
  * @return number of FSRs
  */
 long Geometry::getNumFSRs() {
@@ -327,7 +327,7 @@ long Geometry::getNumFSRs() {
 
 
 /**
- * @brief Returns the number of flat source regions in the entire Geometry.
+ * @brief Returns the number of source regions in the entire Geometry.
  * @return number of FSRs
  */
 long Geometry::getNumTotalFSRs() {
@@ -416,6 +416,7 @@ std::map<int, Surface*> Geometry::getAllSurfaces() {
   std::map<int, Cell*>::iterator c_iter;
   std::map<int, Halfspace*>::iterator s_iter;
 
+  /* Gather all surfaces from all cells */
   if (_root_universe != NULL) {
     std::map<int, Cell*> all_cells = getAllCells();
 
@@ -445,6 +446,7 @@ std::map<int, Material*> Geometry::getAllMaterials() {
   Cell* cell;
   Material* material;
 
+  /* Gather all materials from all cells */
   if (_root_universe != NULL) {
     std::map<int, Cell*> all_cells = _root_universe->getAllCells();
     std::map<int, Cell*>::iterator iter;
@@ -466,7 +468,7 @@ std::map<int, Material*> Geometry::getAllMaterials() {
 
 
 /**
- * @brief Modify scattering and total cross sections to study MOC stability
+ * @brief Modify scattering and total cross sections to study MOC stability.
  */
 void Geometry::manipulateXS() {
 
@@ -482,12 +484,18 @@ void Geometry::manipulateXS() {
       int ng = mat->getNumEnergyGroups();
       for (int g=0; g < ng; g++) {
         double sigma_t = mat->getSigmaTByGroup(g+1);
+
+        /* Set all negative scatter cross sections to 0 */
         for (int gp=0; gp < ng; gp++)
           if (mat->getSigmaSByGroup(g+1, gp+1) < 0)
             mat->setSigmaSByGroup(0.0, g+1, gp+1);
+
+        /* Gather all non-negative scattering terms */
         double sigma_s = 0.0;
         for (int gp=0; gp < ng; gp++)
           sigma_s += mat->getSigmaSByGroup(g+1, gp+1);
+
+        /* Fudge */
         sigma_s *= 1.1;
         if (sigma_s > sigma_t)
           mat->setSigmaTByGroup(sigma_s, g+1);
@@ -539,7 +547,7 @@ std::map<int, Cell*> Geometry::getAllMaterialCells() {
 
 
 /**
- * @brief Return a std::map container of Universe IDs (keys) with Unierses
+ * @brief Return a std::map container of Universe IDs (keys) with Universes
  *        pointers (values).
  * @return a std::map of Universes indexed by Universe ID in the geometry
  */
@@ -573,7 +581,7 @@ Cmfd* Geometry::getCmfd() {
 
 
 /**
- * @breif Returns whether the Geometry is domain decomposed
+ * @brief Returns whether the Geometry is domain decomposed
  * @return If the domain is decomposed (true) or not (false)
  */
 bool Geometry::isDomainDecomposed() {
@@ -630,14 +638,29 @@ void Geometry::setNumDomainModules(int num_x, int num_y, int num_z) {
   _num_modules_z = num_z;
 }
 
+
+/**
+ * @brief Get the number of modular domains in the x-direction per MPI domain
+ * @return _num_modules_x number of modular domains in the x-direction in domain
+ */
 int Geometry::getNumXModules() {
   return _num_modules_x;
 }
 
+
+/**
+ * @brief Get the number of modular domains in the y-direction per MPI domain
+ * @return _num_modules_y number of modular domains in the y-direction in domain
+ */
 int Geometry::getNumYModules() {
   return _num_modules_y;
 }
 
+
+/**
+ * @brief Get the number of modular domains in the z-direction per MPI domain
+ * @return _num_modules_z number of modular domains in the z-direction in domain
+ */
 int Geometry::getNumZModules() {
   return _num_modules_z;
 }
@@ -727,7 +750,7 @@ MPI_Comm Geometry::getMPICart() {
 
 
 /**
- * @breif Returns the rank of the specified neighboring domain
+ * @brief Returns the rank of the specified neighboring domain.
  * @param offset_x The shift in the x-direction (number of domains)
  * @param offset_y The shift in the y-direction (number of domains)
  * @param offset_z The shift in the z-direction (number of domains)
@@ -819,7 +842,7 @@ void Geometry::setOverlaidMesh(double axial_mesh_height, int num_x, int num_y,
   offset.setY(min_y + (max_y - min_y)/2.0);
   offset.setZ(min_z + (max_z - min_z)/2.0);
   _overlaid_mesh->setOffset(offset.getX(), offset.getY(), offset.getZ());
-  
+
   _overlaid_mesh->computeSizes();
 
   log_printf(NORMAL, "Set global axial mesh of width %6.4f cm",
@@ -1210,7 +1233,7 @@ long Geometry::getFSRId(LocalCoords* coords, bool err_check) {
 
 
 /**
- * @brief Returns the rank of the domain containing the given coordinates
+ * @brief Returns the rank of the domain containing the given coordinates.
  * @param coords The coordinates used to search the domain rank
  * @return The rank of the domain containing the coordinates
  */
@@ -1276,7 +1299,7 @@ long Geometry::getGlobalFSRId(LocalCoords* coords, bool err_check) {
 
 
 /**
- * @brief Return the characteristic point for a given FSR ID
+ * @brief Return the characteristic point for a given FSR ID.
  * @param fsr_id the FSR ID
  * @return the FSR's characteristic point
  */
@@ -1297,7 +1320,7 @@ Point* Geometry::getFSRPoint(long fsr_id) {
 
 
 /**
- * @brief Return the centroid for a given FSR ID
+ * @brief Return the centroid for a given FSR ID.
  * @param fsr_id the FSR ID
  * @return the FSR's centroid
  */
@@ -1341,7 +1364,7 @@ void Geometry::countDomainFSRs() {
 
 
 /**
- * @brief Finds the local FSR ID and domain rank from a global FSR ID
+ * @brief Finds the local FSR ID and domain rank from a global FSR ID.
  * @param global_fsr_id The global unique identifier of an FSR
  * @param local_fsr_id The unique identifier of an FSR on its current domain
  * @param domain The rank of the domain containing the FSR
@@ -1378,9 +1401,9 @@ void Geometry::getLocalFSRId(long global_fsr_id, long &local_fsr_id,
 
 
 /**
- * @brief Returns the FSR centroid of a global FSR
+ * @brief Returns the FSR centroid of a global FSR.
  * @param global_fsr_id The global unique identifier of the FSR
- * @return A vector contianing the coordinates of the FSR centroid
+ * @return A vector containing the coordinates of the FSR centroid
  */
 std::vector<double> Geometry::getGlobalFSRCentroidData(long global_fsr_id) {
   double xyz[3];
@@ -1439,7 +1462,7 @@ int Geometry::getCmfdCell(long fsr_id) {
 
 /**
  * @brief reserves the FSR key strings
- * @param the number of threads
+ * @param num_threads the number of threads
  */
 void Geometry::reserveKeyStrings(int num_threads) {
   int string_size = 255;
@@ -1746,7 +1769,7 @@ ExtrudedFSR* Geometry::getExtrudedFSR(int extruded_fsr_id) {
 
 
 /**
- * @brief Subidivides all Cells in the Geometry into rings and angular sectors
+ * @brief Subdivides all Cells in the Geometry into rings and angular sectors
  *        aligned with the z-axis.
  * @details This method is called by the Geometry::initializeFlatSourceRegions()
  *          method but may also be called by the user in Python if needed:
@@ -2127,7 +2150,7 @@ void Geometry::segmentize3D(Track3D* track, bool setup) {
  * @brief This method performs ray tracing to create extruded track segments
  *        within each flat source region in the implicit 2D superposition plane
  *        of the Geometry by 2D ray tracing across input heights that encompass
- *        all radial geometric detail.
+ *        all radial geometric details.
  * @details This method starts at the beginning of an extruded track and finds
  *          successive intersection points with FSRs as the extruded track
  *          crosses radially through the Geometry at defined z-coords. The
@@ -2375,7 +2398,7 @@ void Geometry::segmentizeExtruded(Track* flattened_track,
 
 
 /**
- * @brief Fixes the FSR map size so that the map is static and fast
+ * @brief Fixes the FSR map size so that the map is static and fast.
  */
 void Geometry::fixFSRMaps() {
   _FSR_keys_map.setFixedSize();
@@ -2385,7 +2408,7 @@ void Geometry::fixFSRMaps() {
 
 /**
  * @brief Rays are shot vertically through each ExtrudedFSR struct to calculate
- *        the axial mesh and initialize 3D FSRs
+ *        the axial mesh and initialize 3D FSRs.
  * @details From a 2D point within each FSR, a temporary 3D track is created
  *          starting at the bottom of the geometry and extending vertically to
  *          the top of the geometry. These tracks are segmented using the
@@ -2506,7 +2529,7 @@ void Geometry::initializeAxialFSRs(std::vector<double> global_z_mesh) {
 
 
 /**
- * @brief Reorders FSRs so that they are contiguous in the axial direction
+ * @brief Reorders FSRs so that they are contiguous in the axial direction.
  */
 void Geometry::reorderFSRIDs() {
 
@@ -2569,8 +2592,8 @@ void Geometry::reorderFSRIDs() {
 
 
 /**
- * @brief Initialize key and material ID vectors for lookup by FSR ID
- * @detail This function initializes and sets reverse lookup vectors by FSR ID.
+ * @brief Initialize key and material ID vectors for lookup by FSR ID.
+ * @details This function initializes and sets reverse lookup vectors by FSR ID.
  *      This is called after the FSRs have all been identified and allocated
  *      during segmentation. This function must be called after
  *      Geometry::segmentize() has completed. It should not be called if tracks
@@ -2731,15 +2754,16 @@ std::vector<long> Geometry::getSpatialDataOnGrid(std::vector<double> dim1,
                         const char* plane,
                         const char* domain_type) {
 
-  Cell* cell;
-  LocalCoords* point;
-
   /* Instantiate a vector to hold the domain IDs */
   std::vector<long> domains(dim1.size() * dim2.size());
 
   /* Extract the source region IDs */
-//#pragma omp parallel for private(point, cell)
+#pragma omp parallel for
   for (int i=0; i < dim1.size(); i++) {
+
+    Cell* cell;
+    LocalCoords* point;
+
     for (int j=0; j < dim2.size(); j++) {
 
       /* Find the Cell containing this point */
@@ -2827,20 +2851,20 @@ void Geometry::printString() {
 
 /**
  * @brief Prints FSR layout to file
- * @description This provides a way to get the functionality of the 
+ * @details This provides a way to get the functionality of the 
  *              plot_flat_source_regions Python function without Python
- * @brief plane The "xy", "xz", or "yz" plane in which to extract flat source
+ * @param plane The "xy", "xz", or "yz" plane in which to extract flat source
  *        regions
- * @brief gridsize The number of points to plot in each direction
- * @brief offset The offset of the plane in the third dimension
- * @brief bounds_x a two valued array for the plotted x-limits
- * @brief bounds_y a two valued array for the plotted y-limits
- * @brief bounds_z a two valued array for the plotted z-limits
+ * @param gridsize The number of points to plot in each direction
+ * @param offset The offset of the plane in the third dimension
+ * @param bounds_x a two valued array for the plotted x-limits
+ * @param bounds_y a two valued array for the plotted y-limits
+ * @param bounds_z a two valued array for the plotted z-limits
  */
 void Geometry::printFSRsToFile(const char* plane, int gridsize, double offset,
                                double* bounds_x, double* bounds_y, 
                                double* bounds_z) {
-  
+
   /* Get geometry min and max */
   double min_x = _root_universe->getMinX();
   double max_x = _root_universe->getMaxX();
@@ -2930,7 +2954,6 @@ void Geometry::printFSRsToFile(const char* plane, int gridsize, double offset,
   delete [] reduced_fsr_array;
 #endif
 
-
   /* Print to file */
   log_printf(NORMAL, "Printing FSRs to file");
   if (isRootDomain()) {
@@ -3009,7 +3032,7 @@ void Geometry::initializeCmfd() {
 
 
 /**
- * @brief This is a method that initializes the initial spectrum calculator
+ * @brief This is a method that initializes the initial spectrum calculator.
  */
 void Geometry::initializeSpectrumCalculator(Cmfd* spectrum_calculator) {
 
@@ -3074,7 +3097,7 @@ void Geometry::initializeSpectrumCalculator(Cmfd* spectrum_calculator) {
 
 
 /**
- * @brief Returns a pointer to the map that maps FSR keys to FSR IDs
+ * @brief Returns a pointer to the map that maps FSR keys to FSR IDs.
  * @return pointer to _FSR_keys_map map of FSR keys to FSR IDs
  */
 ParallelHashMap<std::string, fsr_data*>& Geometry::getFSRKeysMap() {
@@ -3083,7 +3106,7 @@ ParallelHashMap<std::string, fsr_data*>& Geometry::getFSRKeysMap() {
 
 
 /**
- * @brief Returns a pointer to the map that maps FSR keys to extruded FSRs
+ * @brief Returns a pointer to the map that maps FSR keys to extruded FSRs.
  * @return pointer to _FSR_keys_map map of FSR keys to extruded FSRs
  */
 ParallelHashMap<std::string, ExtrudedFSR*>& Geometry::getExtrudedFSRKeysMap() {
@@ -3092,7 +3115,7 @@ ParallelHashMap<std::string, ExtrudedFSR*>& Geometry::getExtrudedFSRKeysMap() {
 
 
 /**
- * @brief Returns the vector that maps FSR IDs to FSR key hashes
+ * @brief Returns the vector that maps FSR IDs to FSR key hashes.
  * @return _FSR_keys_map map of FSR keys to FSR IDs
  */
 std::vector<std::string>& Geometry::getFSRsToKeys() {
@@ -3101,7 +3124,7 @@ std::vector<std::string>& Geometry::getFSRsToKeys() {
 
 
 /**
- * @brief Returns the vector that maps FSR IDs to extruded FSRs
+ * @brief Returns the vector that maps FSR IDs to extruded FSRs.
  * @return _extruded_FSR_lookup map of FSR keys to extruded FSRs
  */
 std::vector<ExtrudedFSR*>& Geometry::getExtrudedFSRLookup() {
@@ -3110,7 +3133,7 @@ std::vector<ExtrudedFSR*>& Geometry::getExtrudedFSRLookup() {
 
 
 /**
- * @brief Return a vector indexed by flat source region IDs which contains
+ * @brief Returns a vector indexed by flat source region IDs which contains
  *        the corresponding Material IDs.
  * @return an integer vector of FSR-to-Material IDs indexed by FSR ID
  */
@@ -3140,7 +3163,7 @@ std::vector<int>& Geometry::getFSRsToCMFDCells() {
 
 
 /**
- * @brief Determins whether a point is within the bounding box of the domain.
+ * @brief Determines whether a point is within the bounding box of the domain.
  * @param coords a populated LocalCoords linked list
  * @return boolean indicating whether the coords is within the domain
  */
@@ -3159,7 +3182,7 @@ bool Geometry::withinBounds(LocalCoords* coords) {
 
 
 /**
- * @brief Determins whether a point is within the bounding box of the Geometry.
+ * @brief Determines whether a point is within the bounding box of the Geometry.
  * @param coords a populated LocalCoords linked list
  * @return boolean indicating whether the coords is within the geometry
  */
@@ -3176,7 +3199,6 @@ bool Geometry::withinGlobalBounds(LocalCoords* coords) {
   else
     return true;
 }
-
 
 
 /**
@@ -3199,7 +3221,7 @@ Cell* Geometry::findCellContainingFSR(long fsr_id) {
 
 
 /**
- * @brief Sets the centroid for an FSR
+ * @brief Sets the centroid for an FSR.
  * @details The _FSR_keys_map stores a hash of a std::string representing
  *          the Lattice/Cell/Universe hierarchy for a unique region
  *          and the associated FSR data. _centroid is a point that represents
@@ -3219,16 +3241,16 @@ void Geometry::setFSRCentroid(long fsr, Point* centroid) {
 }
 
 
-/*
+/**
  * @brief Returns a vector of z-coords defining a superposition of all axial
  *        boundaries in the Geometry.
- * @param include_overlaid_mesh whether to include an overlaid mesh in the
- *        set of unique z-coords
  * @details The Geometry is traversed to retrieve all Z-planes and implicit
  *          z-boundaries, such as lattice boundaries. The levels of all these
  *          z-boundaries are rounded and added to a set containing no
  *          duplicates, creating a mesh.
- * @reutrn a vector of z-coords
+ * @param include_overlaid_mesh whether to include an overlaid mesh in the
+ *        set of unique z-coords
+ * @return a vector of z-coords
  */
 std::vector<double> Geometry::getUniqueZHeights(bool include_overlaid_mesh) {
 
@@ -3404,7 +3426,7 @@ std::vector<double> Geometry::getUniqueZHeights(bool include_overlaid_mesh) {
 
 /**
  * @brief Returns a vector of z-coords defining potential unique radial planes
- *        in the Geometry
+ *        in the Geometry.
  * @details The Geometry is traversed to retrieve all Z-planes and implicit
  *          z-boundaries, such as lattice boundaries. The mid points of this
  *          mesh are then used to construct a vector of all potential unique
@@ -3428,7 +3450,7 @@ std::vector<double> Geometry::getUniqueZPlanes() {
 
 
 /**
- * @brief Prints all Geoemetry and Material details to a Geometry restart file
+ * @brief Prints all Geometry and Material details to a Geometry restart file.
  * @param filename The name of the file where the data is printed
  * @param non_uniform_lattice Whether the non-uniform lattice is used to create 
  *        geometry This is to make the code compatible with old version of .geo 
@@ -3597,8 +3619,8 @@ void Geometry::dumpToFile(std::string filename, bool non_uniform_lattice) {
     int id = cell->getId();
     char* name = cell->getName();
     cellType ct = cell->getType();
-    
-    /* Print key and general surface information */
+
+    /* Print key and general cell information */
     fwrite(&key, sizeof(int), 1, out);
     fwrite(&id, sizeof(int), 1, out);
     if (strcmp(name, "") == 0) {
@@ -3612,6 +3634,7 @@ void Geometry::dumpToFile(std::string filename, bool non_uniform_lattice) {
     }
     fwrite(&ct, sizeof(cellType), 1, out);
 
+    /* Print cell fill information */
     if (ct == MATERIAL) {
       Material* mat = cell->getFillMaterial();
       int mat_id = mat->getId();
@@ -3679,7 +3702,7 @@ void Geometry::dumpToFile(std::string filename, bool non_uniform_lattice) {
       fwrite(&num_subnodes, sizeof(int), 1, out);
 
       if (region_type == HALFSPACE) {
-        int surface_id = 
+        int surface_id =
              static_cast<Halfspace*>(*node_iter)->getSurface()->getId();
         int halfspace = static_cast<Halfspace*>(*node_iter)->getHalfspace();
         fwrite(&surface_id, sizeof(int), 1, out);
@@ -3696,14 +3719,14 @@ void Geometry::dumpToFile(std::string filename, bool non_uniform_lattice) {
   for (univ_iter = all_universes.begin();
        univ_iter != all_universes.end(); ++univ_iter) {
 
-    /* Get key, value pair and general cell information */
+    /* Get key, value pair and general universe information */
     int key = univ_iter->first;
     Universe* universe = univ_iter->second;
     int id = universe->getId();
     char* name = universe->getName();
     universeType ut = universe->getType();
-    
-    /* Print key and general surface information */
+
+    /* Print key and general universe information */
     fwrite(&key, sizeof(int), 1, out);
     fwrite(&id, sizeof(int), 1, out);
     if (strcmp(name, "") == 0) {
@@ -3778,10 +3801,10 @@ void Geometry::dumpToFile(std::string filename, bool non_uniform_lattice) {
 
 
 /**
- * @brief Loads all Geoemetry and Material details from a Geometry restart file
+ * @brief Loads all Geometry and Material details from a Geometry restart file
  * @param filename The name of the file from which the data is loaded
- * @param twiddle Whether the bytes are inverted (BGQ) or not
  * @param non_uniform_lattice Option whether the .geo file in non-uniform format
+ * @param twiddle Whether the bytes are inverted (BGQ) or not
  */
 void Geometry::loadFromFile(std::string filename, bool non_uniform_lattice,
                             bool twiddle) {

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -2749,30 +2749,29 @@ void Geometry::computeFissionability(Universe* univ) {
  * @return a NumPy array or list of the domain IDs
  */
 std::vector<long> Geometry::getSpatialDataOnGrid(std::vector<double> dim1,
-                        std::vector<double> dim2,
-                        double offset,
-                        const char* plane,
-                        const char* domain_type) {
+                                                 std::vector<double> dim2,
+                                                 double offset,
+                                                 const char* plane,
+                                                 const char* domain_type) {
 
   /* Instantiate a vector to hold the domain IDs */
   std::vector<long> domains(dim1.size() * dim2.size());
 
   /* Extract the source region IDs */
-#pragma omp parallel for
+//#pragma omp parallel for
   for (int i=0; i < dim1.size(); i++) {
-
-    Cell* cell;
-    LocalCoords* point;
-
     for (int j=0; j < dim2.size(); j++) {
+
+      Cell* cell;
+      LocalCoords* point;
 
       /* Find the Cell containing this point */
       if (strcmp(plane, "xy") == 0)
-        point = new LocalCoords(dim1[i], dim2[j], offset, true);
+        point = new LocalCoords(dim1[i], dim2[j], offset, false);
       else if (strcmp(plane, "xz") == 0)
-        point = new LocalCoords(dim1[i], offset, dim2[j], true);
+        point = new LocalCoords(dim1[i], offset, dim2[j], false);
       else if (strcmp(plane, "yz") == 0)
-        point = new LocalCoords(offset, dim1[i], dim2[j], true); 
+        point = new LocalCoords(offset, dim1[i], dim2[j], false); 
       else
         log_printf(ERROR, "Unable to extract spatial data for "
                           "unsupported plane %s", plane);
@@ -2792,11 +2791,10 @@ std::vector<long> Geometry::getSpatialDataOnGrid(std::vector<double> dim1,
         else
           log_printf(ERROR, "Unable to extract spatial data for "
                             "unsupported domain type %s", domain_type);
+
       }
 
       /* Deallocate memory for LocalCoords */
-      point = point->getHighestLevel();
-      point->prune();
       delete point;
     }
   }

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -2615,8 +2615,7 @@ void Geometry::initializeFSRVectors() {
 
   /* Fill vectors key and material ID information */
   #pragma omp parallel for
-  for (long i=0; i < num_FSRs; i++)
-  {
+  for (long i=0; i < num_FSRs; i++) {
     std::string key = key_list[i];
     fsr_data* fsr = value_list[i];
     long fsr_id = fsr->_fsr_id;

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -162,26 +162,26 @@ private:
 
   /* A boolean to know whether geometry is domain decomposed or not */
   bool _domain_decomposed;
-  
+
   /* A boolean to know whether FSRs were counted */
   bool _domain_FSRs_counted;
-  
+
   /* Number of domains in the X, Y and Z directions */
   int _num_domains_x;
   int _num_domains_y;
   int _num_domains_z;
-  
+
   /* Index of the domain in the whole geometry in the X, Y and Z directions */
   int _domain_index_x;
   int _domain_index_y;
   int _domain_index_z;
-  
+
   /* Lattice object of size 1 that contains the local domain */
   Lattice* _domain_bounds;
-  
+
   /* Number of FSRs in each domain */
   std::vector<long> _num_domain_FSRs;
-  
+
 #ifdef MPIx
   /* MPI communicator, used to transfer information across domain for both 
    * ray-tracing and solving the MOC equations */
@@ -196,14 +196,14 @@ private:
 
   /* Wether to read bites backwards or forward (for BGQ) */
   bool _twiddle;
-  
+
   /* Whether the geometry was loaded from a .geo file or created in the input 
    * file. This matters for memory de-allocation purposes. */
   bool _loaded_from_file;
 
   /* Function to find the cell containing the coordinates */
   Cell* findFirstCell(LocalCoords* coords, double azim, double polar=M_PI_2);
-  
+
   /* Function to find the next cell, starting at some coordinate with a given
    * angle */
   Cell* findNextCell(LocalCoords* coords, double azim, double polar=M_PI_2);
@@ -254,7 +254,7 @@ public:
 
   /* Assign root universe to geometry */
   void setRootUniverse(Universe* root_universe);
-  
+
   /* Set up domain decomposition */
 #ifdef MPIx
   void setDomainDecomposition(int nx, int ny, int nz, MPI_Comm comm);

--- a/src/LocalCoords.cpp
+++ b/src/LocalCoords.cpp
@@ -172,7 +172,7 @@ LocalCoords* LocalCoords::getNext() const {
 
 /**
  * @brief Creates and returns a pointer to the next LocalCoords (nested 
- *        deeper)
+ *        deeper).
  * @param x the x-coordinate
  * @param y the y-coordinate
  * @param z the z-coordinate
@@ -206,7 +206,7 @@ LocalCoords* LocalCoords::getNextCreate(double x, double y, double z) {
 
 
 /**
- * @brief Returns the LocalCoords position in the _next_array
+ * @brief Returns the LocalCoords position in the _next_array.
  * @return The position of this object in the underlying _next_array
  */
 int LocalCoords::getPosition() {
@@ -215,7 +215,7 @@ int LocalCoords::getPosition() {
 
 
 /**
- * @brief Searches through the LocalCoords object to detect a loop
+ * @brief Searches through the LocalCoords object to detect a loop.
  * @details A loop is assumed if the LocalCoords apparent length is greater
  *          1000 members
  */
@@ -245,7 +245,7 @@ LocalCoords* LocalCoords::getPrev() const {
 
 
 /**
- * @brief Returns the version of the LocalCoords object
+ * @brief Returns the version of the LocalCoords object.
  * @details The version number differentiates otherwise matching FSR keys
  * @return The version number
  */
@@ -402,9 +402,9 @@ void LocalCoords::setArrayPosition(LocalCoords* array, int position,
 
 
 /**
- * @brief Setss the version of the LocalCoords object
+ * @brief Sets the version of the LocalCoords object.
  * @details The version number differentiates otherwise matching FSR keys
- * @param The version number
+ * @param version_num the version number
  */
 void LocalCoords::setVersionNum(int version_num) {
   _version_num = version_num;
@@ -507,7 +507,7 @@ void LocalCoords::updateMostLocal(Point* point) {
 
 /**
  * @brief Removes and frees memory for all LocalCoords beyond this one
- *        in the linked list
+ *        in the linked list.
  */
 void LocalCoords::prune() {
 
@@ -515,7 +515,7 @@ void LocalCoords::prune() {
   LocalCoords* next = curr->getPrev();
 
   /* Iterate over LocalCoords beneath this one in the linked list */
-  while (curr != this) {// it seems nothing has been down in this while loop
+  while (curr != this) {
     next = curr->getPrev();
     if (curr->getPosition() == -1)
       curr->deleteArray();
@@ -528,7 +528,7 @@ void LocalCoords::prune() {
 
 
 /**
- * @brief Deletes the underlying array for next coordinates
+ * @brief Deletes the underlying array for next coordinates.
  */
 void LocalCoords::deleteArray() {
   if (_next_array != NULL) {
@@ -540,7 +540,7 @@ void LocalCoords::deleteArray() {
 
 /**
  * @brief Copies a LocalCoords' values to this one.
- * details Given a pointer to a LocalCoords, it first prunes it and then creates
+ * @details Given a pointer to a LocalCoords, it first prunes it and then creates
  *         a copy of the linked list of LocalCoords in the linked list below
  *         this one to give to the input LocalCoords.
  * @param coords a pointer to the LocalCoords to give the linked list copy to

--- a/src/MOCKernel.cpp
+++ b/src/MOCKernel.cpp
@@ -19,7 +19,7 @@ MOCKernel::MOCKernel(TrackGenerator* track_generator, int row_num) {
 
 /**
  * @brief Constructor for the VolumeKernel assigns default values, calls
- *        the MOCKernel constructor, and pulls refernces to FSR locks and FSR
+ *        the MOCKernel constructor, and pulls references to FSR locks and FSR
  *        volumes from the provided TrackGenerator.
  * @param track_generator the TrackGenerator used to pull relevant tracking
  *        data from
@@ -64,7 +64,7 @@ SegmentationKernel::SegmentationKernel(TrackGenerator* track_generator,
 
 /**
  * @brief Constructor for the CounterKernel assigns default values and calls
- *        the MOCKernel constructor
+ *        the MOCKernel constructor.
  * @param track_generator the TrackGenerator used to pull relevant tracking
  *        data from
  * @param row_num the row index into the temporary segments matrix
@@ -74,7 +74,7 @@ CounterKernel::CounterKernel(TrackGenerator* track_generator, int row_num) :
 
 
 /**
- * @brief Prepares an MOCKernel for a new Track
+ * @brief Prepares an MOCKernel for a new Track.
  * @details Resets the segment count
  * @param track The new Track the MOCKernel prepares to handle
  */
@@ -84,7 +84,7 @@ void MOCKernel::newTrack(Track* track) {
 
 
 /**
- * @brief Prepares a VolumeKernel for a new Track
+ * @brief Prepares a VolumeKernel for a new Track.
  * @details Resets the segment count and updates the weight for the new Track
  * @param track The new Track the MOCKernel prepares to handle
  */
@@ -130,7 +130,7 @@ int MOCKernel::getCount() {
  * @brief Resets the maximum optcal path length for a segment.
  * @details MOC kernels ensure that there are no segments with an optical path
  *          length greater than the maximum optical path length by splitting
- *          then when they get too large.
+ *          them when they get too large.
  * @param the maximum optical path length for a segment
  */
 void MOCKernel::setMaxOpticalLength(FP_PRECISION max_tau) {
@@ -145,7 +145,7 @@ void MOCKernel::setMaxOpticalLength(FP_PRECISION max_tau) {
  *          id, referring to the array of FSR volumes.
  * @param length segment length
  * @param mat Material associated with the segment
- * @param id the FSR ID of the FSR associated with the segment
+ * @param fsr_id the FSR ID of the FSR associated with the segment
  */
 void VolumeKernel::execute(FP_PRECISION length, Material* mat, long fsr_id,
                            int track_idx, int cmfd_surface_fwd,
@@ -180,7 +180,7 @@ void VolumeKernel::execute(FP_PRECISION length, Material* mat, long fsr_id,
 
 
 /**
- * @brief Increments the counter for the number of segments on the track
+ * @brief Increments the counter for the number of segments on the track.
  * @details The CounterKernel execute function counts the number of segments
  *          in a track by incrementing the counter variable upon execution. Due
  *          to restrictions on maximum optical path length, the counter may be
@@ -188,7 +188,7 @@ void VolumeKernel::execute(FP_PRECISION length, Material* mat, long fsr_id,
  *          segment into segments of allowed optical path length.
  * @param length segment length
  * @param mat Material associated with the segment
- * @param id the FSR ID of the FSR associated with the segment
+ * @param fsr_id the FSR ID of the FSR associated with the segment
  */
 void CounterKernel::execute(FP_PRECISION length, Material* mat, long fsr_id,
                             int track_idx, int cmfd_surface_fwd,
@@ -214,7 +214,7 @@ void CounterKernel::execute(FP_PRECISION length, Material* mat, long fsr_id,
 
 
 /**
- * @brief Writes segment information to the segmentation data array
+ * @brief Writes segment information to the segmentation data array.
  * @details The SegmentationKernel execute function writes segment information
  *          to the segmentation data referenced by _segments. Due to
  *          restrictions on maximum optical path length, the counter may be
@@ -222,7 +222,17 @@ void CounterKernel::execute(FP_PRECISION length, Material* mat, long fsr_id,
  *          segment into segments of allowed optical path length.
  * @param length segment length
  * @param mat Material associated with the segment
- * @param id the FSR ID of the FSR associated with the segment
+ * @param fsr_id the FSR ID of the FSR associated with the segment
+ * @param track_idx the track index in stack
+ * @param cmfd_surface_fwd CMFD surface at the end of the segment in the forward 
+ *        direction
+ * @param cmfd_surface_bwd CMFD surface at the end of the segment in the 
+ *        backward direction
+ * @param x_start x coordinate of the start of the segment
+ * @param y_start y coordinate of the start of the segment
+ * @param z_start z coordinate of the start of the sement
+ * @param phi azimuthal angle of this segment
+ * @param theta polar angle of this segment
  */
 void SegmentationKernel::execute(FP_PRECISION length, Material* mat, long fsr_id,
                                 int track_idx, int cmfd_surface_fwd,
@@ -308,7 +318,7 @@ TransportKernel::~TransportKernel() {
 
 
 /**
- * @brief Sets a pointer to the CPUSolver to enable use of transport functions
+ * @brief Sets a pointer to the CPUSolver to enable use of transport functions.
  * @param cpu_solver pointer to the CPUSolver
  */
 void TransportKernel::setCPUSolver(CPUSolver* cpu_solver) {
@@ -317,9 +327,8 @@ void TransportKernel::setCPUSolver(CPUSolver* cpu_solver) {
 
 
 /**
- * @brief Sets the indexes of the current Track.
- * @param axim_index the Track's azimuthal index
- * @param polar_index the Track's polar index
+ * @brief Create a new track3D from an existing one.
+ * @param track track to create the new track from
  */
 //FIXME: delete?
 void TransportKernel::newTrack(Track* track) {

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -20,7 +20,7 @@ int material_id() {
 
 
 /**
- * @brief Resets the auto-generated unique Material ID counter to 10000.
+ * @brief Resets the auto-generated unique Material ID counter to 1000,000.
  */
 void reset_material_id() {
   auto_id = DEFAULT_INIT_ID;
@@ -139,7 +139,7 @@ Material::~Material() {
 
 
 /**
- * @brief Return the Material's user-defined ID
+ * @brief Return the Material's user-defined ID.
  * @return the Material's user-defined ID
  */
 int Material::getId() const {
@@ -148,7 +148,7 @@ int Material::getId() const {
 
 
 /**
- * @brief Return the user-defined name of the Material
+ * @brief Return the user-defined name of the Material.
  * @return the Material name
  */
 char* Material::getName() const {
@@ -229,6 +229,7 @@ FP_PRECISION* Material::getSigmaA() {
                _id);
   }
 
+  /* If not initialized, compute _sigma_a the absorption cross section */
   if (_sigma_a == NULL) {
     _sigma_a = new FP_PRECISION[_num_groups];
     for (int g=0; g < _num_groups; g++) {
@@ -549,18 +550,20 @@ void Material::setNumEnergyGroups(const int num_groups) {
   }
 
   /* Allocate memory for data arrays */
-  _sigma_t = (FP_PRECISION*) aligned_alloc(VEC_ALIGNMENT, _num_groups*sizeof(FP_PRECISION));
+  //FIXME If old GCC (<7), use MM_MALLOC instead
+  _sigma_t = (FP_PRECISION*) aligned_alloc(VEC_ALIGNMENT, 
+                                           _num_groups*sizeof(FP_PRECISION));
   _sigma_f = new FP_PRECISION[_num_groups];
   _nu_sigma_f = new FP_PRECISION[_num_groups];
   _chi = new FP_PRECISION[_num_groups];
   _sigma_s = new FP_PRECISION[_num_groups*_num_groups];
 
   /* Assign the null vector to each data array */
-  memset(_sigma_t, 0.0, sizeof(FP_PRECISION) * _num_groups);
-  memset(_sigma_f, 0.0, sizeof(FP_PRECISION) * _num_groups);
-  memset(_nu_sigma_f, 0.0, sizeof(FP_PRECISION) * _num_groups);
-  memset(_chi, 0.0, sizeof(FP_PRECISION) * _num_groups);
-  memset(_sigma_s, 0.0, sizeof(FP_PRECISION) * _num_groups * _num_groups);
+  memset(_sigma_t, 0, sizeof(FP_PRECISION) * _num_groups);
+  memset(_sigma_f, 0, sizeof(FP_PRECISION) * _num_groups);
+  memset(_nu_sigma_f, 0, sizeof(FP_PRECISION) * _num_groups);
+  memset(_chi, 0, sizeof(FP_PRECISION) * _num_groups);
+  memset(_sigma_s, 0, sizeof(FP_PRECISION) * _num_groups * _num_groups);
 }
 
 
@@ -696,9 +699,10 @@ void Material::setSigmaS(double* xs, int num_groups_squared) {
  */
 void Material::setSigmaSByGroup(double xs, int origin, int destination) {
 
-  if (origin <= 0 || destination <= 0 || origin > _num_groups || destination > _num_groups)
-    log_printf(ERROR, "Unable to set sigma_s for group %d -> %d for Material %d "
-               "which contains %d energy groups",
+  if (origin <= 0 || destination <= 0 || origin > _num_groups || 
+      destination > _num_groups)
+    log_printf(ERROR, "Unable to set sigma_s for group %d -> %d for Material %d"
+               " which contains %d energy groups",
                origin, destination, _id, _num_groups);
 
   _sigma_s[_num_groups*(destination-1) + (origin-1)] = xs;
@@ -728,7 +732,8 @@ void Material::setSigmaF(double* xs, int num_groups) {
 
   if (_num_groups != num_groups)
     log_printf(ERROR, "Unable to set sigma_f with %d groups for Material "
-               "%d which contains %d energy groups", num_groups, _id, _num_groups);
+               "%d which contains %d energy groups", num_groups, _id,
+               _num_groups);
 
   for (int i=0; i < _num_groups; i++)
     _sigma_f[i] = xs[i];
@@ -963,8 +968,8 @@ void Material::alignData() {
   }
 
   size *= _num_vector_groups * VEC_LENGTH;
-  memset(new_fiss_matrix, 0.0, size);
-  memset(new_sigma_s, 0.0, size);
+  memset(new_fiss_matrix, 0, size);
+  memset(new_sigma_s, 0, size);
 
   /* Copy materials data from unaligned arrays into new aligned arrays */
   size = _num_groups * sizeof(FP_PRECISION);

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -550,9 +550,14 @@ void Material::setNumEnergyGroups(const int num_groups) {
   }
 
   /* Allocate memory for data arrays */
-  //FIXME If old GCC (<7), use MM_MALLOC instead
-  _sigma_t = (FP_PRECISION*) aligned_alloc(VEC_ALIGNMENT, 
+  try {
+    _sigma_t = (FP_PRECISION*) aligned_alloc(VEC_ALIGNMENT, 
                                            _num_groups*sizeof(FP_PRECISION));
+  }
+  catch (...) {
+    _sigma_t = (FP_PRECISION*) MM_MALLOC(_num_groups*sizeof(FP_PRECISION),
+                                         VEC_ALIGNMENT);
+  }
   _sigma_f = new FP_PRECISION[_num_groups];
   _nu_sigma_f = new FP_PRECISION[_num_groups];
   _chi = new FP_PRECISION[_num_groups];

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -1,10 +1,10 @@
 #include "Matrix.h"
 
 /**
- * @brief Constructor initializes Matrix as a list of lists
+ * @brief Constructor initializes Matrix as a vector of maps
  *        and sets the matrix dimensions.
- * @detail The matrix object uses a "lists of lists" structure (implemented as
- *         a map of lists) to allow for easy setting and incrementing of the
+ * @details The matrix object uses a "lists of lists" structure (implemented as
+ *         a vector of maps) to allow for easy setting and incrementing of the
  *         values in the object. When the matrix is needed to perform linear
  *         algebra operations, it is converted to compressed row storage (CSR)
  *         form. The matrix is ordered by cell (as opposed to by group) on the
@@ -71,8 +71,8 @@ Matrix::~Matrix() {
 
 /**
  * @brief Increment a value in the matrix.
- * @detail This method takes a cell and group of origin (cell/group from)
- *         and cell and group of destination (cell/group to) and floating
+ * @details This method takes a cell and group of origin (cell/group from)
+ *         and cell and group of destination (cell/group to) and a floating
  *         point value. The origin and destination are used to compute the
  *         row and column in the matrix. If a value exists for the row/column,
  *         the value is incremented by val; otherwise, it is set to val.
@@ -116,7 +116,7 @@ void Matrix::incrementValue(int cell_from, int group_from,
 
 /**
  * @brief Set a value in the matrix.
- * @detail This method takes a cell and group of origin (cell/group from)
+ * @details This method takes a cell and group of origin (cell/group from)
  *         and cell and group of destination (cell/group to) and floating
  *         point value. The origin and destination are used to compute the
  *         row and column in the matrix. The location specified by the
@@ -254,7 +254,7 @@ void Matrix::printString() {
 
 /**
  * @brief Get a value in the matrix.
- * @detail This method takes a cell and group of origin (cell/group from)
+ * @details This method takes a cell and group of origin (cell/group from)
  *         and cell and group of destination (cell/group to).
  *         The origin and destination are used to compute the
  *         row and column in the matrix. The value at the location specified

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -27,7 +27,7 @@ class Matrix {
 
 private:
 
-  /** A list of lists representing the matrix */
+  /** A vector of maps representing the matrix */
   std::vector< std::map<int, CMFD_PRECISION> > _LIL;
 
   /** The CSR matrix variables */

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -3,7 +3,7 @@
 #ifndef SWIG
 
 /**
- * @brief The Mesh constructor
+ * @brief The Mesh constructor.
  * @details If no lattice is given, a default lattice can be constructed with
  *          the Mesh::createLattice function.
  * @param solver The solver from which scalar fluxes and cross-sections are
@@ -19,8 +19,8 @@ Mesh::Mesh(Solver* solver, Lattice* lattice) {
 
 
 /**
- * @brief The Mesh destrcutor deletes its lattice if the lattice was allocated
- *        internally
+ * @brief The Mesh destructor deletes its lattice if the lattice was allocated
+ *        internally.
  */
 Mesh::~Mesh() {
   if (_lattice_allocated)
@@ -30,7 +30,7 @@ Mesh::~Mesh() {
 
 /**
  * @brief Creates an internal lattice over which to tally reaction rates with
- *        the user-input dimensions
+ *        the user-input dimensions.
  * @param num_x the number of mesh cells in the x-direction
  * @param num_y the number of mesh cells in the y-direction
  * @param num_z the number of mesh cells in the z-direction
@@ -210,9 +210,9 @@ Vector3D Mesh::getFormattedReactionRates(RxType rx) {
 
 
 /**
- * @brief Tallies reaction rates of the given type over the user defined 
- *        non-uniform lattice
- * @param widths_offsets The XYZ-direction widths and offset of a non-uniform 
+ * @brief Tallies reaction rates of the given type over the user defined
+ *        non-uniform lattice.
+ * @param widths_offsets The XYZ-direction widths and offset of a non-uniform
  *        Lattice. If the widths_offsets size is 3, the center-point of the
  *        geometry is used as the offset.
  * @param rx The type of reaction to tally
@@ -222,7 +222,7 @@ Vector3D Mesh::getFormattedReactionRates(RxType rx) {
 Vector3D Mesh::getFormattedReactionRates
                  (std::vector<std::vector<double> > widths_offsets, RxType rx) {
   Vector3D rx_rates;
-  
+
   /* Get the root universe */
   Geometry* geometry = _solver->getGeometry();
   Universe* root_universe = geometry->getRootUniverse();
@@ -230,18 +230,18 @@ Vector3D Mesh::getFormattedReactionRates
   /* Determine the center-point of the geometry */
   double offset_x = (root_universe->getMinX() + root_universe->getMaxX()) / 2;
   double offset_y = (root_universe->getMinY() + root_universe->getMaxY()) / 2;
-  double offset_z = (root_universe->getMinZ() + root_universe->getMaxZ()) / 2;  
-  
-  /* The Lattice defined by user for reaction rates output, it is likely to be 
-     smaller than the whole geometry*/
+  double offset_z = (root_universe->getMinZ() + root_universe->getMaxZ()) / 2;
+
+  /* The Lattice defined by user for reaction rates output, it is likely to be
+     smaller than the whole geometry */
   Lattice output_lattice;
-  
+
   output_lattice.setNumX(widths_offsets[0].size());
   output_lattice.setNumY(widths_offsets[1].size());
   output_lattice.setNumZ(widths_offsets[2].size());
   output_lattice.setWidths(widths_offsets[0], widths_offsets[1], 
                            widths_offsets[2]);
-  
+
   /* If no offset coordinates is provided, use the geometry center */
   if(widths_offsets.size() == 3) 
     output_lattice.setOffset(offset_x, offset_y, offset_z);
@@ -249,19 +249,19 @@ Vector3D Mesh::getFormattedReactionRates
     output_lattice.setOffset(widths_offsets[3][0], widths_offsets[3][1], 
                              widths_offsets[3][2]);
   output_lattice.computeSizes();
-  
-  /* The whole geometry Lattice based on the user defined one. This new lattice  
-     allows to make use of getFormattedReactionRates function because it's 
-     defined on whole geometry*/
+
+  /* The whole geometry Lattice based on the user defined one. This new lattice
+     allows to make use of getFormattedReactionRates function because it's
+     defined on the whole geometry */
   Lattice wrap_lattice;
-  
+
   std::vector<double> widths_x = widths_offsets[0];
   std::vector<double> widths_y = widths_offsets[1];
   std::vector<double> widths_z = widths_offsets[2];
-  
+
   /* 6 booleans to indicate the truncations in six surfaces */
   std::vector<bool> surface(6, false);
-  
+
   if(fabs(output_lattice.getMinX() - root_universe->getMinX()) > FLT_EPSILON) {
     widths_x.insert(widths_x.begin(),
                     fabs(output_lattice.getMinX() - root_universe->getMinX()));
@@ -286,35 +286,35 @@ Vector3D Mesh::getFormattedReactionRates
     surface[4]=true;
   }
   if(fabs(output_lattice.getMaxZ() - root_universe->getMaxZ()) > FLT_EPSILON) {
-    widths_z.push_back(fabs(output_lattice.getMaxZ() - root_universe->getMaxZ()));  
+    widths_z.push_back(fabs(output_lattice.getMaxZ() - root_universe->getMaxZ()));
     surface[5]=true;
   }
-  
+
   /* Set the whole geometry Lattice */
   wrap_lattice.setNumX(widths_x.size());
   wrap_lattice.setNumY(widths_y.size());
   wrap_lattice.setNumZ(widths_z.size());
   wrap_lattice.setWidths(widths_x, widths_y, widths_z);
-  wrap_lattice.setOffset(offset_x, offset_y, offset_z);                  
+  wrap_lattice.setOffset(offset_x, offset_y, offset_z);
   wrap_lattice.computeSizes();
-  
-  /* set the whole geometry Lattice to the Mesh*/
+
+  /* set the whole geometry Lattice to the Mesh */
   setLattice(&wrap_lattice);
-  
-  /* get reaction rates of the whole geometry Lattice*/
+
+  /* get reaction rates of the whole geometry Lattice */
   rx_rates = getFormattedReactionRates(rx);
-  
-  /* Truncate the reaction rates for user defined output_lattice*/
+
+  /* Truncate the reaction rates for user defined output_lattice */
   if(surface[0]) rx_rates.erase(rx_rates.begin());
   if(surface[3]) rx_rates.pop_back();
-  
+
   if(surface[1]) 
     for(int i=0; i<rx_rates.size(); i++)
       rx_rates[i].erase(rx_rates[i].begin());
   if(surface[4]) 
     for(int i=0; i<rx_rates.size(); i++)
       rx_rates[i].pop_back();
-  
+
   if(surface[2]) 
     for(int i=0; i<rx_rates.size(); i++)
       for(int j=0; j<rx_rates[i].size(); j++)
@@ -323,7 +323,7 @@ Vector3D Mesh::getFormattedReactionRates
     for(int i=0; i<rx_rates.size(); i++)
       for(int j=0; j<rx_rates[i].size(); j++)
         rx_rates[i][j].pop_back();
-  
+
   return rx_rates;
 }
 

--- a/src/ParallelHashMap.h
+++ b/src/ParallelHashMap.h
@@ -1,6 +1,6 @@
 /**
  * @file ParallelHashMap.h
- * @brief A thread-safe hash map supporting insertion and lookup operations
+ * @brief A thread-safe hash map supporting insertion and lookup operations.
  * @details The parallel hash map is built on top of a fixed-sized hash map
  *    object and features OpenMP concurrency structures. The underlying
  *    fixed-sized hash map handles collisions with chaining.
@@ -20,7 +20,7 @@
 
 /**
  * @class FixedHashMap ParallelHashMap.h "src/ParallelHashMap.h"
- * @brief A fixed-size hash map supporting insertion and lookup operations
+ * @brief A fixed-size hash map supporting insertion and lookup operations.
  * @details The FixedHashMap class supports insertion and lookup operations
  *    but not deletion as deletion is not needed in the OpenMOC application.
  *    This hash table uses chaining for collisions and does not incorporate
@@ -62,7 +62,7 @@ class FixedHashMap {
 
 /**
  * @class ParallelHashMap ParallelHashMap.h "src/ParallelHashMap.h"
- * @brief A thread-safe hash map supporting insertion and lookup operations
+ * @brief A thread-safe hash map supporting insertion and lookup operations.
  * @details The ParallelHashMap class is built on top of the FixedHashMap
  *    class, supporting insertion and lookup operations but not deletion as
  *    deletion is not needed in the OpenMOC application. This hash table uses
@@ -82,8 +82,8 @@ class ParallelHashMap {
     volatile long pad_L3;
     volatile long pad_L4;
     volatile long pad_L5;
+    volatile long pad_L6;
     volatile long pad_L7;
-    volatile long pad_L8;
     FixedHashMap<K,V> volatile* value;
     volatile long pad_R1;
     volatile long pad_R2;
@@ -175,7 +175,7 @@ FixedHashMap<K,V>::~FixedHashMap() {
 
 
 /**
- * @brief Determine whether the fixed-size table contains a given key
+ * @brief Determine whether the fixed-size table contains a given key.
  * @details The linked list in the bucket associated with the key is searched
  *       to determine whether the key is present.
  * @param key key to be searched
@@ -224,8 +224,8 @@ V& FixedHashMap<K,V>::at(K& key) {
   }
 
   /* after the bucket has been completely searched without finding the key,
-     throw an exception */
-  throw std::out_of_range("Key not present in map");
+     print an error message */
+  log_printf(ERROR, "Key not present in map");
 }
 
 
@@ -306,7 +306,7 @@ long FixedHashMap<K,V>::insert_and_get_count(K key, V value) {
 
 
 /**
- * @brief Returns the number of key/value pairs in the fixed-size table
+ * @brief Returns the number of key/value pairs in the fixed-size table.
  * @return number of key/value pairs in the map
  */
 template <class K, class V>
@@ -316,7 +316,7 @@ size_t FixedHashMap<K,V>::size() {
 
 
 /**
- * @brief Returns the number of buckets in the fixed-size table
+ * @brief Returns the number of buckets in the fixed-size table.
  * @return number of buckets in the map
  */
 template <class K, class V>
@@ -326,7 +326,7 @@ size_t FixedHashMap<K,V>::bucket_count() {
 
 
 /**
- * @brief Returns an array of the keys in the fixed-size table
+ * @brief Returns an array of the keys in the fixed-size table.
  * @details All buckets are scanned in order to form a list of all keys
  *      present in the table and then the list is returned. WARNING: The user
  *      is responsible for freeing the allocated memory once the array is no
@@ -355,7 +355,7 @@ K* FixedHashMap<K,V>::keys() {
 
 
 /**
- * @brief Returns an array of the values in the fixed-size table
+ * @brief Returns an array of the values in the fixed-size table.
  * @details All buckets are scanned in order to form a list of all values
  *      present in the table and then the list is returned. WARNING: The user
  *      is responsible for freeing the allocated memory once the array is no
@@ -409,7 +409,7 @@ void FixedHashMap<K,V>::clear() {
 
 
 /**
- * @brief Prints the contents of each bucket to the screen
+ * @brief Prints the contents of each bucket to the screen.
  * @details All buckets are scanned and the contents of the buckets are
  *      printed, which are pointers to linked lists. If the pointer is NULL
  *      suggesting that the linked list is empty, NULL is printed to the
@@ -465,7 +465,7 @@ ParallelHashMap<K,V>::~ParallelHashMap() {
 
 
 /**
- * @brief Determine whether the parallel hash map contains a given key
+ * @brief Determine whether the parallel hash map contains a given key.
  * @details First the thread accessing the table announces its presence and
  *      which table it is reading. Then the linked list in the bucket
  *      associated with the key is searched without setting any locks
@@ -716,7 +716,7 @@ void ParallelHashMap<K,V>::resize() {
 
 
 /**
- * @brief Returns the number of key/value pairs in the underlying table
+ * @brief Returns the number of key/value pairs in the underlying table.
  * @return number of key/value pairs in the map
  */
 template <class K, class V>
@@ -726,7 +726,7 @@ size_t ParallelHashMap<K,V>::size() {
 
 
 /**
- * @brief Returns the number of buckets in the underlying table
+ * @brief Returns the number of buckets in the underlying table.
  * @return number of buckets in the map
  */
 template <class K, class V>
@@ -736,7 +736,7 @@ size_t ParallelHashMap<K,V>::bucket_count() {
 
 
 /**
- * @brief Returns the number of locks in the parallel hash map
+ * @brief Returns the number of locks in the parallel hash map.
  * @return number of locks in the map
  */
 template <class K, class V>
@@ -746,7 +746,7 @@ size_t ParallelHashMap<K,V>::num_locks() {
 
 
 /**
- * @brief Returns an array of the keys in the underlying table
+ * @brief Returns an array of the keys in the underlying table.
  * @details All buckets are scanned in order to form a list of all keys
  *      present in the table and then the list is returned. Threads
  *      announce their presence to ensure table memory is not freed
@@ -781,7 +781,7 @@ K* ParallelHashMap<K,V>::keys() {
 
 
 /**
- * @brief Returns an array of the values in the underlying table
+ * @brief Returns an array of the values in the underlying table.
  * @details All buckets are scanned in order to form a list of all values
  *      present in the table and then the list is returned. Threads
  *      announce their presence to ensure table memory is not freed
@@ -816,7 +816,7 @@ V* ParallelHashMap<K,V>::values() {
 
 
 /**
- * @brief Prevents the parallel hash map from further resizing
+ * @brief Prevents the parallel hash map from further resizing.
  */
 template <class K, class V>
 void ParallelHashMap<K,V>::setFixedSize() {
@@ -844,7 +844,7 @@ void ParallelHashMap<K,V>::clear() {
 
 
 /**
- * @brief Prints the contents of each bucket to the screen
+ * @brief Prints the contents of each bucket to the screen.
  * @details All buckets are scanned and the contents of the buckets are
  *      printed, which are pointers to linked lists. If the pointer is NULL
  *      suggesting that the linked list is empty, NULL is printed to the

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -12,7 +12,7 @@ Point::Point() {
 
 
 /**
- * @brief Destructor
+ * @brief Destructor.
  */
 Point::~Point() {
 }
@@ -20,7 +20,8 @@ Point::~Point() {
 
 /**
  * @brief Converts this Point to a character representation of its attributes.
- * @details The character array includes the x-coordinate, y-coordinate, and z-coordinate
+ * @details The character array includes the x-coordinate, y-coordinate, 
+ *          and z-coordinate
  * @return a character array of this Point's attributes
  */
 std::string Point::toString() {

--- a/src/Point.h
+++ b/src/Point.h
@@ -88,8 +88,8 @@ inline double Point::getZ() const {
 
 
 /**
- * @brief Returns this Point's x-coordinate.
- * @return the x-coordinate
+ * @brief Returns this Point's coordinates.
+ * @return the xyz coordinates
  */
 inline double* Point::getXYZ() {
   return _xyz;
@@ -106,7 +106,7 @@ inline void Point::setX(const double x) {
 
 
 /**
- * @brief Set the Point's y-coordinate
+ * @brief Set the Point's y-coordinate.
  * @param y the new y-coordinate
  */
 inline void Point::setY(const double y) {
@@ -115,7 +115,7 @@ inline void Point::setY(const double y) {
 
 
 /**
- * @brief Set the Point's z-coordinate
+ * @brief Set the Point's z-coordinate.
  * @param z the new z-coordinate
  */
 inline void Point::setZ(const double z) {
@@ -124,7 +124,7 @@ inline void Point::setZ(const double z) {
 
 
 /**
- * @brief Set the Point's x, y and z-coordinates
+ * @brief Set the Point's x, y and z-coordinates.
  * @param xyz array with the three coordinates
  */
 inline void Point::setXYZ(double* xyz) {
@@ -138,6 +138,7 @@ inline void Point::setXYZ(double* xyz) {
  * @brief Compute the distance from this Point to another Point of interest.
  * @param x the x-coordinate of the Point of interest
  * @param y the y-coordinate of the Point of interest
+ * @param z the z-coordinate of the Point of interest
  * @return distance to the Point of interest
  */
 inline double Point::distance(const double x, const double y, const double z) const {
@@ -162,7 +163,7 @@ inline double Point::distanceToPoint(const Point* point) {
 
 
 /**
- * @brief Copy the coordinates from another point
+ * @brief Copy the coordinates from another point.
  * @param point a pointer to the Point that has the coordinates of interest
  */
 inline void Point::copyCoords(Point* point) {

--- a/src/Progress.cpp
+++ b/src/Progress.cpp
@@ -47,6 +47,8 @@ void Progress::incrementCounter() {
 
   int curr_count;
   bool found_interval = false;
+
+  /* Increment counter, check if next interval is reached */
   #pragma omp critical
   {
     curr_count = _counter++;

--- a/src/Progress.h
+++ b/src/Progress.h
@@ -1,6 +1,6 @@
 /**
  * @file Progress.h
- * @brief A progress object
+ * @brief An object to track progress
  * @date January 11, 2016
  * @author Samuel Shaner, MIT, Course 22 (shaner@mit.edu)
  */
@@ -34,7 +34,6 @@ class Progress {
 
 private:
 
-  /** A list of lists representing the vector */
   std::string _name;
   int _counter;
   int _num_iterations;

--- a/src/Quadrature.cpp
+++ b/src/Quadrature.cpp
@@ -28,7 +28,7 @@ Quadrature::~Quadrature() {
 
 
 /**
- * @brief Deletes all arrays indexed by polar angle
+ * @brief Deletes all arrays indexed by polar angle.
  */
 void Quadrature::deletePolarArrays() {
 
@@ -70,7 +70,7 @@ void Quadrature::deletePolarArrays() {
 
 
 /**
- * @brief Deletes all arrays allocated by the Quadrature
+ * @brief Deletes all arrays allocated by the Quadrature.
  */
 void Quadrature::deleteAllArrays() {
 
@@ -249,7 +249,7 @@ double Quadrature::getPolarWeight(int azim, int polar) {
 
 /**
  * @brief Returns the total weight for Tracks with the given azimuthal and
- *        polar indexes
+ *        polar indexes.
  * @details Angular weights are multiplied by Track spacings
  * @param azim index of the azimuthal angle of interest
  * @param polar index of the polar angle of interest
@@ -389,7 +389,7 @@ double* Quadrature::getAzimSpacings() {
 /**
  * @brief Returns the adjusted azimuthal spacing at the requested azimuthal
  *        angle index.
- * @details The aziumthal spacing depends on the azimuthal angle. This function
+ * @details The azimuthal spacing depends on the azimuthal angle. This function
  *          returns the azimuthal spacing used at the desired azimuthal angle
  *          index.
  * @param azim the requested azimuthal angle index
@@ -403,7 +403,7 @@ double Quadrature::getAzimSpacing(int azim) {
 
 
 /**
- * @brief Returns a 2D array of adjusted polar spacings
+ * @brief Returns a 2D array of adjusted polar spacings.
  * @details An array of polar spacings after adjustment is returned,
  *          indexed first by azimuthal angle and then by polar angle
  * @return the 2D array of polar spacings
@@ -415,7 +415,7 @@ double** Quadrature::getPolarSpacings() {
 
 /**
  * @brief Returns the adjusted polar spacing at the requested azimuthal
- *        angle index and polar angle index
+ *        angle index and polar angle index.
  * @details The polar spacing depends on the azimuthal angle and the polar
  *          angle. This function returns the azimuthal spacing used at the
  *          desired azimuthal angle and polar angle indexes.
@@ -643,10 +643,10 @@ void Quadrature::setAzimSpacing(double spacing, int azim) {
 
 
 /**
- * @brief Sets the polar spacing for the given indexes
+ * @brief Sets the polar spacing for the given indexes.
  * @param spacing the spacing in the polar direction to be set
  * @param azim the azimuthal index corresponding to the angle
- * @param azim the polar index corresponding to the angle
+ * @param polar the polar index corresponding to the angle
  */
 void Quadrature::setPolarSpacing(double spacing, int azim, int polar) {
 
@@ -702,7 +702,7 @@ void Quadrature::setAzimWeight(double weight, int azim) {
  * @brief Sets the polar weight for the given indexes.
  * @param weight the weight of the polar angle
  * @param azim the azimuthal index corresponding to the angle
- * @param azim the polar index corresponding to the angle
+ * @param polar the polar index corresponding to the angle
  */
 void Quadrature::setPolarWeight(double weight, int azim, int polar) {
 
@@ -751,12 +751,13 @@ void Quadrature::initialize() {
                "angles. Set the number of azimuthal angles before "
                "initialization.");
 
-  if (_phis == NULL)
+  if (_phis == NULL) {
     _phis = new double[_num_azim/2];
 
-  /* Compute a desired azimuthal angles */
-  for (int a = 0; a < _num_azim/2; a++)
-    _phis[a] = 2.0 * M_PI / _num_azim * (0.5 + a);
+    /* Compute a desired set of azimuthal angles */
+    for (int a = 0; a < _num_azim/2; a++)
+      _phis[a] = 2.0 * M_PI / _num_azim * (0.5 + a);
+  }
 }
 
 
@@ -1197,10 +1198,10 @@ void GLPolarQuad::precomputeWeights(bool solve_3D) {
 
 
 /**
- * @brief    the Legendre polynomial of degree n evaluated at x
- * @param    n an integer >=0: the order of the polynomial
- * @param    x in (-1,1), the point at which to evaluate the polynomial
- * @return   the value of the Legendre polynomial of degree n at x
+ * @brief the Legendre polynomial of degree n evaluated at x.
+ * @param n an integer >=0: the order of the polynomial
+ * @param x in (-1,1), the point at which to evaluate the polynomial
+ * @return the value of the Legendre polynomial of degree n at x
  */
 double GLPolarQuad::legendrePolynomial(int n, double x) {
   if (n == 0)
@@ -1219,10 +1220,10 @@ double GLPolarQuad::legendrePolynomial(int n, double x) {
 
 
 /**
- * @brief    the first logarithmic derivative of a Legendre polynomial
- * @param    m the order of the polynomial
- * @param    x point at which to evaluate the logarithmic derivative
- * @return   the value of the logarithmic derivative at x
+ * @brief The first logarithmic derivative of a Legendre polynomial.
+ * @param m the order of the polynomial
+ * @param x point at which to evaluate the logarithmic derivative
+ * @return the value of the logarithmic derivative at x
  */
 double GLPolarQuad::logDerivLegendre(int n, double x) {
   double num = n * x - n * legendrePolynomial(n-1,x) / legendrePolynomial(n,x);
@@ -1232,10 +1233,10 @@ double GLPolarQuad::logDerivLegendre(int n, double x) {
 
 
 /**
- * @brief    the second logarithmic derivative of a Legendre polynomial
- * @param    m the order of the polynomial
- * @param    x point at which to evaluate the logarithmic derivative
- * @return   the value of the logarithmic derivative at x
+ * @brief The second logarithmic derivative of a Legendre polynomial.
+ * @param m the order of the polynomial
+ * @param x point at which to evaluate the logarithmic derivative
+ * @return the value of the logarithmic derivative at x
  */
 double GLPolarQuad::secondLogDerivLegendre(int n, double x) {
   double num =
@@ -1246,17 +1247,17 @@ double GLPolarQuad::secondLogDerivLegendre(int n, double x) {
 
 
 /**
- * @brief    finds the roots of Legendre polynomial of order n
- * @detail   guesses for positive roots are set at logarithmic intervals.
- *           Positive roots are found simultaneously using an
- *           Alberth-Householder-n method. Each guess is successively nudged
- *           towards a true root. Only the positive roots are calculated
- * @param    n the order of the polynomial
- * @return   a list of the roots of the polynomial
+ * @brief Finds the roots of Legendre polynomial of order n.
+ * @details Guesses for positive roots are set at logarithmic intervals.
+ *          Positive roots are found simultaneously using an
+ *          Alberth-Householder-n method. Each guess is successively nudged
+ *          towards a true root. Only the positive roots are calculated
+ * @param n the order of the polynomial
+ * @return a list of the roots of the polynomial
  */
 std::vector <double> GLPolarQuad::getLegendreRoots(int n) {
 
-  /* put these somewhere else */
+  /* desired precision on roots */
   double E1 = 1e-8;
   double E2 = 1e-8;
 
@@ -1361,10 +1362,10 @@ std::vector <double> GLPolarQuad::getLegendreRoots(int n) {
 
 
 /**
- * @brief    calculates the weights to be used in Gauss-Legendre Quadrature
- * @param    roots a vector containing the roots of the Legendre polynomial
- * @param    n the order of the Legendre Polynomial
- * @return   a vector of weights matched by index to the vector of roots
+ * @brief Calculates the weights to be used in Gauss-Legendre Quadrature.
+ * @param roots a vector containing the roots of the Legendre polynomial
+ * @param n the order of the Legendre Polynomial
+ * @return a vector of weights matched by index to the vector of roots
  */
 std::vector<double> GLPolarQuad::getGLWeights(std::vector <double> roots,
                                                int n) {
@@ -1381,10 +1382,10 @@ std::vector<double> GLPolarQuad::getGLWeights(std::vector <double> roots,
 
 
 /**
- * @brief    calculates the weights to be used in Gauss-Legendre Quadrature
- * @param    root the root of the Legendre polynomial
- * @param    n the order of the Legendre Polynomial
- * @return   a vector of weights matched by index to the vector of roots
+ * @brief Calculates the weights to be used in Gauss-Legendre Quadrature.
+ * @param root the root of the Legendre polynomial
+ * @param n the order of the Legendre Polynomial
+ * @return a vector of weights matched by index to the vector of roots
  */
 double GLPolarQuad::getSingleWeight(double root, int n) {
   double weight =
@@ -1396,10 +1397,10 @@ double GLPolarQuad::getSingleWeight(double root, int n) {
 
 
 /**
- * @brief    calculates the weights to be used in numerical integration
- * @details  assumes the function will be integrated over (-1, 1)
- * @details  azim the azimuthal angle index
- * @return   the vector of weights
+ * @brief Calculates the weights to be used in numerical integration.
+ * @details assumes the function will be integrated over (-1, 1)
+ * @details azim the azimuthal angle index
+ * @return the vector of weights
  */
 std::vector<double> GLPolarQuad::getCorrectedWeights(int azim) {
 
@@ -1449,7 +1450,7 @@ std::vector<double> GLPolarQuad::getCorrectedWeights(int azim) {
           A[k][j] = temp;
         }
 
-        // switch their corresponding indeces
+        // switch their corresponding indices
         long double temp_ind = index[i];
         index[i] = index[k];
         index[k] = temp_ind;

--- a/src/Quadrature.cpp
+++ b/src/Quadrature.cpp
@@ -905,7 +905,7 @@ std::string Quadrature::toString() {
 
 
 /**
- * @breif Returns the type of Quadrature created.
+ * @brief Returns the type of Quadrature created.
  * @return The quadrature type
  */
 quadratureType Quadrature::getQuadratureType() {

--- a/src/Region.cpp
+++ b/src/Region.cpp
@@ -2,7 +2,7 @@
 #include <cmath>
 
 /**
- * @brief Constructor sets a few pointers to NULL
+ * @brief Constructor sets a few pointers to NULL.
  */
 Region::Region() {
   _parent_region = NULL;
@@ -81,11 +81,13 @@ std::vector<Region*> Region::getNodes() {
  * @returns a vector of the Region's nodes
  */
 std::vector<Region*> Region::getAllNodes() {
+
   std::vector<Region*> all_nodes;
   std::vector<Region*> nodes;
   std::vector<Region*>::iterator iter;
   std::vector<Region*>::iterator sub_iter;
-   /* Recursively collect all nodes from this Regions nodes */
+
+  /* Recursively collect all nodes from this Regions nodes */
   for (iter = _nodes.begin(); iter != _nodes.end(); iter++) {
     all_nodes.push_back(*iter);
     nodes = (*iter)->getAllNodes();
@@ -109,6 +111,7 @@ std::map<int, Halfspace*> Region::getAllSurfaces() {
   std::map<int, Halfspace*> all_surfaces;
   std::map<int, Halfspace*> node_surfaces;
   std::vector<Region*>::iterator iter;
+
   /* Recursively collect all Halfspaces from this Region's nodes */
   for (iter = _nodes.begin(); iter != _nodes.end(); iter++) {
     node_surfaces = (*iter)->getAllSurfaces();
@@ -128,7 +131,7 @@ regionType Region::getRegionType() {
 
 
 /**
- * @brief Save the parent of the current node/Region.
+ * @brief Set the parent of the current node/Region.
  * @param parent the node/Region that contains the current node/Region
  */
 void Region::setParentRegion(Region* parent) {
@@ -778,7 +781,7 @@ Surface* Halfspace::getSurface() {
 
 /**
  * @brief Return the side of the Surface for this Halfspace.
- * @param the side of the surface for this Halfspace (+1 or -1)
+ * @return the side of the surface for this Halfspace (+1 or -1)
  */
 int Halfspace::getHalfspace() {
   return _halfspace;
@@ -787,7 +790,6 @@ int Halfspace::getHalfspace() {
 
 /**
  * @brief Changes the side of the surface for this Halfspace.
- * @param the side of the surface for this Halfspace (+1 or -1)
  */
 void Halfspace::reverseHalfspace() {
   _halfspace *= -1;
@@ -963,7 +965,7 @@ double Halfspace::minSurfaceDist(LocalCoords* coords) {
 
 /**
  * @brief Constructor creates an Intersection of the Intersection of
- *        two XPlane and two YPlane objects.
+ *        two XPlane and two YPlane (and two ZPlane in 3D) objects.
  * @details This is a special subclass of the Intersection which
  *          represents the interior of a rectangular prism aligned
  *          with th z-axis.
@@ -971,6 +973,8 @@ double Halfspace::minSurfaceDist(LocalCoords* coords) {
  * @param width_y the width of the prism along the y-axis (in cm)
  * @param origin_x the center of the prism along the x-axis (in cm)
  * @param origin_y the center of the prism along the y-axis (in cm)
+ * @param width_z the width of the prism along the z-axis (in cm)
+ * @param origin_z the center of the prism along the z-axis (in cm)
  * @returns a pointer to an Intersection object
  */
 RectangularPrism::RectangularPrism(double width_x, double width_y,
@@ -978,7 +982,7 @@ RectangularPrism::RectangularPrism(double width_x, double width_y,
                                    double width_z, double origin_z):
   Intersection() {
 
-  /* Instantiate the XPlane and YPlane objects bounding the prism */
+  /* Instantiate the XPlane, YPlane and ZPlane objects bounding the prism */
   XPlane* min_x = new XPlane(origin_x-width_x/2.);
   XPlane* max_x = new XPlane(origin_x+width_x/2.);
   YPlane* min_y = new YPlane(origin_y-width_y/2.);
@@ -1007,7 +1011,7 @@ RectangularPrism::RectangularPrism(double width_x, double width_y,
 
 /**
  * @brief Sets the boundary condition type (ie., VACUUM, REFLECTIVE, etc)
- *        to assign to each of the XPlanes and YPlanes bounding the prism.
+ *        to assign to each of the planes bounding the prism.
  * @param boundary_type the boundary condition type for this Prism
  */
 void RectangularPrism::setBoundaryType(boundaryType boundary_type) {
@@ -1015,7 +1019,7 @@ void RectangularPrism::setBoundaryType(boundaryType boundary_type) {
   std::map<int, Halfspace*> all_surfaces = getAllSurfaces();
   std::map<int, Halfspace*>::iterator iter;
 
-  /* Assign the boundary to each of the bounding XPlanes and YPlanes */
+  /* Assign the boundary to each of the bounding XPlanes, YPlanes and ZPlanes */
   for (iter = all_surfaces.begin(); iter != all_surfaces.end(); iter++)
     iter->second->getSurface()->setBoundaryType(boundary_type);
 }

--- a/src/RunTime.cpp
+++ b/src/RunTime.cpp
@@ -2,20 +2,18 @@
 #include "RunTime.h"
 #endif
 
+
 /**
- * @brief Process the run time options
- */
-/**
- * @brief Process the run time options 
+ * @brief Process the run time options.
  * @param RP A reference of RuntimeParameters
  * @param argc number of run time command words
  * @param argv content of run time command words
  */
 int setRuntimeParameters(RuntimeParameters &RP, int argc, char *argv[]) {
-  
+
   int arg_index = 0;
   int print_usage = 0;
-  
+
   /* Parse the run time commands*/
   while (arg_index < argc) {
     if(strcmp(argv[arg_index], "-debug") == 0) {
@@ -359,7 +357,7 @@ int setRuntimeParameters(RuntimeParameters &RP, int argc, char *argv[]) {
       "-verbose_report          1                                          \\\n"
       "-time_report             1                                          \\\n"
     );
-    
+
     printf("\n");
     printf("General parameters\n");
     printf("-debug                  : (0) or 1, waits in while loop for GDB to"
@@ -376,7 +374,7 @@ int setRuntimeParameters(RuntimeParameters &RP, int argc, char *argv[]) {
            "                           1 - non-uniform lattice geometry\n"
           );
     printf("\n");
-    
+
     printf("Track generating parameters\n");
     printf("-azim_spacing           : (0.05)\n");
     printf("-num_azim               : (64)\n");
@@ -449,7 +447,7 @@ int setRuntimeParameters(RuntimeParameters &RP, int argc, char *argv[]) {
 
     printf("\n");
   }
-  
+
   if (print_usage) {
 #ifdef MPIx
     MPI_Finalize();

--- a/src/RunTime.h
+++ b/src/RunTime.h
@@ -1,9 +1,9 @@
 /**
  * @file RunTime.h
- * @brief Utility functions for processing run time options
+ * @brief Utility functions for processing run time options.
  * @details OpenMOC provide another option of input by .cpp file. With these run
- *          time options, it's possible to run various problems with different 
- *          parameters via a standard built executive file, avoiding the 
+ *          time options, it's possible to run various problems with different
+ *          parameters via a standard built executive file, avoiding the
  *          necessity to build the code each time.
  * @author Wenbin Wu (wenbin@mit.edu)
  * @date October 12, 2018
@@ -34,7 +34,7 @@
 typedef std::vector<std::vector<std::vector<double> > > Vector3D;
 
 /**
- * @brief Structure for run time options
+ * @brief Structure for run time options.
  */
 struct RuntimeParameters {
   RuntimeParameters() : _debug_flag(false), _NDx(1), _NDy(1), _NDz(1),
@@ -47,20 +47,26 @@ struct RuntimeParameters {
     _segmentation_type(3), _verbose_report(true), _time_report(true),
     _log_level((char*)"NORMAL"),_quadraturetype(2), _test_run(false), 
     _geo_version(0) {}
-  
+
   /* To debug or not when running, dead while loop */
   bool _debug_flag;
   char* _log_level;
+
   /* Domain decomposition structure */
   int _NDx, _NDy, _NDz;
+
   /* Modules structure, used to define sub-domains */
   int _NMx, _NMy, _NMz;
+
   /* Number of OpenMP threads */
   int _num_threads;
+
   /* Log file name */
   char* _log_filename;
+
   /* Geometry file name */
   std::string _geo_filename;
+
   /* The version of the geometry file (uniform or non-uniform lattice) */
   int _geo_version;
 
@@ -68,58 +74,74 @@ struct RuntimeParameters {
   double _azim_spacing;
   int _num_azim;
   double _polar_spacing;
-  int _num_polar;  
+  int _num_polar;
+
   /* Segmentation zones for 2D extruded segmentation*/
   std::vector<double> _seg_zones;
+
   /* Segmentation type of track generation*/
   int _segmentation_type;
+
   /* Polar quadrature type */
   int _quadraturetype;
-  
-  
+
   /* CMFD group structure */
   std::vector<std::vector<int> > _CMFD_group_structure;
+
   /* CMFD lattice structure, used for uniform CMFD */
   int _NCx, _NCy, _NCz;
+
   /** Physical dimensions of non-uniform CMFD meshes (for whole geometry) */
   std::vector<double> _cell_widths_x;
   std::vector<double> _cell_widths_y;
   std::vector<double> _cell_widths_z;
+
   /* CMFD flux update on or not */
   bool _CMFD_flux_update_on;
+
   /* The order of k-nearest update */
   int _knearest;
+
   /* Knearest update or conventional update */
   bool _CMFD_centroid_update_on;
+
   /* Whether to use axial interpolation for CMFD update */
   int _use_axial_interpolation; 
+
   /* CMFD linear solver SOR factor */
   double _SOR_factor;
+
   /* CMFD relaxation factor */
   double _CMFD_relaxation_factor;
-  
-  
+
   /* Linear source solver if true*/
   bool _linear_solver;
+
   /* The maximum number of MOC source iterations */
   int _max_iters;
+
   /* Type of MOC source residual for convergence check */
-  int _MOC_src_residual_type;  
+  int _MOC_src_residual_type;
+
   /* MOC source convergence tolerance */
   double _tolerance;
 
-  
+
   /* uniform lattice output */
-  std::vector<std::vector<int> > _output_mesh_lattices; 
+  std::vector<std::vector<int> > _output_mesh_lattices;
+
   /* widths and offsets of multiple output meshes with non-uniform lattice */
-  Vector3D _non_uniform_mesh_lattices; 
+  Vector3D _non_uniform_mesh_lattices;
+
   /* output reaction types for both uniform and non-uniform */
-  std::vector<int> _output_types; 
+  std::vector<int> _output_types;
   bool _verbose_report;
   bool _time_report;
+
   /* whether to run the code for test */
   bool _test_run;
 };
+
 
 int setRuntimeParameters(RuntimeParameters &RP, int argc, char *argv[]);
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -38,6 +38,7 @@ Solver::Solver(TrackGenerator* track_generator) {
   _solve_3D = false;
   _segment_formation = EXPLICIT_2D;
 
+  /* Initialize pointers to NULL */
   _tracks = NULL;
   _azim_spacings = NULL;
   _polar_spacings = NULL;
@@ -55,7 +56,6 @@ Solver::Solver(TrackGenerator* track_generator) {
 
   _regionwise_scratch = NULL;
 
-  /* Default polar quadrature */
   _fluxes_per_track = 0;
 
   if (track_generator != NULL)
@@ -66,6 +66,7 @@ Solver::Solver(TrackGenerator* track_generator) {
 
   _timer = new Timer();
 
+  /* Default settings */
   _correct_xs = false;
   _stabilize_transport = false;
   _verbose = false;
@@ -76,9 +77,9 @@ Solver::Solver(TrackGenerator* track_generator) {
 
   _xs_log_level = ERROR;
 
-  //FIXME
+  //FIXME OTF transport isnt implemented
   _OTF_transport = false;
-  //FIXME
+  //FIXME Parameters for xs modification, should be deleted
   _reset_iteration = -1;
   _limit_xs = false;
 }
@@ -106,10 +107,10 @@ Solver::~Solver() {
 
   if (_old_scalar_flux != NULL)
     delete [] _old_scalar_flux;
-  
+
   if (_reference_flux != NULL)
     delete [] _reference_flux;
-  
+
   if (_stabilizing_flux != NULL)
     delete [] _stabilizing_flux;
 
@@ -129,7 +130,7 @@ Solver::~Solver() {
     delete [] _groupwise_scratch.at(i);
   _groupwise_scratch.clear();
 
-  /** Delete exponential evaluators */
+  /* Delete exponential evaluators */
   if (_exp_evaluators != NULL){
     for (int a=0; a < _num_exp_evaluators_azim; a++) {
       for (int p=0; p < _num_exp_evaluators_polar; p++) {
@@ -555,7 +556,7 @@ void Solver::useExponentialIntrinsic() {
 
 
 /**
- * @brief   Directs OpenMOC to correct unphysical cross-sections
+ * @brief Directs OpenMOC to correct unphysical cross-sections.
  * @details If a material is found with greater total scattering cross-section
  *          than total cross-section, the total cross-section is set to the
  *          scattering cross-section.
@@ -566,8 +567,8 @@ void Solver::correctXS() {
 
 
 /**
- * @brief   Directs OpenMOC to use the diagonal stabilizing correction to
- *          the source iteration transport sweep
+ * @brief Directs OpenMOC to use the diagonal stabilizing correction to
+ *        the source iteration transport sweep.
  * @details The source iteration process which MOC uses can be unstable
  *          if negative cross-sections arise from transport correction. This
  *          instability causes issues in convergence. The stabilizing
@@ -599,7 +600,7 @@ void Solver::stabilizeTransport(double stabilization_factor,
   _stabilization_factor = stabilization_factor;
   _stabilization_type = stabilization_type;
 }
-  
+
 
 /**
  * @brief Instructs OpenMOC to perform an initial spectrum calculation
@@ -612,9 +613,9 @@ void Solver::setInitialSpectrumCalculation(double threshold) {
 
 
 /**
- * @brief   Determines which log level to set cross-section warnings
+ * @brief Determines which log level to set cross-section warnings
  * @details The default log level is ERROR
- * @param   log_level The log level for outputing cross-section inconsistencies
+ * @param log_level The log level for outputing cross-section inconsistencies
  */
 void Solver::setCheckXSLogLevel(logLevel log_level) {
   _xs_log_level = log_level;
@@ -736,7 +737,7 @@ void Solver::initializeFSRs() {
     delete [] _groupwise_scratch.at(i);
   if (_regionwise_scratch != NULL)
     delete [] _regionwise_scratch;
-  
+
   int num_threads = omp_get_max_threads();
   _groupwise_scratch.resize(num_threads);
   for (int i=0; i < num_threads; i++)
@@ -778,7 +779,7 @@ void Solver::countFissionableFSRs() {
 
 
 /**
- * @brief Checks to see if limited XS should be reset
+ * @brief Checks to see if limited XS should be reset.
  * @param iteration The MOC iteration number
  */
 void Solver::checkLimitXS(int iteration) {
@@ -819,7 +820,7 @@ void Solver::checkLimitXS(int iteration) {
 
 
 /**
- * @brief Instructs MOC to limit negative cross-sections for early iterations
+ * @brief Instructs MOC to limit negative cross-sections for early iterations.
  * @param material_ids The material IDs of the cross-sections to limit
  * @param reset_iteration The iteration to reset cross-sections to their 
  *        defaults
@@ -833,7 +834,7 @@ void Solver::setLimitingXSMaterials(std::vector<int> material_ids,
 
 
 /**
- * @brief Limits cross-sections so that there are no negative cross-sections
+ * @brief Limits cross-sections so that there are no negative cross-sections.
  * @details A copy of the original cross-section is saved
  */
 void Solver::limitXS() {
@@ -863,7 +864,7 @@ void Solver::limitXS() {
 
 /**
  * @brief All material cross-sections in the geometry are checked for
- *        consistency
+ *        consistency.
  * @details Each cross-section is checked to ensure that the total
  *          cross-section is greater than or equal to the scattering
  *          cross-section for each energy group and that all cross-sections
@@ -983,7 +984,7 @@ void Solver::initializeFixedSources() {
     }
   }
 
-  /** Fixed sources assigned by Material */
+  /* Fixed sources assigned by Material */
   for (mat_iter = _fix_src_material_map.begin();
        mat_iter != _fix_src_material_map.end(); ++mat_iter) {
 
@@ -1002,7 +1003,7 @@ void Solver::initializeFixedSources() {
 
 
 /**
- * @brief Initializes a Cmfd object for acceleratiion prior to source iteration.
+ * @brief Initializes a Cmfd object for acceleration prior to source iteration.
  * @details Instantiates a dummy Cmfd object if one was not assigned to
  *          the Solver by the user and initializes FSRs, materials, fluxes
  *          and the Mesh object. This method is for internal use only
@@ -1047,7 +1048,7 @@ void Solver::initializeCmfd() {
 
 
 /**
- * @brief Performs a spectrum calculation to update the scalar fluxes
+ * @brief Performs a spectrum calculation to update the scalar fluxes.
  * @details This function is meant to be used before transport sweeps in an
  *          eigenvalue calculation in order to gain a better initial guess
  *          on the flux shape. It is equivalent to performing a CMFD update
@@ -1059,15 +1060,15 @@ void Solver::calculateInitialSpectrum(double threshold) {
 
   log_printf(NORMAL, "Calculating initial spectrum with threshold %3.2e", 
              threshold);
-  
+
   /* Setup the spectrum calclator as a CMFD solver in MOC group structure */
-  Cmfd spectrum_calculator;  
+  Cmfd spectrum_calculator;
   std::vector<std::vector<int> > group_structure;
   group_structure.resize(_num_groups);
   for (int g=0; g < _num_groups; g++)
-    group_structure.at(g).push_back(g+1);    
+    group_structure.at(g).push_back(g+1);
   spectrum_calculator.setGroupStructure(group_structure);
-  
+
   /* Set CMFD settings for the spectrum calculator */
   spectrum_calculator.setSORRelaxationFactor(1.6);
   spectrum_calculator.useFluxLimiting(true);
@@ -1257,8 +1258,8 @@ void Solver::computeFlux(int max_iters, bool only_fixed_source) {
  *          // Assign fixed sources
  *          // ...
  *
- *          // Find the flux distribution resulting from the fixed sources
- *          solver.computeFlux(max_iters=100, k_eff=0.981)
+ *          // Find the source distribution resulting from the fixed sources
+ *          solver.computeSource(max_iters=100, k_eff=0.981)
  * @endcode
  *
  * @param max_iters the maximum number of source iterations to allow
@@ -1444,7 +1445,7 @@ void Solver::computeEigenvalue(int max_iters, residualType res_type) {
                "  #FX1 #FXN  MAX P.F.");
     }
   }
-  
+
   /* Record the starting eigenvalue guess */
   double k_prev = _k_eff;
 
@@ -1483,7 +1484,7 @@ void Solver::computeEigenvalue(int max_iters, residualType res_type) {
     double dr = residual / previous_residual;
     int dk = 1e5 * (_k_eff - k_prev);
     k_prev = _k_eff;
-    
+
     /* Ouptut iteration report */
     if (_verbose && convergence_data != NULL) {
 
@@ -1676,7 +1677,13 @@ void Solver::printTimerReport() {
 }
 
 
-//FIXME
+/**
+ * @brief Prints fission rates to a binary file.
+ * @param fname the name of the file to dump the fission rates to
+ * @param nx number of mesh cells in the x-direction
+ * @param ny number of mesh cells in the y-direction
+ * @param nz number of mesh cells in the z-direction
+ */
 void Solver::printFissionRates(std::string fname, int nx, int ny, int nz) {
 
   Universe* root_universe = _geometry->getRootUniverse();
@@ -1739,12 +1746,13 @@ void Solver::printFissionRates(std::string fname, int nx, int ny, int nz) {
 
 
 /**
- * @brief A function that returns the underlying array of scalar fluxes
+ * @brief A function that returns the array of scalar fluxes.
  * @return The scalar fluxes
  */
 FP_PRECISION* Solver::getFluxesArray() {
   return _scalar_flux;
 }
+
 
 /**
  * @brief Sets computation method of k-eff from fission, absorption, and leakage
@@ -1755,9 +1763,10 @@ void Solver::setKeffFromNeutronBalance() {
   _keff_from_fission_rates = false;
 }
 
+
 /**
- * @brief Sets residuals to be computed a error relative to a reference
- * @params fname The file containing the flux solution of the reference
+ * @brief Sets residuals to be computed a error relative to a reference.
+ * @param fname The file containing the flux solution of the reference
  */
 void Solver::setResidualByReference(std::string fname) {
   _calculate_residuals_by_reference = true;
@@ -1766,8 +1775,8 @@ void Solver::setResidualByReference(std::string fname) {
 
 
 /**
- * @brief Prints scalar fluxes to a binary file
- * @details The name of the file to dump the fluxes to
+ * @brief Prints scalar fluxes to a binary file.
+ * @param fname the name of the file to dump the fluxes to
  */
 void Solver::dumpFSRFluxes(std::string fname) {
 
@@ -1788,7 +1797,7 @@ void Solver::dumpFSRFluxes(std::string fname) {
       filename += "_" + str;
     }
   }
-  
+
   /* Write the FSR fluxes file */
   FILE* out;
   out = fopen(filename.c_str(), "w");
@@ -1798,7 +1807,7 @@ void Solver::dumpFSRFluxes(std::string fname) {
 
   /* Write number of energy groups */
   fwrite(&_num_groups, sizeof(int), 1, out);
-  
+
   /* Write number of energy groups */
   fwrite(&_num_FSRs, sizeof(long), 1, out);
 
@@ -1818,7 +1827,7 @@ void Solver::dumpFSRFluxes(std::string fname) {
 
 
 /**
- * @brief Loads the initial scalar flux distribution from a binary file
+ * @brief Load the initial scalar flux distribution from a binary file.
  * @param fname The file containing the scalar fluxes
  */
 void Solver::loadInitialFSRFluxes(std::string fname) {
@@ -1828,10 +1837,11 @@ void Solver::loadInitialFSRFluxes(std::string fname) {
 
 
 /**
- * @brief Load scalar fluxes from a binary file
+ * @brief Load scalar fluxes from a binary file.
  * @details The matching source regions between the current calculation and
  *          those in the loaded file are determined by comparing centroids
- * @param assign_k_eff Whether to set k-eff to that loaded in the binary file
+ * @param fname The file containing the scalar fluxes
+ * @param assign_k_eff Whether to set k-eff to the one loaded in the binary file
  * @param tolerance The width of the region in which to search for the matching
  *        centroid
  */
@@ -1850,7 +1860,7 @@ void Solver::loadFSRFluxes(std::string fname, bool assign_k_eff,
       filename += "_" + str;
     }
   }
-  
+
   /* Load the FSR fluxes file */
   FILE* in;
   in = fopen(filename.c_str(), "r");
@@ -1869,7 +1879,7 @@ void Solver::loadFSRFluxes(std::string fname, bool assign_k_eff,
   /* Read number of energy groups */
   int num_groups;
   ret = fread(&num_groups, sizeof(int), 1, in);
-  
+
   /* Read number of energy groups */
   long num_FSRs;
   ret = fread(&num_FSRs, sizeof(long), 1, in);
@@ -1934,7 +1944,7 @@ void Solver::loadFSRFluxes(std::string fname, bool assign_k_eff,
       hashed_lookup.insert(std::make_pair(index, std::vector<long>()));
     hashed_lookup[index].push_back(r);
   }
-  
+
   /* Generate centroids if they have not been generated yet */
   double max_centroid_error = 0.0;
   if (!_geometry->containsFSRCentroids()) 
@@ -1950,19 +1960,19 @@ void Solver::loadFSRFluxes(std::string fname, bool assign_k_eff,
     int cell_xyz[3];
     for (int i=0; i < 3; i++)
       cell_xyz[i] = centroid_xyz[i] / tolerance;
-    
+
     /* Look at all cell combinations */
     double min_dist = std::numeric_limits<double>::max();
     long load_fsr = -1;
     for (int dx=-1; dx <= 1; dx++) {
       for (int dy=-1; dy <= 1; dy++) {
         for (int dz=-1; dz <= 1; dz++) {
-          
+
           int new_cell_xyz[3];
           int d[3] = {dx, dy, dz};
           for (int i=0; i < 3; i++)
             new_cell_xyz[i] = cell_xyz[i] + d[i];
-          
+
           /* Make sure index is within origin min/max bounds */
           for (int i=0; i < 3; i++) {
             if (new_cell_xyz[i] > max_ind[i])
@@ -1991,7 +2001,7 @@ void Solver::loadFSRFluxes(std::string fname, bool assign_k_eff,
         }
       }
     }
-    
+
     /* Check against maximum centroid mismatch */
     if (min_dist > max_centroid_error)
       max_centroid_error = min_dist;
@@ -2023,7 +2033,7 @@ void Solver::loadFSRFluxes(std::string fname, bool assign_k_eff,
 
 
 /**
- * @brief A function that prints a summary of the input parameters
+ * @brief A function that prints a summary of the input parameters.
  */
 void Solver::printInputParamsSummary() {
 
@@ -2043,12 +2053,12 @@ void Solver::printInputParamsSummary() {
 
   /* Print source type */
   log_printf(NORMAL, "Source type = %s", _source_type.c_str());
-  
+
   /* Print MOC stabilization */
   if (_stabilize_transport) {
 
     std::string stabilization_str;
-    
+
     if (_stabilization_type == DIAGONAL)
       stabilization_str = "DIAGONAL";
     else if (_stabilization_type == YAMAMOTO)

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -36,7 +36,7 @@
 /** Indexing macro for the reference scalar flux in each FSR and energy group */
 #define reference_flux(r,e) (reference_flux[(r)*_num_groups + (e)])
 
-/** Indexing macro for the stabiilizing flux in each FSR and energy group */
+/** Indexing macro for the stabilizing flux in each FSR and energy group */
 #define _stabilizing_flux(r,e) (_stabilizing_flux[(r)*_num_groups + (e)])
 
 /** Indexing macro for the total source divided by the total cross-section
@@ -98,7 +98,7 @@ enum residualType {
 
 /**
  * @enum stabilizationType
- * @brief The type of stabilization to use on source iteration
+ * @brief The type of stabilization to use on source iteration.
  */
 enum stabilizationType {
 
@@ -194,27 +194,27 @@ protected:
 
   /** Boolean for whether to print verbose iteration reports */
   bool _verbose;
-  
+
   /** Boolean for whether to perform a spectrum calculation for the initial 
    *  flux guess */
   bool _calculate_initial_spectrum;
-  
+
   /** Convergence threshold for the initial spectrum calculation */
   double _initial_spectrum_thresh;
-  
+
   /** Boolean for whether to load initial FSR flux profile from file */
   bool _load_initial_FSR_fluxes;
-  
+
   /** Boolean for whether to calculate residuals from reference flux */
   bool _calculate_residuals_by_reference;
 
   /** File to load initial FSR fluxes from */
   std::string _initial_FSR_fluxes_file;
-  
+
   /** File to load reference FSR fluxes from */
   std::string _reference_file;
 
-  /** The log level for outputting cross-section inconsitencies */
+  /** The log level for outputting cross-section inconsistencies */
   logLevel _xs_log_level;
 
   /** Determines the type of track segmentation to use for 3D MOC */
@@ -244,10 +244,10 @@ protected:
 
   /** The old scalar flux for each energy group in each FSR */
   FP_PRECISION* _old_scalar_flux;
-  
+
   /** The reference scalar flux for each energy group in each FSR */
   FP_PRECISION* _reference_flux;
-  
+
   /** The stabilizing flux for each energy group in each FSR */
   FP_PRECISION* _stabilizing_flux;
 
@@ -284,7 +284,7 @@ protected:
 
   /** The factor applied to the source iteration stabilization */
   double _stabilization_factor;
-  
+
   /** The type of source iteration stabilization */
   stabilizationType _stabilization_type;
 

--- a/src/Surface.cpp
+++ b/src/Surface.cpp
@@ -10,8 +10,8 @@ static int auto_id = DEFAULT_INIT_ID;
  *          OpenMOC input files. The method makes use of a static surface
  *          ID which is incremented each time the method is called to enable
  *          unique generation of monotonically increasing IDs. The method's
- *          first ID begins at 10000. Hence, user-defined surface IDs greater
- *          than or equal to 10000 are prohibited.
+ *          first ID begins at 10,000. Hence, user-defined surface IDs greater
+ *          than or equal to 10,000 are prohibited.
  */
 int surface_id() {
   int id = auto_id;
@@ -21,7 +21,7 @@ int surface_id() {
 
 
 /**
- * @brief Resets the auto-generated unique Surface ID counter to 10000.
+ * @brief Resets the auto-generated unique Surface ID counter to 10,000.
  */
 void reset_surface_id() {
   auto_id = DEFAULT_INIT_ID;
@@ -111,7 +111,7 @@ int Surface::getId() const {
 
 
 /**
- * @brief Return the user-defined name of the Surface
+ * @brief Return the user-defined name of the Surface.
  * @return the Surface name
  */
 char* Surface::getName() const {
@@ -130,8 +130,8 @@ surfaceType Surface::getSurfaceType() {
 
 /**
  * @brief Returns the type of boundary conditions for this Surface (REFLECTIVE,
- *        VACUUM or BOUNDARY_NONE)
- * @return the type of boundary condition type for this Surface
+ *        VACUUM or BOUNDARY_NONE).
+ * @return the boundary condition type for this Surface
  */
 boundaryType Surface::getBoundaryType() {
   return _boundary_type;
@@ -140,7 +140,7 @@ boundaryType Surface::getBoundaryType() {
 
 /**
  * @brief Returns the minimum coordinate in the axis direction of the
- *        surface
+ *        surface.
  * @param axis The axis of interest (0 = x, 1 = y, 2 = z)
  * @param halfspace the halfspace to consider
  * @return the minimum coordinate in the axis direction
@@ -161,7 +161,7 @@ double Surface::getMin(int axis, int halfspace) {
 
 /**
  * @brief Returns the maximum coordinate in the axis direction of the
- *        surface
+ *        surface.
  * @param axis The axis of interest (0 = x, 1 = y, 2 = z)
  * @param halfspace the halfspace to consider
  * @return the maximum coordinate in the axis direction
@@ -181,7 +181,7 @@ double Surface::getMax(int axis, int halfspace) {
 
 
 /**
- * @brief Sets the name of the Surface
+ * @brief Sets the name of the Surface.
  * @param name the Surface name string
  */
 void Surface::setName(const char* name) {
@@ -223,7 +223,7 @@ void Surface::addNeighborCell(int halfspace, Cell* cell) {
   /* Get pointer to vector of neighbor Cells for this halfspace */
   std::vector<Cell*>* neighbors = _neighbors[halfspace];
 
-  /* Add the neighbor Cell if the collection does not already contain it*/
+  /* Add the neighbor Cell if the collection does not already contain it */
   if (std::find(neighbors->begin(), neighbors->end(), cell) == neighbors->end())
     neighbors->push_back(cell);
 
@@ -343,7 +343,7 @@ Plane::Plane(const double A, const double B,
 
 
 /**
- * @brief Returns the minimum x value of -INFINITY
+ * @brief Returns the minimum x value of -INFINITY.
  * @param halfspace the halfspace of the Surface to consider
  * @return the minimum x value of -INFINITY
  */
@@ -363,7 +363,7 @@ double Plane::getMaxX(int halfspace) {
 
 
 /**
- * @brief Returns the minimum y value of -INFINITY
+ * @brief Returns the minimum y value of -INFINITY.
  * @param halfspace the halfspace of the Surface to consider
  * @return the minimum y value of -INFINITY
  */
@@ -383,7 +383,7 @@ double Plane::getMaxY(int halfspace) {
 
 
 /**
- * @brief Returns the minimum z value of -INFINITY
+ * @brief Returns the minimum z value of -INFINITY.
  * @param halfspace the halfspace of the Surface to consider
  * @return the minimum z value of -INFINITY
  */
@@ -644,7 +644,7 @@ double YPlane::getMaxY(int halfspace) {
 
 
 /**
- * @brief Converts this yplane's attributes to a character array
+ * @brief Converts this YPlane's attributes to a character array.
  * @details The character array returned conatins the type of Plane (ie,
  *          YPLANE) and the A, B, and C coefficients in the quadratic
  *          Surface equation and the location of the Plane on the y-axis.
@@ -748,7 +748,7 @@ std::string ZPlane::toString() {
 
 
 /**
- * @brief constructor.
+ * @brief Constructor.
  * @param x the x-coordinte of the ZCylinder center
  * @param y the y-coordinate of the ZCylinder center
  * @param radius the radius of the ZCylinder
@@ -862,8 +862,8 @@ double ZCylinder::getMaxZ(int halfspace) {
 
 
 /**
- * @brief Finds the intersection Point with this zcylinder from a given Point and
- *        trajectory defined by an azim/polar angles (0, 1, or 2 points).
+ * @brief Finds the intersection Point with this zcylinder from a given Point
+ *        and trajectory defined by an azim/polar angles (0, 1, or 2 points).
  * @param point pointer to the Point of interest
  * @param azim the azimuthal angle defining the trajectory in radians
  * @param polar the polar angle defining the trajectory in radians
@@ -1092,7 +1092,7 @@ int ZCylinder::intersection(Point* point, double azim, double polar, Point* poin
 
 /**
  * @brief Converts this ZCylinder's attributes to a character array.
- * @details The character array returned conatins the type of Plane (ie,
+ * @details The character array returned contains the type of Plane (ie,
  *          ZCYLINDER) and the A, B, C, D and E coefficients in the
  *          quadratic Surface equation.
  * @return a character array of this ZCylinder's attributes

--- a/src/Surface.h
+++ b/src/Surface.h
@@ -106,7 +106,7 @@ public:
 
   /**
    * @brief Returns the minimum coordinate in the axis direction of the
-   *        space defined by halfspace and this surface 
+   *        space defined by halfspace and this surface.
    * @param axis The axis of interest (0 = x, 1 = y, 2 = z)
    * @param halfspace the halfspace to consider
    * @return the minimum coordinate in the axis direction
@@ -115,8 +115,8 @@ public:
 
 
   /**
- * @brief Returns the maximum coordinate in the axis direction of the
-   *      space defined by halfspace and this surface 
+   * @brief Returns the maximum coordinate in the axis direction of the
+   *        space defined by halfspace and this surface.
    * @param axis The axis of interest (0 = x, 1 = y, 2 = z)
    * @param halfspace the halfspace to consider
    * @return the maximum coordinate in the axis direction
@@ -173,7 +173,7 @@ public:
    * @brief Evaluate a Point using the Surface's potential equation.
    * @details This method returns the values \f$ f(x,y) \f$ for the potential
    *          function \f$f\f$ representing this Surface.
-   * @param point a pointer to the Soint of interest
+   * @param point a pointer to the Point of interest
    * @return the value of Point in the Plane's potential equation.
    */
   virtual double evaluate(const Point* point) const = 0;
@@ -386,7 +386,7 @@ public:
 
 /**
  * @brief Finds the minimum distance to a Surface.
- * @details Finds the miniumum distance to a Surface from a Point with a
+ * @details Finds the minimum distance to a Surface from a Point with a
  *          given trajectory defined by an azim/polar to this Surface. If the
  *          trajectory will not intersect the Surface, returns INFINITY.
  * @param point a pointer to the Point of interest

--- a/src/Timer.h
+++ b/src/Timer.h
@@ -77,7 +77,7 @@ public:
   }
 
   /**
-   * @brief Destructor
+   * @brief Destructor.
    */
   virtual ~Timer() { }
 

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -1,7 +1,7 @@
 #include "Track.h"
 
 
-/*
+/**
  * @brief Constructor initializes an empty Track.
  */
 Track::Track() {
@@ -264,12 +264,12 @@ void Track::setAzimIndex(int index) {
 
 /**
  * @brief Set a Track's link index.
- * @detail In generating 3D tracks, we need to know the tracks
- *         linking this track with both periodic and reflective
- *         boundary conditions. Therefore, we generate a periodic
- *         chain of tracks that extend periodically from the y-min
- *         to the y-max boundary. This is the index of each track in
- *         its' periodic chain.
+ * @details In generating 3D tracks, we need to know the tracks
+ *          linking this track with both periodic and reflective
+ *          boundary conditions. Therefore, we generate a periodic
+ *          chain of tracks that extend periodically from the y-min
+ *          to the y-max boundary. This is the index of each track in
+ *          its' periodic chain.
  * @param index The link index
  */
 void Track::setLinkIndex(int index) {
@@ -288,12 +288,12 @@ int Track::getAzimIndex() {
 
 /**
  * @brief Get a Track's link index.
- * @detail In generating 3D tracks, we need to know the tracks
- *         linking this track with both periodic and reflective
- *         boundary conditions. Therefore, we generate a periodic
- *         chain of tracks that extend periodically from the y-min
- *         to the y-max boundary. This is the index of each track in
- *         its' periodic chain.
+ * @details In generating 3D tracks, we need to know the tracks
+ *          linking this track with both periodic and reflective
+ *          boundary conditions. Therefore, we generate a periodic
+ *          chain of tracks that extend periodically from the y-min
+ *          to the y-max boundary. This is the index of each track in
+ *          its' periodic chain.
  * @return The link index
  */
 int Track::getLinkIndex() {

--- a/src/Track.h
+++ b/src/Track.h
@@ -197,7 +197,7 @@ public:
 
 
 /**
- * @brief Return the Track's unique ID
+ * @brief Return the Track's unique ID.
  * @return the Track's unique ID
  */
 inline int Track::getUid() {
@@ -245,7 +245,7 @@ inline int Track::getNumSegments() {
 }
 
 /**
- * @brief Sets the number of segments in a track
+ * @brief Sets the number of segments in a track.
  * @details This function sets the number of segments in a track. It's purpose
  *          is to be used for 3D tracks with on-the-fly ray tracing where
  *          segments are not explicitly created, but there is a need to know

--- a/src/Track3D.cpp
+++ b/src/Track3D.cpp
@@ -1,7 +1,7 @@
 #include "Track3D.h"
 
 
-/*
+/**
  * @brief Constructor initializes an empty Track3D.
  */
 Track3D::Track3D() : Track() { }
@@ -9,7 +9,7 @@ Track3D::Track3D() : Track() { }
 
 
 /**
- * @brief Destructor clears the Track segments container.
+ * @brief Destructor.
  */
 Track3D::~Track3D() {
 }

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -245,7 +245,7 @@ Track** TrackGenerator::get2DTracks() {
 
 
 /**
- * @breif Calculates and returns the maximum optcial length for any segment
+ * @brief Calculates and returns the maximum optcial length for any segment
  *        in the Geomtry.
  * @details The _max_optical_length value is recomputed, updated, and returned.
  *          This value determines the when segments must be split during ray
@@ -418,9 +418,15 @@ void TrackGenerator::setNumThreads(int num_threads) {
    * CPU grouping */
   std::vector<int> cpus;
   cpus.reserve(num_threads);
+
 #pragma omp parallel for schedule(static)
-  for (int i=0; i<num_threads; i++)
-    cpus.push_back(sched_getcpu());
+  for (int i=0; i<num_threads; i++) {
+#pragma omp critical
+    {
+      cpus.push_back(sched_getcpu());
+    }
+  }
+
   std::stringstream str_cpus;
   for (int i=0; i<cpus.size(); i++)
       str_cpus << cpus.at(i) << " ";
@@ -1583,7 +1589,7 @@ void TrackGenerator::setMaxOpticalLength(FP_PRECISION tau) {
 
 
 /**
- * @breif Sets the maximum number of segments per Track
+ * @brief Sets the maximum number of segments per Track
  * @param max_num_segments the maximum number of segments per Track
  */
 void TrackGenerator::setMaxNumSegments(int max_num_segments) {

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -66,7 +66,7 @@ TrackGenerator::~TrackGenerator() {
 
 
 /**
- * @brief Return the number of tracks for each azimuthal angle
+ * @brief Return the number of tracks for each azimuthal angle.
  * @return the number of tracks for each azimuthal angle
  */
 long* TrackGenerator::getTracksPerAzim() {
@@ -75,7 +75,7 @@ long* TrackGenerator::getTracksPerAzim() {
 
 
 /**
- * @brief Return the number of azimuthal angles in \f$ [0, 2\pi] \f$
+ * @brief Return the number of azimuthal angles in \f$ [0, 2\pi] \f$.
  * @return the number of azimuthal angles in \f$ 2\pi \f$
  */
 int TrackGenerator::getNumAzim() {
@@ -85,7 +85,7 @@ int TrackGenerator::getNumAzim() {
 
 /**
  * @brief Return the track azimuthal spacing (cm).
- * @ditails This will return the user-specified track spacing and NOT the
+ * @details This will return the user-specified track spacing and NOT the
  *          effective track spacing which is computed and used to generate
  *          cyclic tracks.
  * @return the track azimuthal spacing (cm)
@@ -138,7 +138,7 @@ void TrackGenerator::initializeFSRVolumesBuffer() {
 
 
 /**
- * @brief Return the array used to store the FSR volumes
+ * @brief Return the array used to store the FSR volumes.
  * @return _FSR_volumes the FSR volumes array indexed by FSR ID
  */
 FP_PRECISION* TrackGenerator::getFSRVolumesBuffer() {
@@ -245,13 +245,12 @@ Track** TrackGenerator::get2DTracks() {
 
 
 /**
- * @brief Calculates and returns the maximum optcial length for any segment
- *        in the Geomtry.
+ * @brief Calculates and returns the maximum optical length for any segment
+ *        in the Geometry.
  * @details The _max_optical_length value is recomputed, updated, and returned.
- *          This value determines the when segments must be split during ray
+ *          This value determines when segments must be split during ray
  *          tracing.
- * @return _max_optical_length the maximum optical length of any segment in the
- *         Geometry
+ * @return the maximum optical length of any segment in the Geometry
  */
 FP_PRECISION TrackGenerator::getMaxOpticalLength() {
   MaxOpticalLength update_max_optical_length(this);
@@ -261,10 +260,10 @@ FP_PRECISION TrackGenerator::getMaxOpticalLength() {
 
 
 /**
- * @brief Returns the maximum number of segments along a single track
+ * @brief Returns the maximum number of segments along a single track.
  * @details The TrackGenerator::countSegments routine must be called before
  *          this function will return a correct value
- * @return the maximum number of segments
+ * @return the maximum number of segments on a single track
  */
 int TrackGenerator::getMaxNumSegments() {
   return _max_num_segments;
@@ -282,7 +281,7 @@ int TrackGenerator::getNumThreads() {
 
 /**
  * @brief Returns the number of 2D Tracks in the x-direction for a given
- *        azimuthal angle index
+ *        azimuthal angle index.
  * @param azim the azimuthal angle index
  * @return the number of 2D Tracks in the x-direction of the Geometry
  */
@@ -293,7 +292,7 @@ int TrackGenerator::getNumX(int azim) {
 
 /**
  * @brief Returns the number of 2D Tracks in the y-direction for a given
- *        azimuthal angle index
+ *        azimuthal angle index.
  * @param azim the azimuthal angle index
  * @return the number of 2D Tracks in the y-direction of the Geometry
  */
@@ -303,10 +302,10 @@ int TrackGenerator::getNumY(int azim) {
 
 
 /**
- * @brief FSR volumes are coppied to an array input by the user
- * @param out_volumes The array to which FSR volumes are coppied
+ * @brief FSR volumes are copied to an array input by the user.
+ * @param out_volumes The array to which FSR volumes are copied
  * @param num_fsrs The number of FSR volumes to copy. The first num_fsrs
- *        volumes stored in the FSR volumes array are coppied.
+ *        volumes stored in the FSR volumes array are copied.
  */
 void TrackGenerator::exportFSRVolumes(double* out_volumes, int num_fsrs) {
 
@@ -369,7 +368,7 @@ FP_PRECISION TrackGenerator::getFSRVolume(long fsr_id) {
 
 
 /**
- * @brief Returns the z-coord of the radial plane used in 2D calcualtions
+ * @brief Returns the z-coord of the radial plane used in 2D calculations.
  * @return the z-coord of the 2D calculation
  */
 double TrackGenerator::getZCoord() {
@@ -378,7 +377,7 @@ double TrackGenerator::getZCoord() {
 
 
 /**
- * @brief Returns the Quadrature object
+ * @brief Returns the Quadrature object.
  * @return the Quadrature object
  */
 Quadrature* TrackGenerator::getQuadrature() {
@@ -494,7 +493,7 @@ void TrackGenerator::setGeometry(Geometry* geometry) {
 
 
 /**
- * @brief Sets the z-coord of the raidal plane used in 2D calculations
+ * @brief Sets the z-coord of the radial plane used in 2D calculations.
  * @param z_coord the z-coord of the radial plane
  */
 void TrackGenerator::setZCoord(double z_coord) {
@@ -503,7 +502,7 @@ void TrackGenerator::setZCoord(double z_coord) {
 
 
 /**
- * @brief sets the Quadrature used for integrating the MOC equations
+ * @brief Sets the Quadrature used for integrating the MOC equations.
  * @param quadrature a pointer to the Quadrature object used in calculation
  */
 void TrackGenerator::setQuadrature(Quadrature* quadrature) {
@@ -525,8 +524,8 @@ bool TrackGenerator::containsTracks() {
 /**
  * @brief Returns whether or not the TrackGenerator contains segments
  *        for its current number of azimuthal angles, track spacing and
- *        geometry for it's current segmentation type.
- * @return true if the TrackGenerator conatains segments; false otherwise
+ *        geometry for its current segmentation type.
+ * @return true if the TrackGenerator contains segments; false otherwise
  */
 bool TrackGenerator::containsSegments() {
   return _contains_2D_segments;
@@ -691,7 +690,7 @@ void TrackGenerator::retrieve2DSegmentCoords(double* coords, long num_segments) 
 
 /**
  * @brief Checks the boundary conditions for all 2D surfaces for inconsistent
- *        periodic boundary conditions
+ *        periodic boundary conditions.
  */
 void TrackGenerator::checkBoundaryConditions() {
 
@@ -826,8 +825,8 @@ void TrackGenerator::generateTracks() {
 
 
 /**
- * @brief Allocates a new Quadrature with the default Quadrature
- * @details The defualt quadrature for 2D calculations is the TY quadrature
+ * @brief Allocates a new Quadrature with the default Quadrature.
+ * @details The default quadrature for 2D calculations is the TY quadrature
  */
 void TrackGenerator::initializeDefaultQuadrature() {
 
@@ -842,9 +841,9 @@ void TrackGenerator::initializeDefaultQuadrature() {
 
 
 /**
- * @brief calcualtes the least common multiple of two numbers a and b
+ * @brief Calculates the least common multiple of two numbers a and b
  * @param first number a
- * @param second nuber b (order does not matter)
+ * @param second number b (order does not matter)
  * @return the least common multiple of a and b
  */
 double TrackGenerator::leastCommonMultiple(double a, double b) {
@@ -877,7 +876,7 @@ double TrackGenerator::leastCommonMultiple(double a, double b) {
 
 
 /**
- * @brief Returns the type of ray tracing used for segment formation
+ * @brief Returns the type of ray tracing used for segment formation.
  * @return the segmentation type
  */
 segmentationType TrackGenerator::getSegmentFormation() {
@@ -1023,7 +1022,7 @@ void TrackGenerator::initializeTracks() {
 
 
 /**
- * @brief Initializes 2D Track reflections
+ * @brief Initializes 2D Track reflections.
  * @details This method computes the connecting Tracks for all 2D Tracks in
  *          the TrackGenerator analytically, handling both reflective and
  *          periodic boundaries.
@@ -1222,7 +1221,7 @@ void TrackGenerator::initializeTrackFileDirectory() {
 
 
 /**
- * @brief Returns the filename for writing tracking data
+ * @brief Returns the filename for writing tracking data.
  */
 std::string TrackGenerator::getTestFilename(std::string directory) {
 
@@ -1246,7 +1245,7 @@ std::string TrackGenerator::getTestFilename(std::string directory) {
 
 
 /**
- * @brief Updates whether the TrackGenerator contains segments
+ * @brief Updates whether the TrackGenerator contains segments.
  * @param contains_segments whether the TrackGenerator contains segments
  */
 void TrackGenerator::setContainsSegments(bool contains_segments) {
@@ -1289,7 +1288,7 @@ void TrackGenerator::dumpSegmentsToFile() {
   dump_segments.setOutputFile(out);
   if (_segment_formation == EXPLICIT_2D || _segment_formation == EXPLICIT_3D)
     dump_segments.execute();
-  
+
   /* Get FSR vector maps */
   ParallelHashMap<std::string, fsr_data*>& FSR_keys_map =
       _geometry->getFSRKeysMap();
@@ -1396,7 +1395,8 @@ bool TrackGenerator::readSegmentsFromFile() {
   /* Import Geometry metadata from the Track file */
   ret = _geometry->twiddleRead(&string_length, sizeof(int), 1, in);
   char* geometry_to_string = new char[string_length];
-  ret = _geometry->twiddleRead(geometry_to_string, sizeof(char)*string_length, 1, in);
+  ret = _geometry->twiddleRead(geometry_to_string, sizeof(char)*string_length,
+                               1, in);
 
   /* Check if our Geometry is exactly the same as the Geometry in the
    * Track file for this number of azimuthal angles and track spacing */
@@ -1580,7 +1580,7 @@ void TrackGenerator::generateFSRCentroids(FP_PRECISION* FSR_volumes) {
 
 /**
  * @brief Sets the max optical path length of 3D segments for use in
- *        on-the-fly computation
+ *        on-the-fly computation.
  * @param tau maximum optical path length
  */
 void TrackGenerator::setMaxOpticalLength(FP_PRECISION tau) {
@@ -1589,7 +1589,7 @@ void TrackGenerator::setMaxOpticalLength(FP_PRECISION tau) {
 
 
 /**
- * @brief Sets the maximum number of segments per Track
+ * @brief Sets the maximum number of segments per Track.
  * @param max_num_segments the maximum number of segments per Track
  */
 void TrackGenerator::setMaxNumSegments(int max_num_segments) {
@@ -1599,7 +1599,7 @@ void TrackGenerator::setMaxNumSegments(int max_num_segments) {
 
 /**
  * @brief Retrieves the max optical path length of 3D segments for use in
- *        on-the-fly computation
+ *        on-the-fly computation.
  * @return maximum optical path length
  */
 FP_PRECISION TrackGenerator::retrieveMaxOpticalLength() {
@@ -1608,7 +1608,7 @@ FP_PRECISION TrackGenerator::retrieveMaxOpticalLength() {
 
 
 /**
- * @brief Counts the number of segments for each Track in the Geomtery
+ * @brief Counts the number of segments for each Track in the Geometry.
  * @details All segments are subject to the max optical path length to
  *          determine the number of segments for each track as well as the
  *          maximum number of segments per Track in the Geometry. For
@@ -1620,7 +1620,7 @@ void TrackGenerator::countSegments() {
   std::string msg = "Counting segments";
   Progress progress(_num_2D_tracks, msg);
 
-  /* Count the number of segments on each track and update the maximium */
+  /* Count the number of segments on each track and update the maximum */
   SegmentCounter counter(this);
   counter.execute();
 
@@ -1631,7 +1631,7 @@ void TrackGenerator::countSegments() {
 
 
 /**
- * @brief Creates a Track array by increasing uid
+ * @brief Creates a Track array by increasing uid.
  * @details An array is created which indexes Tracks by increasing uid.
  *          Parallel groups are also initialized -- groups of Tracks that can
  *          be computed in parallel without the potential of overwriting
@@ -1664,7 +1664,7 @@ void TrackGenerator::initializeTracksArray() {
 
 
 /**
- * @brief returns whether periodic boundaries are present in Track generation
+ * @brief Returns whether periodic boundaries are present in Track generation.
  * @return a boolean value - true if periodic; false otherwise
  */
 bool TrackGenerator::getPeriodic() {
@@ -1673,9 +1673,9 @@ bool TrackGenerator::getPeriodic() {
 
 
 /**
- * @brief Sets a flag to record all segment information in the tracking file
- * @param A boolean value to determine whether or not to record segment
- *        information in the tracking file: true to record, false not to record
+ * @brief Sets a flag to record all segment information in the tracking file.
+ * @param dump_segments whether or not to record segment information in the 
+ *        tracking file: true to record, false not to record
  */
 void TrackGenerator::setDumpSegments(bool dump_segments) {
   _dump_segments = dump_segments;
@@ -1683,7 +1683,7 @@ void TrackGenerator::setDumpSegments(bool dump_segments) {
 
 
 /**
- * @brief Resets the TrackGenerator to not contain tracks or segments
+ * @brief Resets the TrackGenerator to not contain tracks or segments.
  */
 void TrackGenerator::resetStatus() {
   _contains_2D_tracks = false;
@@ -1694,7 +1694,7 @@ void TrackGenerator::resetStatus() {
 
 
 /**
- * @brief Allocates memory for temporary segment storage if necessary
+ * @brief Allocates memory for temporary segment storage if necessary.
  * @details Temporary segments are not allocated for 2D calculations
  */
 void TrackGenerator::allocateTemporarySegments() {}
@@ -1702,7 +1702,7 @@ void TrackGenerator::allocateTemporarySegments() {}
 
 /**
  * @brief Get the id of a 2D Track based on its azimuthal angle and index in the
- *        azimuthal stack
+ *        azimuthal stack.
  * @param a azimuthal angle of the Track
  * @param x index in azimuthal stack
  * @return Track unique id

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -817,10 +817,8 @@ void TrackGenerator::generateTracks() {
 #endif
   _timer->stopTimer();
   _timer->recordSplit("Track Generation Time");
-  double gen_time = _timer->getSplit("Track Generation Time");
-  std::string msg_string = "Total Track Generation & Segmentation Time";
-  msg_string.resize(53, '.');
-  log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), gen_time);
+
+  printTimerReport(true);
 }
 
 
@@ -1716,4 +1714,22 @@ int TrackGenerator::get2DTrackID(int a, int x) {
 
   uid += x;
   return uid;
+}
+
+
+/**
+ * @brief Print the track generation timer report.
+ * @param mpi_reduce whether to reduce timer across MPI processes (only once!)
+ */
+void TrackGenerator::printTimerReport(bool mpi_reduce) {
+
+#ifdef MPIx
+  if (_geometry->isDomainDecomposed() && mpi_reduce)
+    _timer->reduceTimer(_geometry->getMPICart());
+#endif
+
+  double gen_time = _timer->getSplit("Track Generation Time");
+  std::string msg_string = "Total Track Generation & Segmentation Time";
+  msg_string.resize(53, '.');
+  log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), gen_time);
 }

--- a/src/TrackGenerator.h
+++ b/src/TrackGenerator.h
@@ -113,7 +113,7 @@ protected:
 
   /** A buffer holding the computed FSR volumes */
   FP_PRECISION* _FSR_volumes;
-  
+
   /** A timer to record timing data for track generation */
   Timer* _timer;
 
@@ -200,6 +200,7 @@ public:
   void initializeTrackFileDirectory();
   void initializeTracksArray();
   virtual void checkBoundaryConditions();
+  void printTimerReport(bool mpi_reduce);
 };
 
 

--- a/src/TrackGenerator3D.cpp
+++ b/src/TrackGenerator3D.cpp
@@ -877,7 +877,7 @@ void TrackGenerator3D::initializeTracks() {
 
 
 /**
- * @brief Initializes 2D Track chains array
+ * @brief Initializes 2D Track chains array.
  * @details This method creates an array of 2D Tracks ordered by azimuthal
  *          angle, x index, and link index.
  */
@@ -964,7 +964,7 @@ void TrackGenerator3D::getCycleTrackData(TrackChainIndexes* tcis,
 
 /**
  * @brief Compute the starting coordinates of a 3D chain track, and the link 
-          number of the 2D track where its start point reside on
+          number of the 2D track where its start point reside on.
  * @param tci the track chain index of a chain track
  * @param track_3D the chain track
  * @return the link number of the 2D track where the track_3D start point 
@@ -1058,7 +1058,7 @@ int TrackGenerator3D::getFirst2DTrackLinkIndex(TrackChainIndexes* tci,
 
 /**
  * @brief A 3D Track is decomposed by intersections with x and y boundaries of 
- *        z-stacks
+ *        z-stacks.
  * @details A 3D Track which initially neglects intersections with x and y
  *          boundaries is split into multiple tracks by finding those
  *          x and y intersections. If create_arrays is True, the number of 
@@ -1146,7 +1146,7 @@ void TrackGenerator3D::set3DTrackData(TrackChainIndexes* tci,
       break;
 
     /* If the Z boundary or last link or the desired link has been reached,
-     * exit. tci->_link appoints the desired track*/
+     * exit. tci->_link appoints the desired track */
     if (dl_z < dl_xy || track_2D->getXYIndex() >= _num_y[tci->_azim] ||
         tci->_link == link - first_link)
       end_of_chain = true;
@@ -1350,7 +1350,7 @@ void TrackGenerator3D::retrieveSingle3DTrackCoords(double coords[6],
 
 
 /**
- * @brief allocates memory for 3D Tracks
+ * @brief Allocates memory for 3D Tracks.
  * @details Before calling this function, the number of tracks per z-stack
  *          should be known and initialized in the _tracks_per_stack 3D array
  */
@@ -1359,6 +1359,7 @@ void TrackGenerator3D::create3DTracksArrays() {
   long num_tracks = 0;
   long tracks_per_azim = 0;
 
+  /* Count number of tracks : total, per azimuthal and polar angle */
   for (int a=0; a < _num_azim/2; a++) {
     tracks_per_azim = 0;
     for (int i=0; i < _num_x[a] + _num_y[a]; i++) {
@@ -1374,6 +1375,7 @@ void TrackGenerator3D::create3DTracksArrays() {
 
   log_printf(NORMAL, "Total number of Tracks = %ld", num_tracks);
 
+  /* Allocate tracks arrays if using explicit ray tracing */
   if (_segment_formation == EXPLICIT_3D) {
     _tracks_3D = new Track3D***[_num_azim/2];
     for (int a=0; a < _num_azim/2; a++) {
@@ -1398,7 +1400,7 @@ void TrackGenerator3D::create3DTracksArrays() {
 
 
 /**
- * @brief Returns the 3D Track ID based on its indexes
+ * @brief Returns the 3D Track ID based on its indexes.
  * @param tsi The indexes of the Track of interest (azimuthal, xy track, polar,
  *        and z stack)
  */
@@ -1408,7 +1410,7 @@ long TrackGenerator3D::get3DTrackID(TrackStackIndexes* tsi) {
 
 
 /**
- * @brief Allocates a new Quadrature with the default Quadrature
+ * @brief Allocates a new Quadrature with the default Quadrature.
  * @details The default quadrature for 3D calculations is equal weight
  */
 void TrackGenerator3D::initializeDefaultQuadrature() {
@@ -1424,7 +1426,7 @@ void TrackGenerator3D::initializeDefaultQuadrature() {
 
 
 /**
- * @brief Returns the filename for writing tracking data
+ * @brief Returns the filename for writing tracking data.
  */
 std::string TrackGenerator3D::getTestFilename(std::string directory) {
 
@@ -1482,7 +1484,7 @@ std::string TrackGenerator3D::getTestFilename(std::string directory) {
 
 
 /**
- * @brief Updates whether the TrackGenerator contains segments
+ * @brief Updates whether the TrackGenerator contains segments.
  * @param contains_segments whether the TrackGenerator contains segments
  */
 void TrackGenerator3D::setContainsSegments(bool contains_segments) {
@@ -1495,7 +1497,7 @@ void TrackGenerator3D::setContainsSegments(bool contains_segments) {
 
 /**
  * @brief Checks the boundary conditions for all 3D surfaces for inconsistent
- *        periodic boundary conditions
+ *        periodic boundary conditions.
  */
 void TrackGenerator3D::checkBoundaryConditions() {
 
@@ -1525,13 +1527,13 @@ void TrackGenerator3D::checkBoundaryConditions() {
 
 
 /**
- * @brief Allocates memory for temporary segment storage if necessary
+ * @brief Allocates memory for temporary segment storage if necessary.
  * @details New memory is only allocated if _max_num_segments exceeds
  *          _num_seg_matrix_columns (the maximum when the segments were allocated)
  */
 void TrackGenerator3D::allocateTemporarySegments() {
 
-  /* Check if a risize is unnecessary */
+  /* Check if a resize is unnecessary */
   if (_max_num_segments <= _num_seg_matrix_columns)
     return;
 
@@ -1569,7 +1571,7 @@ void TrackGenerator3D::allocateTemporarySegments() {
 
 
 /**
- * @brief Allocates memory for temporary Track storage if necessary
+ * @brief Allocates memory for temporary Track storage if necessary.
  */
 void TrackGenerator3D::allocateTemporaryTracks() {
 
@@ -1603,7 +1605,7 @@ void TrackGenerator3D::allocateTemporaryTracks() {
 
 
 /**
- * @brief Resets the TrackGenerator to not contain tracks or segments
+ * @brief Resets the TrackGenerator to not contain tracks or segments.
  */
 void TrackGenerator3D::resetStatus() {
   TrackGenerator::resetStatus();
@@ -1639,7 +1641,7 @@ bool TrackGenerator3D::containsSegments() {
 
 /**
  * @brief Updates the provided Track with the correct information based on the
- *        Track indexes
+ *        Track indexes.
  * @param track The 3D Track whose information is updated
  * @param tsi The indexes of the 3D Track
  */
@@ -1705,7 +1707,7 @@ Track3D**** TrackGenerator3D::get3DTracks() {
 
 
 /**
- * @brief Converts TrackStackIndexes to TrackChainIndexes
+ * @brief Converts TrackStackIndexes to TrackChainIndexes.
  * @param tsi The TrackStackIndexes of the 3D Track
  * @param tci The TrackChainIndexes of the 3D Track to be updated
  */
@@ -1722,7 +1724,7 @@ void TrackGenerator3D::convertTSItoTCI(TrackStackIndexes* tsi,
 
 
 /**
- * @brief Converts TrackChainIndexes to TrackStackIndexes
+ * @brief Converts TrackChainIndexes to TrackStackIndexes.
  * @param tci The TrackChainIndexes of the 3D Track
  * @param tsi The TrackStackIndexes of the 3D Track to be updated
  */
@@ -1739,7 +1741,7 @@ void TrackGenerator3D::convertTCItoTSI(TrackChainIndexes* tci,
 
 
 /**
- * @brief Returns the index into the chain based on chain indexes
+ * @brief Returns the index into the chain based on chain indexes.
  * @param tci The chain indexes
  * @return the index into the 3D z-stack
  */
@@ -1750,7 +1752,7 @@ int TrackGenerator3D::getLinkIndex(TrackChainIndexes* tci) {
 
 
 /**
- * @brief Updates the index into the 3D chain based on chain and stack indexes
+ * @brief Updates the index into the 3D chain based on chain and stack indexes.
  * @param tci The chain indexes to be updated
  * @param tsi The stack indexes
  */
@@ -1764,7 +1766,7 @@ void TrackGenerator3D::setLinkIndex(TrackChainIndexes* tci,
 
 
 /**
- * @brief Calculates the number of Tracks in the l-z traversal
+ * @brief Calculates the number of Tracks in the l-z traversal.
  * @param tci The chain indexes
  * @return the number of Tracks in the l-z traversal
  */
@@ -1804,7 +1806,7 @@ int TrackGenerator3D::getNum3DTrackChainLinks(TrackChainIndexes* tci) {
 
 
 /**
- * @brief Fills the provided 3D Track with its linking information
+ * @brief Fills the provided 3D Track with its linking information.
  * @param tsi The stack indexes
  * @param tci The chain indexes
  * @param tci outgoing A boolean indicating the direction of the Track
@@ -2325,7 +2327,7 @@ void TrackGenerator3D::setLinkingTracks(TrackStackIndexes* tsi,
 
 
 /**
- * @brief Updates stack indexes to reflect those from the given Track ID
+ * @brief Updates stack indexes to reflect those from the given Track ID.
  * @param id The 3D Track ID
  * @param tsi The stack indexes to be updated
  */
@@ -2379,21 +2381,21 @@ void TrackGenerator3D::writeExtrudedFSRInfo(FILE* out) {
         _geometry->getExtrudedFSRKeysMap();
     std::string* extruded_fsr_key_list = extruded_FSR_keys_map.keys();
     ExtrudedFSR** extruded_fsr_list = extruded_FSR_keys_map.values();
-    
+
     /* Write number of extruded FSRs */
     int num_extruded_FSRs = extruded_FSR_keys_map.size();
     fwrite(&num_extruded_FSRs, sizeof(int), 1, out);
 
     /* Write extruded FSR data */
     for (int i=0; i < num_extruded_FSRs; i++) {
-      
+
       std::string key = extruded_fsr_key_list[i];
       int string_length = key.length() + 1;
       fwrite(&string_length, sizeof(int), 1, out);
       fwrite(key.c_str(), sizeof(char)*string_length, 1, out);
 
       ExtrudedFSR* extruded_fsr = extruded_fsr_list[i];
-      
+
       int extruded_fsr_id = extruded_fsr->_fsr_id;
       fwrite(&extruded_fsr_id, sizeof(int), 1, out);
  
@@ -2403,13 +2405,13 @@ void TrackGenerator3D::writeExtrudedFSRInfo(FILE* out) {
       fwrite(&x, sizeof(double), 1, out);
       fwrite(&y, sizeof(double), 1, out);
       fwrite(&z, sizeof(double), 1, out);
-      
+
       int num_fsrs = extruded_fsr->_num_fsrs;
       fwrite(&num_fsrs, sizeof(int), 1, out);
-     
+
       double init_mesh_val = extruded_fsr->_mesh[0];
       fwrite(&init_mesh_val, sizeof(double), 1, out);
-      
+
       for (int j=0; j < num_fsrs; j++) {
         long fsr_id = extruded_fsr->_fsr_ids[j];
         fwrite(&fsr_id, sizeof(long), 1, out);
@@ -2417,7 +2419,7 @@ void TrackGenerator3D::writeExtrudedFSRInfo(FILE* out) {
         fwrite(&mesh_val, sizeof(double), 1, out);
       }
     }
-    
+
     /* Delete extruded FSR key and value lists */
     delete [] extruded_fsr_key_list;
     delete [] extruded_fsr_list;
@@ -2441,7 +2443,7 @@ void TrackGenerator3D::writeExtrudedFSRInfo(FILE* out) {
  * @param in file to read from
  */
 void TrackGenerator3D::readExtrudedFSRInfo(FILE* in) {
-  
+
   /* Module to read track info */
   ReadSegments read_segments(this);
   read_segments.setInputFile(in);
@@ -2451,7 +2453,7 @@ void TrackGenerator3D::readExtrudedFSRInfo(FILE* in) {
         _geometry->getExtrudedFSRKeysMap();
     int num_extruded_FSRs;
     int ret = _geometry->twiddleRead(&num_extruded_FSRs, sizeof(int), 1, in);
-    
+
     /* Resize for the number of extruded FSRs */
     std::vector<ExtrudedFSR*>& extruded_FSR_lookup = 
         _geometry->getExtrudedFSRLookup();
@@ -2460,7 +2462,7 @@ void TrackGenerator3D::readExtrudedFSRInfo(FILE* in) {
 
     /* Write extruded FSR data */
     for (int i=0; i < num_extruded_FSRs; i++) {
-      
+
       /* Read the extruded FSR key */
       int string_length;
       ret = _geometry->twiddleRead(&string_length, sizeof(int), 1, in);
@@ -2472,7 +2474,7 @@ void TrackGenerator3D::readExtrudedFSRInfo(FILE* in) {
       /* Create new extruded FSR and add to map */
       ExtrudedFSR* extruded_fsr = new ExtrudedFSR;
       extruded_FSR_keys_map.insert(key, extruded_fsr);
-      
+
       /* Read ID */
       int extruded_fsr_id;
       ret = _geometry->twiddleRead(&extruded_fsr_id, sizeof(int), 1, in);

--- a/src/TrackGenerator3D.cpp
+++ b/src/TrackGenerator3D.cpp
@@ -2325,7 +2325,7 @@ void TrackGenerator3D::setLinkingTracks(TrackStackIndexes* tsi,
 
 
 /**
- * @breif Updates stack indexes to reflect those from the given Track ID
+ * @brief Updates stack indexes to reflect those from the given Track ID
  * @param id The 3D Track ID
  * @param tsi The stack indexes to be updated
  */

--- a/src/TrackGenerator3D.cpp
+++ b/src/TrackGenerator3D.cpp
@@ -3,10 +3,12 @@
 
 
 /**
- * @brief Constructor for the TrackGenerator assigns default values.
+ * @brief Constructor for the TrackGenerator3D assigns default values.
  * @param geometry a pointer to a Geometry object
  * @param num_azim number of azimuthal angles in \f$ [0, 2\pi] \f$
- * @param spacing track spacing (cm)
+ * @param num_polar number of polar angles in \f$ [0, \pi] \f$
+ * @param azim_spacing track azimuthal spacing (cm)
+ * @param z_spacing track axial spacing (cm)
  */
 TrackGenerator3D::TrackGenerator3D(Geometry* geometry, int num_azim,
                                    int num_polar, double azim_spacing,
@@ -113,8 +115,8 @@ TrackGenerator3D::~TrackGenerator3D() {
 
 
 /**
- * @brief Return the number of polar angles in \f$ [0, \pi] \f$
- * @return the number of polar angles in \f$ \pi \f$
+ * @brief Return the number of polar angles in \f$ [0, \pi] \f$.
+ * @return the number of polar angles in \f$ [0, \pi] \f$
  */
 int TrackGenerator3D::getNumPolar() {
   return _num_polar;
@@ -200,10 +202,10 @@ long TrackGenerator3D::getNum3DSegments() {
 
 /**
  * @brief Returns the spacing between tracks in the axial direction for the
- *        requested azimuthal angle index and polar angle index
+ *        requested azimuthal angle index and polar angle index.
  * @param azim the requested azimuthal angle index
  * @param polar the requested polar angle index
- * @return the requested axial spacing
+ * @return the effective axial spacing
  */
 double TrackGenerator3D::getZSpacing(int azim, int polar) {
   return _dz_eff[azim][polar];
@@ -211,7 +213,7 @@ double TrackGenerator3D::getZSpacing(int azim, int polar) {
 
 
 /**
- * @brief Returns the maximum number of tracks in a single stack
+ * @brief Returns the maximum number of tracks in a single stack.
  * @return the maximum number of tracks
  */
 int TrackGenerator3D::getMaxNumTracksPerStack() {
@@ -220,13 +222,13 @@ int TrackGenerator3D::getMaxNumTracksPerStack() {
 
 
 /**
- * @brief Returns the number of rows in the temporary segment storage matrix
+ * @brief Returns the number of rows in the temporary segment storage matrix.
  * @details For on-the-fly computation, a matrix of temporary segments is
  *          allocated for each thread. This matrix is indexed by the z-stack
  *          index (row) and the segment number (column). For ray tracing by
  *          individual Tracks the number of rows is always one since temporary
  *          segments only need to be stored for one Track at a time.
- * @return _num_seg_matrix_rows the number of rows in the temporary segment storage matrix
+ * @return the number of rows in the temporary segment storage matrix
  */
 int TrackGenerator3D::getNumRows() {
   _num_seg_matrix_rows = 1;
@@ -235,14 +237,13 @@ int TrackGenerator3D::getNumRows() {
 
 
 /**
- * @brief Returns the number of columns in the temporary segment storage matrix
+ * @brief Returns the number of columns in the temporary segment storage matrix.
  * @details For on-the-fly computation, a matrix of temporary segments is
  *          allocated for each thread. This matrix is indexed by the z-stack
  *          index (row) and the segment number (column). The number of columns
  *          is equal to the maximum number of segments per Track at the time of
  *          allocation.
- * @return _num_seg_matrix_columns the number of columns in the temporary segment storage
- *         matrix
+ * @return the number of columns in the temporary segment storage matrix
  */
 int TrackGenerator3D::getNumColumns() {
   return _num_seg_matrix_columns;
@@ -305,7 +306,7 @@ bool TrackGenerator3D::containsTemporaryTracks() {
 
 
 /**
- * @brief Returns a 3D array of the number of 3D Tracks in each z-stack
+ * @brief Returns a 3D array of the number of 3D Tracks in each z-stack.
  * @details A 3D array is returned indexed first by azimuthal angle, second by
  *          2D track number, and third by polar angle. This array describes
  *          the number of tracks in each z-stack.
@@ -318,7 +319,7 @@ int*** TrackGenerator3D::getTracksPerStack() {
 
 /**
  * @brief Returns the number of 3D Tracks in the z-direction for a given
- *        azimuthal angle index and polar angle index
+ *        azimuthal angle index and polar angle index.
  * @param azim the azimuthal angle index
  * @param polar the polar angle index
  * @return the number of 3D Tracks in the z-direction of the Geometry
@@ -330,7 +331,7 @@ int TrackGenerator3D::getNumZ(int azim, int polar) {
 
 /**
  * @brief Returns the number of 3D Tracks in the radial direction for a given
- *        azimuthal angle index and polar angle index
+ *        azimuthal angle index and polar angle index.
  * @param azim the azimuthal angle index
  * @param polar the polar angle index
  * @return the number of 3D Tracks in the radial direction of the Geometry
@@ -374,7 +375,7 @@ void TrackGenerator3D::setDesiredZSpacing(double spacing) {
 
 
 /**
- * @brief sets the type of segmentation used for segment formation
+ * @brief Set the type of segmentation used for segment formation.
  * @param segmentation_type a segmentationType defining the type of
  *        segmentation to be used in segment formation. Options are:
  *          - EXPLICIT_3D: explicit 2D/3D segment formation
@@ -450,9 +451,9 @@ void TrackGenerator3D::setSegmentationZones(std::vector<double> zones) {
 
 
 /**
- * @brief Sets a global z-mesh to use during axial on-the-fly ray tracing
+ * @brief Sets a global z-mesh to use during axial on-the-fly ray tracing.
  * @details In axial on-the-fly ray tracing, normally each extruded FSR
- *          contians a z-mesh. During on-the-fly segmentation when a new
+ *          contains a z-mesh. During on-the-fly segmentation when a new
  *          extruded FSR is entered, a binary search must be conducted to
  *          determine the axial cell. Alternatively, this function can be
  *          called which creates a global z-mesh from the geometry so that
@@ -466,17 +467,16 @@ void TrackGenerator3D::useGlobalZMesh() {
 
 
 /**
- * @brief Provides the global z-mesh and size if available
+ * @brief Provides the global z-mesh and size if available.
  * @details For some cases, a global z-mesh is generated for the Geometry. If
- *          so, a pointer to the assocaited mesh (array) is updated as well as
+ *          so, a pointer to the associated mesh (array) is updated as well as
  *          the number of FSRs in the mesh. If no global z-mesh has been
  *          generated, a null pointer is given to z_mesh and the number of FSRs
  *          is assigned to be zero.
  * @param z_mesh The global z-mesh to be updated
  * @param num_fsrs The number of FSRs in the z-mesh
  */
-void TrackGenerator3D::retrieveGlobalZMesh(double*& z_mesh,
-                                           int& num_fsrs) {
+void TrackGenerator3D::retrieveGlobalZMesh(double*& z_mesh, int& num_fsrs) {
   if (_contains_global_z_mesh) {
     z_mesh = &_global_z_mesh[0];
     num_fsrs = _global_z_mesh.size() - 1;

--- a/src/TrackGenerator3D.h
+++ b/src/TrackGenerator3D.h
@@ -14,7 +14,7 @@
 
 /**
  * @struct TrackChainIndexes
- * @brief A Track chain represents a list of Tracks connected vai periodic BSs
+ * @brief A Track chain represents a list of Tracks connected via periodic BCs
  *        that extend in the l-z plane and this struct contains the azim, x, polar,
  *        lz, and link indexes of a Track.
  */
@@ -103,11 +103,11 @@ private:
     * z-stack (azim, xy, polar) */
   long*** _cum_tracks_per_stack;
 
-  /** An array of the Track UID for the first Track iin each z-stack
+  /** An array of the Track UID for the first Track in each z-stack
     * (azim, xy) */
   long** _cum_tracks_per_xy;
 
-  /** Ann array of the first Track's l-z index for each z-stack */
+  /** An array of the first Track's l-z index for each z-stack */
   int*** _first_lz_of_stack;
 
   /** The total number of Tracks for all azimuthal and polar angles */
@@ -176,7 +176,7 @@ private:
                       bool create_arrays, bool save_tracks);
   double getLStart(TrackChainIndexes* tci);
   int getFirst2DTrackLinkIndex(TrackChainIndexes* tci, Track3D* track_3D);
-  
+
   void writeExtrudedFSRInfo(FILE* out);
   void readExtrudedFSRInfo(FILE* in);
 

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -5,7 +5,7 @@
 
 /**
  * @brief Constructor for MaxOpticalLength calls the TraverseSegments
- *        constructor and sets the max optical path length to zero
+ *        constructor and sets the max optical path length to zero.
  * @param track_generator The TrackGenerator to pull tracking information from
  */
 MaxOpticalLength::MaxOpticalLength(TrackGenerator* track_generator)
@@ -16,7 +16,7 @@ MaxOpticalLength::MaxOpticalLength(TrackGenerator* track_generator)
 
 /**
  * @brief Determines the maximum optical path length for the TrackGenerator
- *        provided during construction
+ *        provided during construction.
  * @details The maximum optical path length is initialized to infinity for
  *          segmentation within the TrackGenerator and then SegmentationKernels
  *          are allocated to store temporary segmnents. Tracks are traversed
@@ -37,7 +37,7 @@ void MaxOpticalLength::execute() {
 
 /**
  * @brief Calculates the optical path length for the provided segments and
- *        updates the maximum optical path length if necessary
+ *        updates the maximum optical path length if necessary.
  * @param track The track associated with the segments
  * @param segments The segments for which the optical path length is calculated
  */
@@ -66,7 +66,7 @@ void MaxOpticalLength::onTrack(Track* track, segment* segments) {
 
 /**
  * @brief Constructor for SegmentCounter calls the TraverseSegments
- *        constructor and sets the max number of segments per Track to zero
+ *        constructor and sets the max number of segments per Track to zero.
  * @param track_generator The TrackGenerator to pull tracking information from
  */
 SegmentCounter::SegmentCounter(TrackGenerator* track_generator)
@@ -120,7 +120,7 @@ long SegmentCounter::getTotalNumSegments() {
 
 /**
  * @brief Updates the maximum number of segments per Track if a Track with a
- *        larger number of segments is observed
+ *        larger number of segments is observed.
  * @param track The Track whose segments are counted
  * @param segments The segments associated with the Track
  */
@@ -138,7 +138,7 @@ void SegmentCounter::onTrack(Track* track, segment* segments) {
 
 /**
  * @brief Constructor for SegmentSplitter calls the TraverseSegments
- *        constructor
+ *        constructor.
  * @param track_generator The TrackGenerator to pull tracking information from
  */
 SegmentSplitter::SegmentSplitter(TrackGenerator* track_generator)
@@ -147,7 +147,7 @@ SegmentSplitter::SegmentSplitter(TrackGenerator* track_generator)
 
 
 /**
- * @brief Splits segments stored explicity along each Track
+ * @brief Splits segments stored explicity along each Track.
  * @details No MOCKernels are initialized for this function.
  */
 void SegmentSplitter::execute() {
@@ -160,7 +160,7 @@ void SegmentSplitter::execute() {
 
 /**
  * @brief Segments for the provided Track are split so that no segment has a
- *        larger optical path length than the maximum optical path length
+ *        larger optical path length than the maximum optical path length.
  * @param track The Track whose segments are potentially split
  * @param segments The segments associated with the Track
  */
@@ -249,7 +249,7 @@ void SegmentSplitter::onTrack(Track* track, segment* segments) {
 
 /**
  * @brief Constructor for SegmentSplitter calls the TraverseSegments
- *        constructor
+ *        constructor.
  * @param track_generator The TrackGenerator to pull tracking information from
  */
 VolumeCalculator::VolumeCalculator(TrackGenerator* track_generator)
@@ -259,7 +259,7 @@ VolumeCalculator::VolumeCalculator(TrackGenerator* track_generator)
 
 /**
  * @brief FSR volumes are calculated and saved in the TrackGenerator's FSR
- *        volumes buffer
+ *        volumes buffer.
  * @details VolumeKernels are created and used to loop over all segments and
  *          tally each segments contribution to FSR volumes.
  */
@@ -274,7 +274,7 @@ void VolumeCalculator::execute() {
 
 /**
  * @brief No functionality is applied for each Track during the execution of
- *        the VolumeCalculator
+ *        the VolumeCalculator.
  * @param track The current Track
  * @param segments The segments associated with the Track
  */
@@ -284,8 +284,8 @@ void VolumeCalculator::onTrack(Track* track, segment* segments) {
 
 /**
  * @brief Constructor for CentroidGenerator calls the TraverseSegments
- *        constructor and imports refernces to both the FSR volumes and FSR
- *        locks arrays
+ *        constructor and imports references to both the FSR volumes and FSR
+ *        locks arrays.
  * @param track_generator The TrackGenerator to pull tracking information from
  */
 CentroidGenerator::CentroidGenerator(TrackGenerator* track_generator)
@@ -318,7 +318,7 @@ CentroidGenerator::~CentroidGenerator() {
 
 
 /**
- * @brief Calculates the centroid of every FSR
+ * @brief Calculates the centroid of every FSR.
  * @details SegmentationKernels are created to temporarily save segments for
  *          on-the-fly methods. Then on each segment, onTrack(...) calculates
  *          the contribution to each FSR centroid and saves the centroids in
@@ -335,7 +335,7 @@ void CentroidGenerator::execute() {
 
 /**
  * @brief Specifies an array to save calculated FSR centroids
- * @brief centroids The array of FSR centroids pointers
+ * @param centroids The array of pointer to FSR centroids
  */
 void CentroidGenerator::setCentroids(Point** centroids) {
   _centroids = centroids;
@@ -343,7 +343,7 @@ void CentroidGenerator::setCentroids(Point** centroids) {
 
 
 /**
- * @brief Centroid contributions are calculated for every segment in the Track
+ * @brief Centroid contributions are calculated for every segment in the Track.
  * @param track The Track associated with the segments
  * @param segments The segments whose contributions are added to the centroids
  */
@@ -535,6 +535,7 @@ void LinearExpansionGenerator::execute() {
         log_printf(INFO, "Unable to form linear source components in "
                    "source region %d. Switching to flat source in that "
                    "source region.", r);
+#pragma omp atomic update
         _num_flat++;
         ilem[r*nc + 0] = 0.0;
         ilem[r*nc + 1] = 0.0;
@@ -587,6 +588,7 @@ void LinearExpansionGenerator::execute() {
         log_printf(INFO, "Unable to form linear source components in "
                    "source region %d. Switching to flat source in that "
                    "source region.", r);
+#pragma omp atomic update
         _num_flat++;
       }
       else {
@@ -596,7 +598,7 @@ void LinearExpansionGenerator::execute() {
       }
     }
   }
-  
+
   /* Copy the source constants to buffer */
   FP_PRECISION* src_constants_buffer = _solver->getSourceConstantsBuffer();
   long size = num_FSRs * _num_coeffs * _num_groups;
@@ -785,7 +787,7 @@ void LinearExpansionGenerator::onTrack(Track* track, segment* segments) {
 
 /**
  * @brief Constructor for TransportSweep calls the TraverseSegments
- *        constructor and initializes the associated CPUSolver to NULL
+ *        constructor and initializes the associated CPUSolver to NULL.
  * @param track_generator The TrackGenerator to pull tracking information from
  */
 TransportSweep::TransportSweep(CPUSolver* cpu_solver)
@@ -809,7 +811,7 @@ TransportSweep::~TransportSweep() {
 
 /**
  * @brief MOC equations are applied to every segment in the TrackGenerator
- * @details SegmntationKernels are allocated to temporarily save segments. Then
+ * @details SegmentationKernels are allocated to temporarily save segments. Then
  *          onTrack(...) applies the MOC equations to each segment and
  *          transfers boundary fluxes for the corresponding Track.
  */
@@ -823,7 +825,7 @@ void TransportSweep::execute() {
 
 
 /**
- * @brief Applies the MOC equations the Track and segments
+ * @brief Applies the MOC equations the Track and segments.
  * @details The MOC equations are applied to each segment, attenuating the
  *          Track's angular flux and tallying FSR contributions. Finally,
  *          Track boundary fluxes are transferred.
@@ -990,7 +992,7 @@ void TransportSweep::onTrack(Track* track, segment* segments) {
 
 /**
  * @brief Constructor for DumpSegments calls the TraverseSegments
- *        constructor and initializes the output FILE to NULL
+ *        constructor and initializes the output FILE to NULL.
  * @param track_generator The TrackGenerator to pull tracking information from
  */
 DumpSegments::DumpSegments(TrackGenerator* track_generator)
@@ -1000,7 +1002,7 @@ DumpSegments::DumpSegments(TrackGenerator* track_generator)
 
 
 /**
- * @brief Writes all tracking information to file
+ * @brief Writes all tracking information to file.
  * @details SegmentationKernels are created to temporarily store segments for
  *          on-the-fly method. For each Track, onTrack(...) writes the tracking
  *          information to file.
@@ -1012,8 +1014,8 @@ void DumpSegments::execute() {
 
 
 /**
- * @brief Sets the file which to write tracking information
- * @param out the file which to write tracking infmormation
+ * @brief Sets the file in which to write tracking information.
+ * @param out the file in which to write tracking information
  */
 void DumpSegments::setOutputFile(FILE* out) {
   _out = out;
@@ -1022,7 +1024,7 @@ void DumpSegments::setOutputFile(FILE* out) {
 
 /**
  * @brief Writes tracking information to file for a Track and associated
- *        segments
+ *        segments.
  * @param track The Track whose information is written to file
  * @param segments The segments associated with the Track whose information is
  *        written to file
@@ -1075,7 +1077,7 @@ void DumpSegments::onTrack(Track* track, segment* segments) {
 
 /**
  * @brief Constructor for ReadSegments calls the TraverseSegments
- *        constructor and initializes the input FILE to NULL
+ *        constructor and initializes the input FILE to NULL.
  * @param track_generator The TrackGenerator to pull tracking information from
  */
 ReadSegments::ReadSegments(TrackGenerator* track_generator)
@@ -1095,7 +1097,7 @@ void ReadSegments::execute() {
 
 
 /**
- * @brief Sets the input file to read in tracking information
+ * @brief Sets the input file to read in tracking information.
  * @param in The input tracking file
  */
 void ReadSegments::setInputFile(FILE* input) {
@@ -1104,7 +1106,7 @@ void ReadSegments::setInputFile(FILE* input) {
 
 
 /**
- * @brief Saves tracking information to the corresponding Track explicity
+ * @brief Saves tracking information to the corresponding Track explicitly.
  * @param track The track for which all tracking information is explicitly
  *        saved (including segments)
  * @param segments The segments associated with the Track
@@ -1255,7 +1257,7 @@ void RecenterSegments::onTrack(Track* track, segment* segments) {
 
 /**
  * @brief Constructor for PrintSegments calls the TraverseSegments
- *        constructor and initializes the output FILE to NULL
+ *        constructor and initializes the output FILE to NULL.
  * @param track_generator The TrackGenerator to pull tracking information from
  */
 PrintSegments::PrintSegments(TrackGenerator* track_generator)
@@ -1265,7 +1267,7 @@ PrintSegments::PrintSegments(TrackGenerator* track_generator)
 
 
 /**
- * @brief Wrties all tracking information to file.
+ * @brief Writes all tracking information to file.
  * @details SegmentationKernels are created to temporarily store segments for
  *          on-the-fly methods. For each Track, onTrack(...) writes the tracking
  *          information to file.

--- a/src/TrackTraversingAlgorithms.h
+++ b/src/TrackTraversingAlgorithms.h
@@ -1,7 +1,7 @@
 /**
  * @file TrackTraversingAlgorithms.h
  * @brief Contains classes which extend the TraverseSegments class to apply
- *        algorithms to Tracks and possibly their segments
+ *        algorithms to Tracks and possibly their segments.
  * @details The classes defined within this file extend the TraverseSegments
  *          class so that they are capable of using the abstract looping
  *          defined in TraverseSegments::loopOverTracks(...). Each class
@@ -33,10 +33,10 @@ class CPULSSolver;
  * @class MaxOpticalLength TrackTraversingAlgorithms.h
  *        "src/TrackTraversingAlgorithms.h"
  * @brief A class used to calculate the maximum optical path length across
- *        all segments in the Geometry
+ *        all segments in the Geometry.
  * @details A MaxOpticalLength allocates SegmentationKernels to temporarily
  *          store segment data. The segments are then traversed afterwards and
- *          the maximium optical path length is calculated.
+ *          the maximum optical path length is calculated.
  */
 class MaxOpticalLength: public TraverseSegments {
 private:
@@ -80,7 +80,7 @@ public:
 /**
  * @class SegmentSplitter TrackTraversingAlgorithms.h
  *        "src/TrackTraversingAlgorithms.h"
- * @brief A class used to split explicit segments along Tracks
+ * @brief A class used to split explicit segments along Tracks.
  * @details A SegmentSplitter imports a maximum optical path length from the
  *          provided TrackGenerator and then ensures all segments have an
  *          optical path length less than the maximum optical path length by
@@ -99,7 +99,7 @@ public:
 /**
  * @class VolumeCalculator TrackTraversingAlgorithms.h
  *        "src/TrackTraversingAlgorithms.h"
- * @brief A class used to calculate FSR volumes
+ * @brief A class used to calculate FSR volumes.
  * @details A VolumeCalculator imports a buffer to store FSR volumes from the
  *          provided TrackGenerator and the allocates VolumeKernels to
  *          calculate and update the volumes in each FSR, implicitly writing
@@ -118,7 +118,7 @@ public:
 /**
  * @class CentroidGenerator TrackTraversingAlgorithms.h
  *        "src/TrackTraversingAlgorithms.h"
- * @brief A class used to calculate the centroids of each FSR
+ * @brief A class used to calculate the centroids of each FSR.
  * @details A CentroidGenerator imports FSR Volumes and associated locks form
  *          the provided TrackGenerator, then centroids are calculated and
  *          stored in the provided buffer by first allocating
@@ -149,7 +149,7 @@ public:
 /**
  * @class LinearExpansionGenerator TrackTraversingAlgorithms.h
  *        "src/TrackTraversingAlgorithms.h"
- * @brief A class used to calculate the linear expansion coeffs of each FSR
+ * @brief A class used to calculate the linear expansion coeffs of each FSR.
  * @details A LinearExpansionGenerator loops through all tracks and computes :
  *          a linear source term that is constant through all iterations, matrix
  *          coefficients in each FSR that help compute the linear source.
@@ -184,7 +184,7 @@ public:
 /**
  * @class TransportSweep TrackTraversingAlgorithms.h
  *        "src/TrackTraversingAlgorithms.h"
- * @brief A class used to apply the MOC transport equations to all segments
+ * @brief A class used to apply the MOC transport equations to all segments.
  * @details TransportSweep imports data from the provided TrackGenerator and
  *          using a provided CPUSolver, it applies the MOC equations to each
  *          segment, tallying the contributions to each FSR. At the end of each
@@ -213,7 +213,7 @@ public:
 /**
  * @class DumpSegments TrackTraversingAlgorithms.h
  *        "src/TrackTraversingAlgorithms.h"
- * @brief A class used to write tracking data to a file
+ * @brief A class used to write tracking data to a file.
  * @details DumpSegments imports Track data from the provided TrackGenerator
  *          and writes the tracking data to the provided file.
  */
@@ -305,7 +305,7 @@ public:
 /**
  * @class PrintSegments TrackTraversingAlgorithms.h
  *        "src/TrackTraversingAlgorithms.h"
- * @brief A class used to write tracking data to a file
+ * @brief A class used to write tracking data to a file.
  * @details PrintSegments imports Track data from the provided TrackGenerator
  *          and writes the tracking data to the provided file.
  */

--- a/src/TraverseSegments.cpp
+++ b/src/TraverseSegments.cpp
@@ -28,7 +28,7 @@ TraverseSegments::~TraverseSegments() {
 
 
 /**
- * @breif Loops over Tracks, applying the provided kernel to all segments and
+ * @brief Loops over Tracks, applying the provided kernel to all segments and
  *        the functionality described in onTrack(...) to all Tracks.
  * @details The segment formation method imported from the TrackGenerator
  *          during construction is used to redirect to the appropriate looping

--- a/src/TraverseSegments.cpp
+++ b/src/TraverseSegments.cpp
@@ -1,7 +1,7 @@
 #include "TraverseSegments.h"
 
 /**
- * @brief Constructor for the TravseSegments class assigns the TrackGenerator
+ * @brief Constructor for the TraverseSegments class assigns the TrackGenerator
  *        and pulls relevant information from it.
  */
 TraverseSegments::TraverseSegments(TrackGenerator* track_generator) {
@@ -21,7 +21,7 @@ TraverseSegments::TraverseSegments(TrackGenerator* track_generator) {
 
 
 /**
- * @brief Destructor for TraverseSegments
+ * @brief Destructor for TraverseSegments.
  */
 TraverseSegments::~TraverseSegments() {
 }
@@ -59,7 +59,7 @@ void TraverseSegments::loopOverTracks(MOCKernel* kernel) {
 
 
 /**
- * @brief Loops over all explicit 2D Tracks
+ * @brief Loops over all explicit 2D Tracks.
  * @details The onTrack(...) function is applied to all 2D Tracks and the
  *          specified kernel is applied to all segments. If NULL is provided
  *          for the kernel, only the onTrack(...) functionality is applied.
@@ -93,7 +93,7 @@ void TraverseSegments::loopOverTracks2D(MOCKernel* kernel) {
 
 
 /**
- * @brief Loops over all explicit 3D Tracks
+ * @brief Loops over all explicit 3D Tracks.
  * @details The onTrack(...) function is applied to all 3D Tracks and the
  *          specified kernel is applied to all segments. If NULL is provided
  *          for the kernel, only the onTrack(...) functionality is applied.
@@ -119,7 +119,7 @@ void TraverseSegments::loopOverTracksExplicit(MOCKernel* kernel) {
         /* Loop over tracks in the z-stack */
         for (int z=0; z < tracks_per_stack[a][i][p]; z++) {
 
-          /* Extract 3D track and initialize segments pointer */
+          /* Extract 3D track */
           Track* track_3D = &tracks_3D[a][i][p][z];
 
           /* Operate on segments if necessary */
@@ -143,7 +143,7 @@ void TraverseSegments::loopOverTracksExplicit(MOCKernel* kernel) {
 
 
 /**
- * @brief Loops over all 3D Tracks using axial on-the-fly ray tracking by Track
+ * @brief Loops over all 3D Tracks using axial on-the-fly ray tracing by Track.
  * @details The onTrack(...) function is applied to all 3D Tracks and the
  *          specified kernel is applied to all segments. If NULL is provided
  *          for the kernel, only the onTrack(...) functionality is applied.
@@ -204,8 +204,8 @@ void TraverseSegments::loopOverTracksByTrackOTF(MOCKernel* kernel) {
 
 
 /**
- * @brief Loops over all 3D Tracks using axial on-the-fly ray tracking by
- *        z-stack
+ * @brief Loops over all 3D Tracks using axial on-the-fly ray tracing by
+ *        z-stack.
  * @details The onTrack(...) function is applied to all 3D Tracks and the
  *          specified kernel is applied to all segments. If NULL is provided
  *          for the kernel, only the onTrack(...) functionality is applied.
@@ -263,7 +263,7 @@ void TraverseSegments::loopOverTracksByStackOTF(MOCKernel* kernel) {
 
 
 /**
- * @brief Loops over segments in a Track when segments are explicitly generated
+ * @brief Loops over segments in a Track when segments are explicitly generated.
  * @details All segments in the provided Track are looped over and the provided
  *          MOCKernel is applied to them.
  * @param track The Track whose segments will be traversed
@@ -331,7 +331,7 @@ void TraverseSegments::traceSegmentsOTF(Track* flattened_track, Point* start,
       break;
     }
   }
-  
+
   Geometry* geometry = _track_generator_3D->getGeometry();
   Cmfd* cmfd = geometry->getCmfd();
 
@@ -509,7 +509,7 @@ void TraverseSegments::traceSegmentsOTF(Track* flattened_track, Point* start,
  *        passes the computed segments to the provided kernel.
  * @details Segment lengths are computed on-the-fly using 2D segment lengths
  *          stored in a 2D Track object and 1D meshes from the extruded
- *          FSRs. Note: before calling this funciton with SegmentationKernels,
+ *          FSRs. Note: before calling this function with SegmentationKernels,
  *          the memory for the segments should be allocated and referenced by
  *          the kernel using the setSegments routine.
  * @param flattened_track the 2D track associated with the z-stack for which
@@ -528,7 +528,7 @@ void TraverseSegments::traceStackOTF(Track* flattened_track, int polar_index,
   int num_z_stack = tracks_per_stack[azim_index][track_index][polar_index];
   double z_spacing = _track_generator_3D->getZSpacing(azim_index, polar_index);
 
-  /* Get infromation for the first Track in the z-stack */
+  /* Get information for the first Track in the z-stack */
   TrackStackIndexes tsi;
   Track3D first;
   tsi._azim = azim_index;

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -13,8 +13,8 @@ static std::set<int> used_ids;
  *          OpenMOC input files. The method makes use of a static Universe
  *          ID which is incremented each time the method is called to enable
  *          unique generation of monotonically increasing IDs. The method's
- *          first ID begins at 10000. Hence, user-defined Universe IDs greater
- *          than or equal to 10000 is prohibited.
+ *          first ID begins at 1,000,000. Hence, user-defined Universe IDs
+ *          greater than or equal to 1,000,000 is prohibited.
  */
 int universe_id() {
   int id = auto_id;
@@ -28,7 +28,7 @@ int universe_id() {
 
 
 /**
- * @brief Resets the auto-generated unique Universe ID counter to 10000.
+ * @brief Resets the auto-generated unique Universe ID counter to 1,000,000.
  */
 void reset_universe_id() {
   auto_id = DEFAULT_INIT_ID;
@@ -107,7 +107,7 @@ int Universe::getUid() const {
 
 
 /**
- * Return the user-specified ID for this Universe.
+ * @brief Return the user-specified ID for this Universe.
  * @return the user-specified Universe ID
  */
 int Universe::getId() const {
@@ -116,7 +116,7 @@ int Universe::getId() const {
 
 
 /**
- * @brief Return the user-defined name of the Universe
+ * @brief Return the user-defined name of the Universe.
  * @return the Universe name
  */
 char* Universe::getName() const {
@@ -131,6 +131,7 @@ char* Universe::getName() const {
 universeType Universe::getType() {
   return _type;
 }
+
 
 /**
  * @brief Return the number of Cells in this Universe.
@@ -221,7 +222,7 @@ double Universe::getMaxZ() {
 
 /**
  * @brief Returns the boundary conditions (VACUUM or REFLECTIVE) at the minimum
- *         reachable x-coordinate in the Universe.
+ *        reachable x-coordinate in the Universe.
  * @return the boundary conditions at the minimum reachable x-coordinate
  */
 boundaryType Universe::getMinXBoundaryType() {
@@ -235,7 +236,7 @@ boundaryType Universe::getMinXBoundaryType() {
 
 /**
  * @brief Returns the boundary conditions (VACUUM or REFLECTIVE) at the maximum
- *         reachable x-coordinate in the Universe.
+ *        reachable x-coordinate in the Universe.
  * @return the boundary conditions at the maximum reachable x-coordinate
  */
 boundaryType Universe::getMaxXBoundaryType() {
@@ -249,7 +250,7 @@ boundaryType Universe::getMaxXBoundaryType() {
 
 /**
  * @brief Returns the boundary conditions (VACUUM or REFLECTIVE) at the minimum
- *         reachable y-coordinate in the Universe.
+ *        reachable y-coordinate in the Universe.
  * @return the boundary conditions at the minimum reachable y-coordinate
  */
 boundaryType Universe::getMinYBoundaryType() {
@@ -263,7 +264,7 @@ boundaryType Universe::getMinYBoundaryType() {
 
 /**
  * @brief Returns the boundary conditions (VACUUM or REFLECTIVE) at the maximum
- *         reachable y-coordinate in the Universe.
+ *        reachable y-coordinate in the Universe.
  * @return the boundary conditions at the maximum reachable y-coordinate
  */
 boundaryType Universe::getMaxYBoundaryType() {
@@ -277,7 +278,7 @@ boundaryType Universe::getMaxYBoundaryType() {
 
 /**
  * @brief Returns the boundary conditions (VACUUM or REFLECTIVE) at the minimum
- *         reachable z-coordinate in the Universe.
+ *        reachable z-coordinate in the Universe.
  * @return the boundary conditions at the minimum reachable z-coordinate
  */
 boundaryType Universe::getMinZBoundaryType() {
@@ -291,7 +292,7 @@ boundaryType Universe::getMinZBoundaryType() {
 
 /**
  * @brief Returns the boundary conditions (VACUUM or REFLECTIVE) at the maximum
- *         reachable z-coordinate in the Universe.
+ *        reachable z-coordinate in the Universe.
  * @return the boundary conditions at the maximum reachable z-coordinate
  */
 boundaryType Universe::getMaxZBoundaryType() {
@@ -352,7 +353,7 @@ std::map<int, Cell*> Universe::getAllCells() {
 
 /**
  * @brief Returns the std::map of all IDs and Material pointers filling
-          this Universe.
+ *        this Universe.
  * @return std::map of Material IDs and pointers
  */
 std::map<int, Material*> Universe::getAllMaterials() {
@@ -379,7 +380,7 @@ std::map<int, Material*> Universe::getAllMaterials() {
 
 /**
  * @brief Returns the std::map of all nested Universe IDs and Universe pointers
-          filling this Universe.
+ *         filling this Universe.
  * @return std::map of Universe IDs and pointers
  */
 std::map<int, Universe*> Universe::getAllUniverses() {
@@ -416,7 +417,7 @@ bool Universe::isFissionable() {
 
 
 /**
- * @brief Sets the name of the Universe
+ * @brief Sets the name of the Universe.
  * @param name the Universe name string
  */
 void Universe::setName(const char* name) {
@@ -650,7 +651,7 @@ void Universe::printString() {
 
 
 /**
- * @brief Clones this Universe and copy cells map
+ * @brief Clones this Universe and copy cells map.
  * @return a pointer to the Universe clone
  */
 Universe* Universe::clone() {
@@ -686,9 +687,9 @@ Universe* Universe::clone() {
 
 
 /**
-  * @brief  Calculates the boundary locations and
-  *         conditions (VACUUM or REFLECTIVE) at the
-  *         maximum and minimum reachable coordinates in the Universe
+  * @brief  Calculates the boundary locations and conditions (VACUUM or
+  *         REFLECTIVE) at the maximum and minimum reachable coordinates in the
+  *         Universe.
   */
 void Universe::calculateBoundaries() {
 
@@ -700,9 +701,8 @@ void Universe::calculateBoundaries() {
   Surface* surf;
   int halfspace;
 
-  /* Calculate the boundary condition at the minimum
-  * reachable x-coordinate in the Universe and store it in _min_x_bound
-  */
+  /* Calculate the boundary condition at the minimum reachable x-coordinate in 
+   * the Universe and store it in _min_x_bound */
   _min_x_bound = BOUNDARY_NONE;
 
   /* Check if the universe contains a cell with an x-min boundary */
@@ -741,31 +741,30 @@ void Universe::calculateBoundaries() {
   /* Calculate the maximum reachable x-coordinate in the geometry and store it
    * in _max_x */
   double max_x = -std::numeric_limits<double>::infinity();
-  
-  /* Calculate the boundary condition at the maximum
-  * reachable x-coordinate in the Universe and store it in _max_x_bound
-  */
+
+  /* Calculate the boundary condition at the maximum reachable x-coordinate in 
+   * the Universe and store it in _max_x_bound */
   _max_x_bound = BOUNDARY_NONE;
 
   /* Check if the universe contains a cell with an x-max boundary */
   for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
     std::map<int, Halfspace*> surfs = c_iter->second->getSurfaces();
-    
+
     double cell_max_x = std::numeric_limits<double>::infinity();
     boundaryType cell_max_x_bound = BOUNDARY_NONE;
     for (s_iter = surfs.begin(); s_iter != surfs.end(); ++s_iter) {
       surf = s_iter->second->_surface;
       halfspace = s_iter->second->_halfspace;
-      
+
       if (surf->getSurfaceType() == XPLANE && halfspace == -1 &&
           surf->getBoundaryType() != BOUNDARY_NONE) {
-        if(surf->getMaxX(halfspace) < cell_max_x) {
+        if (surf->getMaxX(halfspace) < cell_max_x) {
           cell_max_x = surf->getMaxX(halfspace);
           cell_max_x_bound = surf->getBoundaryType();
         }
       }
     }
-    if(cell_max_x_bound != BOUNDARY_NONE && cell_max_x > max_x) {
+    if (cell_max_x_bound != BOUNDARY_NONE && cell_max_x > max_x) {
       max_x = cell_max_x;
       _max_x_bound = cell_max_x_bound;
     }
@@ -784,10 +783,9 @@ void Universe::calculateBoundaries() {
   /* Calculate the minimum reachable y-coordinate in the geometry and store it
    * in _min_y */
   double min_y = std::numeric_limits<double>::infinity();
-  
-  /* Calculate the boundary condition at the minimum
-  * reachable y-coordinate in the Universe and store it in _min_y_bound
-  */
+
+  /* Calculate the boundary condition at the minimum reachable y-coordinate in 
+   * the Universe and store it in _min_y_bound */
   _min_y_bound = BOUNDARY_NONE;
 
   /* Check if the universe contains a cell with an y-min boundary */
@@ -802,13 +800,13 @@ void Universe::calculateBoundaries() {
 
       if (surf->getSurfaceType() == YPLANE && halfspace == +1 &&
         surf->getBoundaryType() != BOUNDARY_NONE) {
-        if(surf->getMinY(halfspace) > cell_min_y) {
+        if (surf->getMinY(halfspace) > cell_min_y) {
           cell_min_y = surf->getMinY(halfspace);
           cell_min_y_bound = surf->getBoundaryType();
         }
       }
     }
-    if(cell_min_y_bound != BOUNDARY_NONE && cell_min_y < min_y) {
+    if (cell_min_y_bound != BOUNDARY_NONE && cell_min_y < min_y) {
       min_y = cell_min_y;
       _min_y_bound = cell_min_y_bound;
     }
@@ -827,9 +825,8 @@ void Universe::calculateBoundaries() {
    * in _max_y */
   double max_y = -std::numeric_limits<double>::infinity();
 
-  /* Calculate the boundary condition at the maximum
-  * reachable y-coordinate in the Universe and store it in _max_y_bound
-  */
+  /* Calculate the boundary condition at the maximum reachable y-coordinate in 
+   * the Universe and store it in _max_y_bound */
   _max_y_bound = BOUNDARY_NONE;
 
   /* Check if the universe contains a cell with an y-max boundary */
@@ -844,13 +841,13 @@ void Universe::calculateBoundaries() {
 
       if (surf->getSurfaceType() == YPLANE && halfspace == -1 &&
         surf->getBoundaryType() != BOUNDARY_NONE) {
-        if(surf->getMaxY(halfspace) < cell_max_y) {
+        if (surf->getMaxY(halfspace) < cell_max_y) {
           cell_max_y = surf->getMaxY(halfspace);
           cell_max_y_bound = surf->getBoundaryType();
         }
       }
     }
-    if(cell_max_y_bound != BOUNDARY_NONE && cell_max_y > max_y) {
+    if (cell_max_y_bound != BOUNDARY_NONE && cell_max_y > max_y) {
       max_y = cell_max_y;
       _max_y_bound = cell_max_y_bound;
     }
@@ -868,10 +865,9 @@ void Universe::calculateBoundaries() {
   /* Calculate the minimum reachable z-coordinate in the geometry and store it
    * in _min_z */
   double min_z = std::numeric_limits<double>::infinity();
-  
-  /* Calculate the boundary condition at the minimum
-  * reachable z-coordinate in the Universe and store it in _min_z_bound
-  */
+
+  /* Calculate the boundary condition at the minimum reachable z-coordinate in
+   * the Universe and store it in _min_z_bound */
   _min_z_bound = BOUNDARY_NONE;
 
   /* Check if the universe contains a cell with an z-min boundary */
@@ -886,13 +882,13 @@ void Universe::calculateBoundaries() {
 
       if (surf->getSurfaceType() == ZPLANE && halfspace == +1 &&
           surf->getBoundaryType() != BOUNDARY_NONE) {
-        if(surf->getMinZ(halfspace) > cell_min_z) {
+        if (surf->getMinZ(halfspace) > cell_min_z) {
           cell_min_z = surf->getMinZ(halfspace);
           cell_min_z_bound = surf->getBoundaryType();
         }
       }
     }
-    if(cell_min_z_bound != BOUNDARY_NONE && cell_min_z < min_z) {
+    if (cell_min_z_bound != BOUNDARY_NONE && cell_min_z < min_z) {
       min_z = cell_min_z;
       _min_z_bound = cell_min_z_bound;
     }
@@ -915,7 +911,7 @@ void Universe::calculateBoundaries() {
   * reachable z-coordinate in the Universe and store it in _max_z_bound */
   _max_z_bound = BOUNDARY_NONE;
 
-  /* Check if the universe contains a cell with an y-max boundary */
+  /* Check if the universe contains a cell with an z-max boundary */
   for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
     std::map<int, Halfspace*>surfs = c_iter->second->getSurfaces();
 
@@ -927,13 +923,13 @@ void Universe::calculateBoundaries() {
 
       if (surf->getSurfaceType() == ZPLANE && halfspace == -1 &&
           surf->getBoundaryType() != BOUNDARY_NONE) {
-        if(surf->getMaxZ(halfspace) < cell_max_z) {
+        if (surf->getMaxZ(halfspace) < cell_max_z) {
           cell_max_z = surf->getMaxZ(halfspace);
           cell_max_z_bound = surf->getBoundaryType();
         }
       }
     }
-    if(cell_max_z_bound != BOUNDARY_NONE && cell_max_z > max_z) {
+    if (cell_max_z_bound != BOUNDARY_NONE && cell_max_z > max_z) {
       max_z = cell_max_z;
       _max_z_bound = cell_max_z_bound;
     }
@@ -953,8 +949,8 @@ void Universe::calculateBoundaries() {
 
 
 /**
-  * @brief  sets _boundaries_not_updated to true so boundaries will be
-  *         recalculated if needed
+  * @brief Sets _boundaries_not_updated to true so boundaries will be
+  *        recalculated if needed.
   */
 void Universe::resetBoundaries() {
   _boundaries_inspected = false;
@@ -1037,7 +1033,7 @@ int Lattice::getNumX() const {
 
 
 /**
- * @brief Return the number of Lattice cells along the y-axis
+ * @brief Return the number of Lattice cells along the y-axis.
  * @return the number of Lattice cells along y
  */
 int Lattice::getNumY() const {
@@ -1046,7 +1042,7 @@ int Lattice::getNumY() const {
 
 
 /**
- * @brief Return the number of Lattice cells along the z-axis
+ * @brief Return the number of Lattice cells along the z-axis.
  * @return the number of Lattice cells along z
  */
 int Lattice::getNumZ() const {
@@ -1091,7 +1087,7 @@ bool Lattice::getNonUniform() const {
 
 
 /**
- * @brief Return the widths of non-uniform Lattice in x direction
+ * @brief Return the widths of non-uniform Lattice in x direction.
  * @return the widths of non-uniform Lattice in x direction
  */
 const std::vector<double>& Lattice::getWidthsX() const {
@@ -1100,7 +1096,7 @@ const std::vector<double>& Lattice::getWidthsX() const {
 
 
 /**
- * @brief Return the widths of non-uniform Lattice in y direction
+ * @brief Return the widths of non-uniform Lattice in y direction.
  * @return the widths of non-uniform Lattice in y direction
  */
 const std::vector<double>& Lattice::getWidthsY() const {
@@ -1109,7 +1105,7 @@ const std::vector<double>& Lattice::getWidthsY() const {
 
 
 /**
- * @brief Return the widths of non-uniform Lattice in z direction
+ * @brief Return the widths of non-uniform Lattice in z direction.
  * @return the widths of non-uniform Lattice in z direction
  */
 const std::vector<double>& Lattice::getWidthsZ() const {
@@ -1118,7 +1114,7 @@ const std::vector<double>& Lattice::getWidthsZ() const {
 
 
 /**
- * @brief Return the accumulate widths of non-uniform Lattice in x direction
+ * @brief Return the accumulate widths of non-uniform Lattice in x direction.
  * @return the accumulated widths of non-uniform Lattice in x direction
  */
 const std::vector<double>& Lattice::getAccumulateX() const {
@@ -1127,7 +1123,7 @@ const std::vector<double>& Lattice::getAccumulateX() const {
 
 
 /**
- * @brief Return the accumulate widths of non-uniform Lattice in y direction
+ * @brief Return the accumulate widths of non-uniform Lattice in y direction.
  * @return the accumulated widths of non-uniform Lattice in y direction
  */
 const std::vector<double>& Lattice::getAccumulateY() const {
@@ -1136,7 +1132,7 @@ const std::vector<double>& Lattice::getAccumulateY() const {
 
 
 /**
- * @brief Return the accumulate widths of non-uniform Lattice in z direction
+ * @brief Return the accumulate widths of non-uniform Lattice in z direction.
  * @return the accumulated widths of non-uniform Lattice in z direction
  */
 const std::vector<double>& Lattice::getAccumulateZ() const {
@@ -1219,8 +1215,8 @@ Universe* Lattice::getUniverse(int lat_x, int lat_y, int lat_z) const {
 
 
 /**
- * @brief Return a 2D vector of the Universes in the Lattice.
- * @return 2D vector of Universes
+ * @brief Return a 3D vector of the Universes in the Lattice.
+ * @return 3D vector of Universes
  */
 std::vector< std::vector< std::vector< std::pair<int, Universe*> > > >*
   Lattice::getUniverses() {
@@ -1265,11 +1261,11 @@ std::map<int, double> Lattice::getUniqueRadius
   std::map<int, double> unique_radius;
   std::map<int, Universe*>::iterator iter;
   Universe* universe;
-  
+
   /* Create and initialize the <universe ID, unique radius> map */
   for (iter = unique_universes.begin(); iter != unique_universes.end(); ++iter)
     unique_radius[iter->first] = 0.;
-  
+
   /* Get the maximum equivalent radius of each unique universe */
   for (int k = _universes.size()-1; k > -1; k--) {
     for (int j = _universes.at(k).size()-1; j > -1;  j--) {
@@ -1393,7 +1389,7 @@ void Lattice::setNonUniform(bool non_uniform) {
 
 
 /**
- * @brief Set the widths of non-uniform Lattice in x direction
+ * @brief Set the widths of non-uniform Lattice in x direction.
  * @param widthsx the widths of non-uniform Lattice in x direction
  */
 void Lattice::setWidthsX(std::vector<double> widthsx) {
@@ -1402,7 +1398,7 @@ void Lattice::setWidthsX(std::vector<double> widthsx) {
 
 
 /**
- * @brief Set the widths of non-uniform Lattice in y direction
+ * @brief Set the widths of non-uniform Lattice in y direction.
  * @param widthsy the widths of non-uniform Lattice in y direction
  */
 void Lattice::setWidthsY(std::vector<double> widthsy) {
@@ -1411,7 +1407,7 @@ void Lattice::setWidthsY(std::vector<double> widthsy) {
 
 
 /**
- * @brief Set the widths of non-uniform Lattice in z direction
+ * @brief Set the widths of non-uniform Lattice in z direction.
  * @param widthsz the widths of non-uniform Lattice in z direction
  */
 void Lattice::setWidthsZ(std::vector<double> widthsz) {
@@ -1420,8 +1416,8 @@ void Lattice::setWidthsZ(std::vector<double> widthsz) {
 
 
 /**
- * @brief Set the accumulate widths of non-uniform Lattice in x direction
- * @param accumulatex the accumulate widths of non-uniform Lattice in x 
+ * @brief Set the accumulate widths of non-uniform Lattice in x direction.
+ * @param accumulatex the accumulated widths of non-uniform Lattice in x
           direction
  */
 void Lattice::setAccumulateX(std::vector<double> accumulatex) {
@@ -1430,8 +1426,8 @@ void Lattice::setAccumulateX(std::vector<double> accumulatex) {
 
 
 /**
- * @brief Set the accumulate widths of non-uniform Lattice in y direction
- * @param accumulatey the accumulate widths of non-uniform Lattice in y 
+ * @brief Set the accumulate widths of non-uniform Lattice in y direction.
+ * @param accumulatey the accumulated widths of non-uniform Lattice in y
           direction
  */
 void Lattice::setAccumulateY(std::vector<double> accumulatey) {
@@ -1440,8 +1436,8 @@ void Lattice::setAccumulateY(std::vector<double> accumulatey) {
 
 
 /**
- * @brief Set the accumulate widths of non-uniform Lattice in z direction
- * @param accumulatez the accumulate widths of non-uniform Lattice in z 
+ * @brief Set the accumulate widths of non-uniform Lattice in z direction.
+ * @param accumulatez the accumulated widths of non-uniform Lattice in z
           direction
  */
 void Lattice::setAccumulateZ(std::vector<double> accumulatez) {
@@ -2126,9 +2122,10 @@ int Lattice::getLatticeSurface(int cell, Point* point) {
  * @details The surface indices are defined in constants.h as they
  *          need to be consistent with the surface constant definitions
  *          used in Cmfd. The index returned takes into account
- *         the cell index and returns NUM_SURFACES*cell_index + surface_index.
- * @param cell the cell index that the point is in.
- * @param point a pointer to a point being evaluated.
+ *          the cell index and returns NUM_SURFACES*cell_index + surface_index.
+ * @param cell the cell index that the point is in
+ * @param z z coordinate of the point
+ * @param surface_2D 2D surface considered
  * @return the Lattice surface index.
  */
 int Lattice::getLatticeSurfaceOTF(int cell, double z, int surface_2D) {
@@ -2219,7 +2216,7 @@ int Lattice::getLatticeSurfaceOTF(int cell, double z, int surface_2D) {
 
 
 /**
- * @brief Set width of non-uniform meshes in x y z directions.
+ * @brief Set widths of non-uniform meshes in x y z directions.
  * @details An example of how this may be called from Python illustrated below:
  *
  * @code
@@ -2303,4 +2300,3 @@ void Lattice::printLatticeSizes() {
     printf("i=%d, %f; ",i, _accumulate_z[i]);
   printf("\n");
 }
-

--- a/src/Universe.h
+++ b/src/Universe.h
@@ -35,7 +35,7 @@ void maximize_universe_id(int universe_id);
 
 /**
  * @enum universeType
- * @brief The type of universe
+ * @brief The type of universe.
  */
 enum universeType{
 
@@ -168,11 +168,11 @@ private:
 
   /** True if the lattice is non-uniform */
   bool _non_uniform;
-  
+
   /** The width of each Lattice cell (cm) along the x-axis
       (uniform lattices only) */
   double _width_x;
-  
+
   /** x-direction dimensions of non-uniform lattice meshes */
   std::vector<double> _widths_x;
   std::vector<double> _accumulate_x;
@@ -180,7 +180,7 @@ private:
   /** The width of each Lattice cell (cm) along the y-axis 
       (uniform lattices only) */
   double _width_y;
-  
+
   /** y-direction dimensions of non-uniform lattice meshes */
   std::vector<double> _widths_y;
   std::vector<double> _accumulate_y;
@@ -188,7 +188,7 @@ private:
   /** The width of each Lattice cell (cm) along the z-axis 
       (uniform lattices only) */
   double _width_z;
-  
+
   /** z-direction dimensions of non-uniform lattice meshes */
   std::vector<double> _widths_z;
   std::vector<double> _accumulate_z;
@@ -267,15 +267,15 @@ public:
 
   std::string toString();
   void printString();
-  
+
   /* Set XYZ widths of non-uniform meshes */
   void setWidths(std::vector<double> widths_x, std::vector<double> widths_y, 
                  std::vector<double> widths_z);
   void computeSizes();
-  
+
   /* For debug use */
   void printLatticeSizes();
-  
+
 };
 
 /**

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -3,14 +3,15 @@
 /**
  * @brief Constructor initializes Vector object as a floating point array
  *        and sets the vector dimensions.
- * @detail The vector is ordered by cell (as opposed to by group) on the
- *         outside to be consistent with the Matrix object. Locks are used to
- *         make the vector object thread-safe against concurrent writes the
- *          same value. One lock locks out multiple rows of
- *         the vector at a time representing multiple groups in the same cell.
+ * @details The vector is ordered by cell (as opposed to by group) on the
+ *          outside to be consistent with the Matrix object. Locks are used to
+ *          make the vector object thread-safe against concurrent writes the
+ *          same value. One lock locks out multiple rows of the vector at a
+ *          time representing multiple groups in the same cell.
  * @param cell_locks OpenMP locks for atomic cell operations.
  * @param num_x The number of cells in the x direction.
  * @param num_y The number of cells in the y direction.
+ * @param num_z The number of cells in the z direction.
  * @param num_groups The number of energy groups in each cell.
  */
 Vector::Vector(omp_lock_t* cell_locks, int num_x, int num_y, int num_z,
@@ -48,10 +49,10 @@ Vector::~Vector() {
 
 /**
  * @brief Increment a value in the vector.
- * @detail This method takes a cell and group and floating
- *         point value. The cell and group are used to compute the
- *         row in the vector. If a value exists for the row,
- *         the value is incremented by val; otherwise, it is set to val.
+ * @details This method takes a cell and group and floating
+ *          point value. The cell and group are used to compute the
+ *          row in the vector. If a value exists for the row,
+ *          the value is incremented by val; otherwise, it is set to val.
  * @param cell The cell location.
  * @param group The group location.
  * @param val The value used to increment the row location.
@@ -78,10 +79,10 @@ void Vector::incrementValue(int cell, int group, CMFD_PRECISION val) {
 
 /**
  * @brief Increment values in the vector.
- * @detail This method takes a cell, first group, last group, and floating
- *         point value. The cell and groups are used to compute the
- *         rows in the vector. If values exist for the rows,
- *         the values are incremented by vals; otherwise, they are set.
+ * @details This method takes a cell, first group, last group, and floating
+ *          point value. The cell and groups are used to compute the
+ *          rows in the vector. If values exist for the rows,
+ *          the values are incremented by vals; otherwise, they are set.
  * @param cell The cell location.
  * @param group_first The first group location to increment.
  * @param group_last The last group location to increment.
@@ -116,6 +117,10 @@ void Vector::incrementValues(int cell, int group_first, int group_last,
 }
 
 
+/**
+ * @brief Fill vector with a value.
+ * @param val value to use to fill
+ */
 void Vector::setAll(CMFD_PRECISION val) {
   std::fill_n(_array, _num_rows, val);
 }
@@ -123,10 +128,10 @@ void Vector::setAll(CMFD_PRECISION val) {
 
 /**
  * @brief Set a value in the vector.
- * @detail This method takes a cell and group and floating
- *         point value. The cell and group are used to compute the
- *         row and column in the vector. The location of the corresponding
- *         row is set to val.
+ * @details This method takes a cell and group and floating
+ *          point value. The cell and group are used to compute the
+ *          row and column in the vector. The location of the corresponding
+ *          row is set to val.
  * @param cell The cell location.
  * @param group The group location.
  * @param val The value used to set the row location.
@@ -153,10 +158,10 @@ void Vector::setValue(int cell, int group, CMFD_PRECISION val) {
 
 /**
  * @brief Set values in the vector.
- * @detail This method takes a cell, first group, last group, and floating
- *         point value. The cell and groups are used to compute the
- *         rows in the vector. If a values exist for the rows,
- *         the values are overwritten.
+ * @details This method takes a cell, first group, last group, and floating
+ *          point value. The cell and groups are used to compute the
+ *          rows in the vector. If a value exist for the rows,
+ *          the values are overwritten.
  * @param cell The cell location.
  * @param group_first The first group location to set.
  * @param group_last The last group location to set.
@@ -243,7 +248,7 @@ void Vector::copyTo(Vector* vector) {
 
 
 /**
- * @brief Get a value at location described by a given cell and group index
+ * @brief Get a value at location described by a given cell and group index.
  * @param cell The cell location index.
  * @param group The group location index.
  */

--- a/src/Vector.h
+++ b/src/Vector.h
@@ -5,19 +5,19 @@
  * @author Samuel Shaner, MIT, Course 22 (shaner@mit.edu)
  */
 
-#ifndef VECTOR_H_
-#define VECTOR_H_
+#ifndef SRC_VECTOR_H_
+#define SRC_VECTOR_H_
 
 
 #ifdef __cplusplus
 #include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
 #include <map>
 #include <vector>
 #include <string>
 #include <iostream>
 #include <sstream>
-#include <stdlib.h>
-#include <stdio.h>
 #include <iomanip>
 #include "log.h"
 #include "pairwise_sum.h"
@@ -25,9 +25,7 @@
 
 
 class Vector {
-
-private:
-
+ private:
   /** A list of lists representing the vector */
   CMFD_PRECISION* _array;
   int _num_rows;
@@ -44,9 +42,9 @@ private:
   void setNumZ(int num_z);
   void setNumGroups(int num_groups);
 
-public:
-  Vector(omp_lock_t* cell_locks, int num_x=1, int num_y=1, int num_z=1,
-         int num_groups=1);
+ public:
+  Vector(omp_lock_t* cell_locks, int num_x = 1, int num_y = 1, int num_z = 1,
+         int num_groups = 1);
   virtual ~Vector();
 
   /* Worker functions */
@@ -71,8 +69,9 @@ public:
 
   /* Setter functions */
   void setValue(int cell, int group, CMFD_PRECISION val);
-  void setValues(int cell, int group_start, int group_end, CMFD_PRECISION* vals);
+  void setValues(int cell, int group_start, int group_end,
+                 CMFD_PRECISION* vals);
   void setAll(CMFD_PRECISION val);
 };
 
-#endif /* VECTOR_H_ */
+#endif  // SRC_VECTOR_H_

--- a/src/VectorizedSolver.cpp
+++ b/src/VectorizedSolver.cpp
@@ -410,7 +410,7 @@ void VectorizedSolver::computeFSRSources(int iteration) {
 
 /**
  * @brief Add the source term contribution in the transport equation to
- *        the FSR scalar flux
+ *        the FSR scalar flux.
  */
 void VectorizedSolver::addSourceToScalarFlux() {
 

--- a/src/linalg.h
+++ b/src/linalg.h
@@ -29,20 +29,28 @@
  * @brief Verbose iteration information for the CMFD eigenvalue solver 
  */
 struct ConvergenceData {
+
   /* The Max. prolongation factor of the CMFD */
   double pf;
+
   /* The initial residual of the CMFD eigenvalue problem */
   double cmfd_res_1;
+
   /* The final residual of the CMFD eigenvalue problem */
   double cmfd_res_end;
+
   /* The linear solver residual of the first CMFD eigenvalue iteration */
   double linear_res_1;
+
   /* The linear solver residual of the final CMFD eigenvalue iteration */
   double linear_res_end;
+
   /* The number of the CMFD eigenvalue iterations */
   int cmfd_iters;
+
   /* The number of linear iterations for the first CMFD eigenvalue iteration */
   int linear_iters_1;
+
   /* The number of linear iterations for the final CMFD eigenvalue iteration */
   int linear_iters_end;
 };
@@ -52,6 +60,7 @@ struct ConvergenceData {
  * @brief Structure for communication of fluxes between neighbor domains
  */
 struct DomainCommunicator {
+
   int _num_domains_x;
   int _num_domains_y;
   int _num_domains_z;
@@ -61,21 +70,29 @@ struct DomainCommunicator {
   int _local_num_x;
   int _local_num_y;
   int _local_num_z;
+
   /* Sum of the starting CMFD global indexes of a domain, for the color*/
   int _offset;
+
   /* Number of connecting neighbors for each surface cell */
   int** num_connections;
+
   /* Indexes of connecting neighbors for each surface cell */
   int*** indexes;
+
   /* Surface numbers of connecting neighbors for each surface cell */
   int*** domains;
+
   /* Coupling coeffs between connecting neighbors and itself for each 
      surface cell */
   CMFD_PRECISION*** coupling_coeffs;
+
   /* Fluxes of connecting neighbors for each surface cell*/
   CMFD_PRECISION*** fluxes;
+
   /* Buffer for sending/receiving fluxes to/from connecting neighbors */
   CMFD_PRECISION** buffer;
+
   int num_groups;
   bool stop;
 #ifdef MPIx
@@ -83,9 +100,10 @@ struct DomainCommunicator {
 #endif
 };
 
+
 /**
  * @brief Get coupling fluxes and other information from neighbors. 
- * The information are transfered by reference.
+ * @details The information are transfered by reference.
  */
 #ifdef MPIx
 void getCouplingTerms(DomainCommunicator* comm, int color, int*& coupling_sizes,
@@ -106,11 +124,12 @@ bool ddLinearSolve(Matrix* A, Matrix* M, Vector* X, Vector* B, double tol,
                    double SOR_factor, ConvergenceData* convergence_data,
                    DomainCommunicator* comm);
 void matrixMultiplication(Matrix* A, Vector* X, Vector* B);
-double computeRMSE(Vector* x, Vector* y, bool integrated, int it,
+double computeRMSE(Vector* x, Vector* y, bool integrated,
                          DomainCommunicator* comm = NULL);
 void oldLinearSolve(Matrix* A, Matrix* M, Vector* X, Vector* B, double tol,
                     double SOR_factor=1.5,
                     ConvergenceData* convergence_data = NULL);
+
 
 /**
  * @brief Transpose a 2D matrix.

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -99,6 +99,7 @@ static omp_lock_t log_error_lock;
  *          is reported and program execution is terminated.
  */
 void initialize_logger() {
+
   /* Initialize OpenMP mutex lock for ERROR messages with exceptions */
   omp_init_lock(&log_error_lock);
 }
@@ -179,7 +180,7 @@ void set_header_character(char c) {
 
 /**
  * @brief Returns the character used to format HEADER type log messages.
- * @return the character used for HEADER type log messages
+ * @return the character used for HEADER log messages
  */
 char get_header_character() {
   return header_char;

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -539,9 +539,11 @@ void log_printf(logLevel level, const char* format, ...) {
 #ifdef MPIx
         if (_MPI_present) {
           printf("%s", "[  ERROR  ] ");
-          printf("%s", msg_string.c_str());
+          printf("%s", &msg_string[0]);
           fflush(stdout);
           MPI_Finalize();
+          MPI_Abort(_MPI_comm, 0);
+          //FIXME Not best communicator to abort, but better than not returning.
         }
 #endif
         throw std::logic_error(msg_string.c_str());

--- a/src/log.h
+++ b/src/log.h
@@ -66,7 +66,7 @@ typedef enum {
   /** A message sandwiched between two lines of characters */
   TITLE,
 
-  /** A message for to warn the user */
+  /** A message to warn the user */
   WARNING,
 
   /** A message to warn of critical program conditions */


### PR DESCRIPTION
Pretty big PR in terms of lines but beyond the typos and the dots at the end of docstrings there is only : 

- lots of openmp schedules changed to static since no load imbalance is expected and guided schedules have a cost. This is more of a style fix than an optimization
- ERROR logs now call MPI_abort, otherwise the error is not caught and the job keeps running, wasting cluster ressources
- a few log variables (number of flat sources in LS, highest prolongation ratio in CMFD) were not updated in a thread safe manner, so that's fixed with atomic and critical sections respectively
- residuals are now computed in parallel. It's not a big time save, but that way it's consistent with the rest of the code where every loop on FSRs is parallelized
- default alignment changed to 32. This is safer because it will work on machines that are 16 bytes aligned and 32 bytes aligned
- rework of the timer to make it clear what is included in what