### PR TITLE
Corrected test_mesh_tally comment

### DIFF
--- a/tests/test_mesh_tally/test_mesh_tally.py
+++ b/tests/test_mesh_tally/test_mesh_tally.py
@@ -56,7 +56,7 @@ class MeshTallyTestHarness(TestHarness):
                 domains_to_coeffs[material_id][group] = \
                     materials[material_id].getSigmaTByGroup(group+1)
 
-        # Tally volume-averaged OpenMOC total rates on the Mesh
+        # Tally volume-integrated OpenMOC total rates on the Mesh
         tot_rates = mesh.tally_on_mesh(self.solver, domains_to_coeffs, 
                                        domain_type='material', 
                                        volume='integrated')


### PR DESCRIPTION
The comment incorrectly specified "volume-averaged". The tally actually requests "volume-integrated".