### PR TITLE
2D domain decomposition, improved neutron balance checking and other improvements

### DIFF
--- a/config.py
+++ b/config.py
@@ -161,14 +161,15 @@ class configuration:
     compiler_flags = dict()
 
     compiler_flags['gcc'] = ['-c', '-O3', '-ffast-math', '-fopenmp',
-                             '-std=c++11', '-fpic']
+                             '-std=c++11', '-fpic', '-march=native']
     compiler_flags['mpicc'] = ['-c', '-O3', '-ffast-math', '-fopenmp',
-                               '-std=c++11', '-fpic']
+                               '-std=c++11', '-fpic', '-march=native']
     compiler_flags['clang'] = ['-c', '-O3', '-ffast-math', '-std=c++11',
                                '-fopenmp', '-fvectorize', '-fpic',
                                '-Qunused-arguments',
                                '-Wno-deprecated-register',
-                               '-Wno-parentheses-equality']
+                               '-Wno-parentheses-equality',
+                               '-march=native']
     compiler_flags['icpc'] =['-c', '-O3', '-fast', '--ccache-skip',
                              '-openmp', '-xhost', '-std=c++11',
                              '--ccache-skip', '-fpic',
@@ -355,8 +356,8 @@ class configuration:
         for precision in macros[compiler]:
             macros[compiler][precision].append(('OPENMP', None))
             macros[compiler][precision].append(('SWIG', None))
-        if cc == 'mpicc':
-            macros[compiler][precision].append(('MPIx', None))
+            if compiler == 'mpicc':
+                macros[compiler][precision].append(('MPIx', None))
 
     # set CMFD precision and linear algebra solver tolerance
     for compiler in macros:
@@ -377,8 +378,9 @@ class configuration:
         if self.debug_mode:
             for k in self.compiler_flags:
                 self.compiler_flags[k].append('-g')
+                self.compiler_flags[k].append('-fno-omit-frame-pointer')
                 ind = [i for i, item in enumerate(self.compiler_flags[k]) \
-            if item.startswith('-O')]
+                       if item.startswith('-O')]
                 self.compiler_flags[k][ind[0]] = '-O0'
 
         # If the user wishes to compile using the address sanitizer, append
@@ -417,7 +419,7 @@ class configuration:
         # Add the mpi4py module directory
         try:
             import mpi4py
-            mpi4py_include = mpi4py.__file__
+            mpi4py_include = mpi4py.__file__.split("__")[0]+"include"
         except:
             mpi4py_include = ''
         self.include_directories['mpicc'].append(mpi4py_include)

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -105,7 +105,7 @@ endif
 
 # MPI wrapped compiler
 ifeq ($(COMPILER),mpi)
-  CC = mpicc
+  CC = mpic++
   CFLAGS += -DMPIx
   LDFLAGS += -lm
   LDFLAGS += -lstdc++

--- a/setup.py
+++ b/setup.py
@@ -412,3 +412,6 @@ if "clean" in sys.argv:
     install_location = site.getusersitepackages()
     print("Removing build from "+ install_location)
     os.system("rm -rf " + install_location + "/*openmoc*")
+    install_location = "./tests/"
+    print("Removing build from "+ install_location)
+    os.system("rm -rf "+install_location+"openmoc "+install_location+"build")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 The setup script for OpenMOC
 '''
 
-import os, string
+import os, site, string, sys
 from distutils.errors import DistutilsOptionError
 import distutils.ccompiler
 import multiprocessing
@@ -403,3 +403,12 @@ dist = setup(name = 'openmoc',
 build_py = build_py(dist)
 build_py.ensure_finalized()
 build_py.run()
+
+# Remove the shared library in the site packages
+if "clean" in sys.argv:
+    install_location = site.getsitepackages()[0]
+    print("Removing build from "+ install_location)
+    os.system("rm -rf " + install_location + "/*openmoc*")
+    install_location = site.getusersitepackages()
+    print("Removing build from "+ install_location)
+    os.system("rm -rf " + install_location + "/*openmoc*")

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -197,7 +197,7 @@ void CPULSSolver::computeFSRSources(int iteration) {
   CPUSolver::computeFSRSources(iteration);
 
   int num_coeffs = 3;
-  if (_solve_3D)
+  if (_SOLVE_3D)
     num_coeffs = 6;
 
 #pragma omp parallel
@@ -292,7 +292,7 @@ void CPULSSolver::computeFSRSources(int iteration) {
         src_z = scatter_source_z + chi[g] * fission_source_z;
 
         /* Compute total (scatter+fission) reduced source moments */
-        if (_solve_3D) {
+        if (_SOLVE_3D) {
           if (_reduced_sources(r,g) > 1e-15 || iteration > 29) {
             _reduced_sources_xyz(r,g,0) = ONE_OVER_FOUR_PI / 2 *
                  (_FSR_lin_exp_matrix[r*num_coeffs  ] * src_x +
@@ -363,7 +363,7 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
   FP_PRECISION* position = curr_segment->_starting_position;
   ExpEvaluator* exp_evaluator = _exp_evaluators[azim_index][polar_index];
 
-  if (_solve_3D) {
+  if (_SOLVE_3D) {
 
     /* Compute the segment midpoint (with factor 2 for LS) */
     FP_PRECISION center_x2[3];
@@ -558,7 +558,7 @@ void CPULSSolver::accumulateLinearFluxContribution(long fsr_id,
 void CPULSSolver::addSourceToScalarFlux() {
 
   int nc = 3;
-  if (_solve_3D)
+  if (_SOLVE_3D)
     nc = 6;
 
 #pragma omp parallel
@@ -594,7 +594,7 @@ void CPULSSolver::addSourceToScalarFlux() {
         _scalar_flux_xyz(r,e,1) += flux_const * _reduced_sources_xyz(r,e,1)
             * _FSR_source_constants[r*_num_groups*nc + nc*e + 1];
 
-        if (_solve_3D) {
+        if (_SOLVE_3D) {
           _scalar_flux_xyz(r,e,0) += flux_const * _reduced_sources_xyz(r,e,2)
               * _FSR_source_constants[r*_num_groups*nc + nc*e + 3];
           _scalar_flux_xyz(r,e,1) += flux_const * _reduced_sources_xyz(r,e,2)
@@ -611,7 +611,7 @@ void CPULSSolver::addSourceToScalarFlux() {
 
         _scalar_flux_xyz(r,e,0) /= sigma_t[e];
         _scalar_flux_xyz(r,e,1) /= sigma_t[e];
-        if (_solve_3D)
+        if (_SOLVE_3D)
           _scalar_flux_xyz(r,e,2) /= sigma_t[e];
       }
     }
@@ -836,7 +836,7 @@ FP_PRECISION CPULSSolver::getFluxByCoords(LocalCoords* coords, int group) {
   double flux_y = 0.0;
   double flux_z = 0.0;
 
-  if (_solve_3D) {
+  if (_SOLVE_3D) {
     flux_x = (x - xc) *
         (_FSR_lin_exp_matrix[fsr*6  ] * _scalar_flux_xyz(fsr, group, 0) +
          _FSR_lin_exp_matrix[fsr*6+2] * _scalar_flux_xyz(fsr, group, 1) +
@@ -903,7 +903,7 @@ void CPULSSolver::initializeLinearSourceConstants() {
   {
     /* Initialize linear source constant component */
     long size = 3 * _geometry->getNumEnergyGroups() * _geometry->getNumFSRs();
-    if (_solve_3D)
+    if (_SOLVE_3D)
       size *= 2;
 
     long max_size = size;
@@ -921,7 +921,7 @@ void CPULSSolver::initializeLinearSourceConstants() {
 
     /* Initialize linear source matrix coefficients */
     size = _geometry->getNumFSRs() * 3;
-    if (_solve_3D)
+    if (_SOLVE_3D)
       size *= 2;
     _FSR_lin_exp_matrix = new double[size]();
   }

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -891,10 +891,6 @@ void CPUSolver::transferAllInterfaceFluxes() {
     bool communication_complete = true;
     for (int i=0; i < num_domains; i++) {
 
-      /* Initialize MPI request */
-      _MPI_requests[i*2] = MPI_REQUEST_NULL;
-      _MPI_requests[i*2+1] = MPI_REQUEST_NULL;
-
       /* Get the communicating neighbor domain */
       int domain = _neighbor_domains.at(i);
 
@@ -918,6 +914,10 @@ void CPUSolver::transferAllInterfaceFluxes() {
 
         /* Mark communication as ongoing */
         communication_complete = false;
+      }
+      else {
+        _MPI_requests[i*2] = MPI_REQUEST_NULL;
+        _MPI_requests[i*2+1] = MPI_REQUEST_NULL;
       }
     }
 

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -535,7 +535,7 @@ void CPUSolver::setupMPIBuffers() {
 
       Track* track;
       /* Get 3D Track data */
-      if (_solve_3D) {
+      if (_SOLVE_3D) {
         TrackStackIndexes tsi;
         track = new Track3D();
         TrackGenerator3D* track_generator_3D =
@@ -567,7 +567,7 @@ void CPUSolver::setupMPIBuffers() {
           num_tracks[neighbor]++;
         }
       }
-      if (_solve_3D)
+      if (_SOLVE_3D)
         delete track;
 
     }
@@ -584,7 +584,7 @@ void CPUSolver::setupMPIBuffers() {
 
       Track* track;
       /* Get 3D Track data */
-      if (_solve_3D) {
+      if (_SOLVE_3D) {
         TrackStackIndexes tsi;
         track = new Track3D();
         TrackGenerator3D* track_generator_3D =
@@ -619,7 +619,7 @@ void CPUSolver::setupMPIBuffers() {
           _boundary_tracks.at(neighbor).at(slot) = 2*t + d;
         }
       }
-      if (_solve_3D)
+      if (_SOLVE_3D)
         delete track;
     }
 
@@ -1878,7 +1878,7 @@ void CPUSolver::tallyScalarFlux(segment* curr_segment,
   FP_PRECISION* sigma_t = curr_segment->_material->getSigmaT();
   ExpEvaluator* exp_evaluator = _exp_evaluators[azim_index][polar_index];
 
-  if (_solve_3D) {
+  if (_SOLVE_3D) {
 
     FP_PRECISION length_2D = exp_evaluator->convertDistance3Dto2D(length);
 

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -1279,7 +1279,7 @@ void CPUSolver::boundaryFluxChecker() {
         long connection[2];
         MPI_Recv(connection, 2, MPI_LONG, tester, 0, MPI_cart, &stat);
 
-        /* Check for a broadcast */
+        /* Check for a broadcast of the new tester rank */
         if (connection[0] == -1) {
           tester = connection[1];
         }

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -3642,8 +3642,9 @@ void Cmfd::initialize() {
 void Cmfd::initializeLattice(Point* offset, bool is_2D) {
 
   /* Deal with 2D case, set all widths Z to 1 */
-  if (is_2D) {
-    setNumZ(1);
+  if (is_2D || _width_z == std::numeric_limits<double>::infinity()) {
+    _num_z = 1;
+    _local_num_z = 1;
     _width_z = 1.0;
     _cell_width_z = 1.0;
     _cell_widths_z.resize(_num_z, _cell_width_z);
@@ -3651,7 +3652,7 @@ void Cmfd::initializeLattice(Point* offset, bool is_2D) {
     setBoundary(SURFACE_Z_MAX, REFLECTIVE);
   }
 
-  if(_non_uniform) {
+  if (_non_uniform) {
     setNumX(_cell_widths_x.size());
     setNumY(_cell_widths_y.size());
     setNumZ(_cell_widths_z.size());
@@ -3670,16 +3671,16 @@ void Cmfd::initializeLattice(Point* offset, bool is_2D) {
   _accumulate_y.resize(_num_y+1, 0.0);
   _accumulate_z.resize(_num_z+1, 0.0);
 
-  for(int i=0; i<_num_x; i++)
+  for (int i=0; i<_num_x; i++)
     _accumulate_x[i+1] = _accumulate_x[i] + _cell_widths_x[i];
 
-  for(int i=0; i<_num_y; i++)
+  for (int i=0; i<_num_y; i++)
     _accumulate_y[i+1] = _accumulate_y[i] + _cell_widths_y[i];
 
-  for(int i=0; i<_num_z; i++)
+  for (int i=0; i<_num_z; i++)
     _accumulate_z[i+1] = _accumulate_z[i] + _cell_widths_z[i];
 
-  if(fabs(_width_x - _accumulate_x[_num_x]) > FLT_EPSILON ||
+  if (fabs(_width_x - _accumulate_x[_num_x]) > FLT_EPSILON ||
      fabs(_width_y - _accumulate_y[_num_y]) > FLT_EPSILON ||
      fabs(_width_z - _accumulate_z[_num_z]) > FLT_EPSILON)
     log_printf(ERROR, "The sum of non-uniform mesh widths are not consistent "
@@ -3704,16 +3705,9 @@ void Cmfd::initializeLattice(Point* offset, bool is_2D) {
 
   if (_non_uniform)
     _lattice->setWidths(_cell_widths_x, _cell_widths_y, _cell_widths_z);
-  else {
-    if (is_2D)
-      _lattice->setWidth(_cell_width_x, _cell_width_y, 
-                         std::numeric_limits<double>::infinity());
-    else
-      _lattice->setWidth(_cell_width_x, _cell_width_y, _cell_width_z);
-  }
-
+  else
+    _lattice->setWidth(_cell_width_x, _cell_width_y, _cell_width_z);
   _lattice->setOffset(offset->getX(), offset->getY(), offset->getZ());
-
   _lattice->computeSizes();
 }
 

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -3646,7 +3646,8 @@ void Cmfd::initializeLattice(Point* offset, bool is_2D) {
     _local_num_z = 1;
     _width_z = 1.0;
     _cell_width_z = 1.0;
-    _cell_widths_z.resize(_num_z, _cell_width_z);
+    _cell_widths_z.resize(_num_z);
+    _cell_widths_z[0] = _cell_width_z;
     setBoundary(SURFACE_Z_MIN, REFLECTIVE);
     setBoundary(SURFACE_Z_MAX, REFLECTIVE);
   }

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -253,7 +253,6 @@ Cmfd::~Cmfd() {
 /**
  * @brief Set the number of Mesh cells in a row.
  * @param number of Mesh cells in a row
- * @param whether to set the local number of mesh cells
  */
 void Cmfd::setNumX(int num_x) {
 

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -41,7 +41,7 @@ Cmfd::Cmfd() {
   _SOR_factor = 1.0;
   _num_FSRs = 0;
 #ifndef THREED
-  _solve_3D = false;
+  _SOLVE_3D = false;
 #endif
   _total_tally_size = 0;
   _tallies_allocated = false;
@@ -3786,7 +3786,7 @@ void Cmfd::initializeBackupCmfdSolver() {
   _backup_cmfd->initializeGroupMap();
 
   /* Give CMFD number of FSRs and FSR property arrays */
-  _backup_cmfd->setSolve3D(_solve_3D);
+  _backup_cmfd->setSolve3D(_SOLVE_3D);
   _backup_cmfd->setNumFSRs(_num_FSRs);
   _backup_cmfd->setFSRVolumes(_FSR_volumes);
   _backup_cmfd->setFSRMaterials(_FSR_materials);
@@ -3947,7 +3947,7 @@ int Cmfd::getSense(int surface) {
  */
 void Cmfd::setSolve3D(bool solve_3D) {
 #ifndef THREED
-  _solve_3D = solve_3D;
+  _SOLVE_3D = solve_3D;
 #endif
 }
 

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -571,9 +571,8 @@ inline void Cmfd::tallyCurrent(segment* curr_segment, float* track_flux,
       /* Increment currents on corners and edges */
       else {
 
-        omp_set_lock(&_edge_corner_lock);
-
         int first_ind = (local_cell_id * NUM_SURFACES + surf_id) * ncg;
+        omp_set_lock(&_edge_corner_lock);
 
 #pragma omp simd aligned(currents)
         for (int g=0; g < ncg; g++)
@@ -584,7 +583,7 @@ inline void Cmfd::tallyCurrent(segment* curr_segment, float* track_flux,
     }
     else {
       int pe = 0;
-      for (int p = 0; p < _num_polar/2; p++) {
+      for (int p=0; p < _num_polar/2; p++) {
         for (int e=0; e < _num_moc_groups; e++) {
 
           /* Get the CMFD group */

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -26,7 +26,7 @@
 
 /** Optimization macro for 3D calculations to avoid branch statements */
 #ifdef THREED
-#define _solve_3D (true)
+#define _SOLVE_3D (true)
 #endif
 
 /** Forward declaration of Geometry class */
@@ -262,7 +262,7 @@ private:
 
 #ifndef THREED
   /** Flag indicating whether the problem is 2D or 3D */
-  bool _solve_3D;
+  bool _SOLVE_3D;
 #endif
 
   /** Array of azimuthal track spacings */
@@ -548,7 +548,7 @@ inline void Cmfd::tallyCurrent(segment* curr_segment, float* track_flux,
          __attribute__ ((aligned(VEC_ALIGNMENT))) = {0.0};
     int local_cell_id = getLocalCMFDCell(cell_id);
 
-    if (_solve_3D) {
+    if (_SOLVE_3D) {
       double wgt = _quadrature->getWeightInline(azim_index, polar_index);
       for (int e=0; e < _num_moc_groups; e++) {
 

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -207,6 +207,9 @@ private:
   /** True if the cmfd meshes are non-uniform */
   bool _non_uniform;
 
+  /** True if the cmfd mesh has been adjusted to fit the domain decomposition */
+  bool _widths_adjusted_for_domains;
+
   /** Array of geometry boundaries */
   boundaryType* _boundaries;
 

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -397,7 +397,7 @@ public:
   void initializeCellMap();
   void initializeGroupMap();
   void allocateTallies();
-  void initializeLattice(Point* offset);
+  void initializeLattice(Point* offset, bool is_2D=false);
   void initializeBackupCmfdSolver();
   void copyCurrentsToBackup();
   int findCmfdCell(LocalCoords* coords);

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -383,7 +383,7 @@ private:
 #endif
   void unpackSplitCurrents(bool faces);
   void copyFullSurfaceCurrents();
-  void checkNeutronBalance(bool pre_split=true);
+  void checkNeutronBalance(bool pre_split=true, bool old_source=false);
   void printProlongationFactors(int iteration);
 
 public:

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -524,8 +524,6 @@ inline void Cmfd::tallyCurrent(segment* curr_segment, float* track_flux,
 
   int surf_id, cell_id, cmfd_group;
   int ncg = _num_cmfd_groups;
-  CMFD_PRECISION currents[_num_cmfd_groups] 
-       __attribute__ ((aligned(VEC_ALIGNMENT))) = {0.0};
 
   /* Check if the current needs to be tallied */
   bool tally_current = false;
@@ -543,6 +541,8 @@ inline void Cmfd::tallyCurrent(segment* curr_segment, float* track_flux,
   /* Tally current if necessary */
   if (tally_current) {
 
+    CMFD_PRECISION currents[_num_cmfd_groups] 
+         __attribute__ ((aligned(VEC_ALIGNMENT))) = {0.0};
     int local_cell_id = getLocalCMFDCell(cell_id);
 
     if (_solve_3D) {

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -563,12 +563,12 @@ inline void Cmfd::tallyCurrent(segment* curr_segment, float* track_flux,
       for (int g=0; g < ncg; g++)
         currents[g] *= wgt;
 
-      /* Increment currents on face */
+      /* Increment currents on faces */
       if (surf_id < NUM_FACES) {
         _surface_currents->incrementValues
             (local_cell_id, surf_id*ncg, (surf_id+1)*ncg - 1, currents);
       }
-      /* Increment currents on corners */
+      /* Increment currents on corners and edges */
       else {
 
         omp_set_lock(&_edge_corner_lock);

--- a/src/ExpEvaluator.cpp
+++ b/src/ExpEvaluator.cpp
@@ -259,8 +259,8 @@ void ExpEvaluator::initialize(int azim_index, int polar_index, bool solve_3D) {
 
   /* Allocate array for the table */
   _table_size = num_array_values * _num_exp_terms * _num_polar_terms;
-  _exp_table = (FP_PRECISION*) aligned_alloc(VEC_ALIGNMENT, 
-               _table_size*sizeof(FP_PRECISION));
+  _exp_table = (FP_PRECISION*) memalign(VEC_ALIGNMENT, 
+               _table_size * sizeof(FP_PRECISION));
 
   /* Create exponential linear interpolation table */
   for (int i=0; i < num_array_values; i++) {

--- a/src/ExpEvaluator.h
+++ b/src/ExpEvaluator.h
@@ -11,7 +11,9 @@
 #ifdef __cplusplus
 #define _USE_MATH_DEFINES
 #include "log.h"
+#include "exponentials.h"
 #include "Quadrature.h"
+#include <malloc.h>
 #include <math.h>
 #endif
 

--- a/src/ExpEvaluator.h
+++ b/src/ExpEvaluator.h
@@ -11,7 +11,6 @@
 #ifdef __cplusplus
 #define _USE_MATH_DEFINES
 #include "log.h"
-#include "exponentials.h"
 #include "Quadrature.h"
 #include <malloc.h>
 #include <math.h>

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -630,6 +630,9 @@ void Geometry::setNumDomainModules(int num_x, int num_y, int num_z) {
   _num_modules_x = num_x;
   _num_modules_y = num_y;
   _num_modules_z = num_z;
+
+  log_printf(NORMAL, "Using a [%d %d %d] inner domain structure for track "
+             "laydown.", num_x, num_y, num_z);
 }
 
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -3009,7 +3009,10 @@ void Geometry::initializeCmfd() {
   Point offset;
   offset.setX(min_x + (max_x - min_x)/2.0);
   offset.setY(min_y + (max_y - min_y)/2.0);
-  offset.setZ(min_z + (max_z - min_z)/2.0);
+  if (std::abs(min_z + (max_z - min_z)/2.0) < FLT_INFINITY)
+    offset.setZ(min_z + (max_z - min_z)/2.0);
+  else
+    offset.setZ(0.);
 
   _cmfd->initializeLattice(&offset);
 
@@ -3023,7 +3026,7 @@ void Geometry::initializeCmfd() {
     _cmfd->setDomainIndexes(_domain_index_x, _domain_index_y, _domain_index_z);
   }
 #endif
-  /* Intialize CMFD Maps */
+  /* Initialize CMFD Maps */
   _cmfd->initializeCellMap();
 }
 
@@ -3066,7 +3069,7 @@ void Geometry::initializeSpectrumCalculator(Cmfd* spectrum_calculator) {
   spectrum_calculator->setWidthY(max_y - min_y);
   spectrum_calculator->setWidthZ(max_z - min_z);
 
-  /* Intialize CMFD Maps */
+  /* Initialize CMFD Maps */
   spectrum_calculator->initializeCellMap();
 
   /* Initialize the CMFD lattice */

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -2215,7 +2215,7 @@ void Geometry::segmentizeExtruded(Track* flattened_track,
     /* Check if stuck in loop */
     find_cell_count++;
     if (find_cell_count > 1e6)
-      log_printf(ERROR, "Caught in inifinite loop finding next cell");
+      log_printf(ERROR, "Caught in infinite loop finding next cell");
 
     /* Records the minimum length to a 2D intersection */
     double min_length = std::numeric_limits<double>::infinity();
@@ -4240,6 +4240,7 @@ void Geometry::loadFromFile(std::string filename, bool non_uniform_lattice,
       universes[i] = all_universes[array[i]];
     }
     lattice->setUniverses(num_z, num_y, num_x, universes);
+    delete [] lattice_iter->second;
   }
 
   /* Set root universe */

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -550,8 +550,8 @@ void Material::setNumEnergyGroups(const int num_groups) {
   }
 
   /* Allocate memory for data arrays */
-  _sigma_t = (FP_PRECISION*) aligned_alloc(VEC_ALIGNMENT,
-                                           _num_groups*sizeof(FP_PRECISION));
+  _sigma_t = (FP_PRECISION*) memalign(VEC_ALIGNMENT,
+                                      _num_groups*sizeof(FP_PRECISION));
   _sigma_f = new FP_PRECISION[_num_groups];
   _nu_sigma_f = new FP_PRECISION[_num_groups];
   _chi = new FP_PRECISION[_num_groups];

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -20,7 +20,7 @@ int material_id() {
 
 
 /**
- * @brief Resets the auto-generated unique Material ID counter to 1000,000.
+ * @brief Resets the auto-generated unique Material ID counter to 1,000,000.
  */
 void reset_material_id() {
   auto_id = DEFAULT_INIT_ID;

--- a/src/Material.h
+++ b/src/Material.h
@@ -19,23 +19,22 @@
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
+#include <malloc.h>
 #endif
 
 #ifdef ICPC
-/** Word-aligned memory allocation for Intel's compiler */
-#define MM_FREE(array) _mm_free(array)
-
-/** Word-aligned memory allocation for Intel's compiler */
+/** Aligned memory allocation for Intel's compiler */
 #define MM_MALLOC(size,alignment) _mm_malloc(size, alignment)
 
+/** Aligned memory deallocation for Intel's compiler */
+#define MM_FREE(array) _mm_free(array)
+
 #else
+/** Aligned memory allocation for GNU's compiler */
+#define MM_MALLOC(size,alignment) memalign(alignment, size)
 
-/** Word-aligned memory deallocation for GNU's compiler */
+/** Aligned memory deallocation for GNU's compiler */
 #define MM_FREE(array) free(array)
-
-/** Word-aligned memory allocation for GNU's compiler */
-#define MM_MALLOC(size,alignment) malloc(size)
-
 #endif
 
 

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -172,12 +172,20 @@ std::vector<FP_PRECISION> Mesh::getReactionRates(RxType rx,
   /* If domain decomposed, do a reduction */
 #ifdef MPIx
   if (geometry->isDomainDecomposed()) {
+
+    /* Select appropriate floating point size for transfer */
+    MPI_Datatype precision;
+    if (sizeof(FP_PRECISION) == 4)
+      precision = MPI_FLOAT;
+    else
+      precision = MPI_DOUBLE;
+
     MPI_Comm comm = geometry->getMPICart();
     FP_PRECISION* rx_rates_array = &rx_rates[0];
     FP_PRECISION* rx_rates_send = new FP_PRECISION[size];
     for (int i=0; i < size; i++)
       rx_rates_send[i] = rx_rates_array[i];
-    MPI_Allreduce(rx_rates_send, rx_rates_array, size, MPI_FP, MPI_SUM,
+    MPI_Allreduce(rx_rates_send, rx_rates_array, size, precision, MPI_SUM,
                   comm);
     delete [] rx_rates_send;
   }

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -17,13 +17,6 @@
 /* A Vector3D is simply a 3-dimensional std::vector of floats */
 typedef std::vector<std::vector<std::vector<FP_PRECISION> > > Vector3D;
 
-/* Define a floating point type for domain communication of reaction rates */
-#ifndef SINGLE
-#define MPI_FP (MPI_DOUBLE)
-#else
-#define MPI_FP (MPI_FLOAT)
-#endif
-
 /**
  * @enum RxType
  * @brief The type of reaction to be tallied

--- a/src/ParallelHashMap.h
+++ b/src/ParallelHashMap.h
@@ -429,7 +429,7 @@ void FixedHashMap<K,V>::print_buckets() {
 
 /**
  * @brief Constructor generates initial underlying table as a fixed-sized
- *      hash map and intializes concurrency structures.
+ *      hash map and initializes concurrency structures.
  */
 template <class K, class V>
 ParallelHashMap<K,V>::ParallelHashMap(size_t M, size_t L) {

--- a/src/Region.cpp
+++ b/src/Region.cpp
@@ -368,7 +368,7 @@ boundaryType Region::getMinXBoundaryType() {
   }
 
   /* If the min coordinate is infinite, it's not really a boundary */
-  if (std::abs(min_x) != std::numeric_limits<double>::infinity())
+  if (std::abs(min_x) < FLT_INFINITY)
     return bc;
   else
     return BOUNDARY_NONE;
@@ -407,7 +407,7 @@ boundaryType Region::getMaxXBoundaryType() {
   }
 
   /* If the max coordinate is infinite, it's not really a boundary */
-  if (std::abs(max_x) != std::numeric_limits<double>::infinity())
+  if (std::abs(max_x) < FLT_INFINITY)
     return bc;
   else
     return BOUNDARY_NONE;
@@ -446,7 +446,7 @@ boundaryType Region::getMinYBoundaryType() {
   }
 
   /* If the min coordinate is infinite, it's not really a boundary */
-  if (std::abs(min_y) != std::numeric_limits<double>::infinity())
+  if (std::abs(min_y) < FLT_INFINITY)
     return bc;
   else
     return BOUNDARY_NONE;
@@ -485,7 +485,7 @@ boundaryType Region::getMaxYBoundaryType() {
   }
 
   /* If the max coordinate is infinite, it's not really a boundary */
-  if (std::abs(max_y) != std::numeric_limits<double>::infinity())
+  if (std::abs(max_y) < FLT_INFINITY)
     return bc;
   else
     return BOUNDARY_NONE;
@@ -524,7 +524,7 @@ boundaryType Region::getMinZBoundaryType() {
   }
 
   /* If the min coordinate is infinite, it's not really a boundary */
-  if (std::abs(min_z) != std::numeric_limits<double>::infinity())
+  if (std::abs(min_z) < FLT_INFINITY)
     return bc;
   else
     return BOUNDARY_NONE;
@@ -562,7 +562,7 @@ boundaryType Region::getMaxZBoundaryType() {
     }
   }
   /* If the max coordinate is infinite, it's not really a boundary */
-  if (std::abs(max_z) != std::numeric_limits<double>::infinity())
+  if (std::abs(max_z) < FLT_INFINITY)
     return bc;
   else
     return BOUNDARY_NONE;

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -774,11 +774,8 @@ void Solver::initializeFSRs() {
   _FSR_materials = new Material*[_num_FSRs];
 
   /* Loop over all FSRs to extract FSR material pointers */
-  for (long r=0; r < _num_FSRs; r++) {
+  for (long r=0; r < _num_FSRs; r++)
     _FSR_materials[r] = _geometry->findFSRMaterial(r);
-    log_printf(DEBUG, "FSR ID = %d has Material ID = %d, volume = %f", r, 
-               _FSR_materials[r]->getId(), _FSR_volumes[r]);
-  }
 }
 
 
@@ -1622,8 +1619,11 @@ void Solver::printTimerReport() {
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), transport_sweep);
 
+  double transfer_time = 0.;
+  double idle_time = 0.;
+#ifdef MPIx
   /* Boundary track angular fluxes transfer */
-  double transfer_time = _timer->getSplit("Total transfer time");
+  transfer_time = _timer->getSplit("Total transfer time");
   msg_string = "    Angular Flux Transfer";
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), transfer_time);
@@ -1641,10 +1641,11 @@ void Solver::printTimerReport() {
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), comm_time);
 
   /* Idle time between transport sweep and angular fluxes transfer */
-  double idle_time = _timer->getSplit("Idle time");
+  idle_time = _timer->getSplit("Idle time");
   msg_string = "    Total Idle Time Between Sweeps";
   msg_string.resize(53, '.');
   log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), idle_time);
+#endif
 
   /* CMFD acceleration time */
   if (_cmfd != NULL)

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -36,7 +36,7 @@ Solver::Solver(TrackGenerator* track_generator) {
   _exp_evaluators[0] = new ExpEvaluator*[_num_exp_evaluators_polar];
   _exp_evaluators[0][0] = new ExpEvaluator();
 #ifndef THREED
-  _solve_3D = false;
+  _SOLVE_3D = false;
 #endif
   _segment_formation = EXPLICIT_2D;
 
@@ -424,7 +424,7 @@ void Solver::setTrackGenerator(TrackGenerator* track_generator) {
     _polar_spacings = _quad->getPolarSpacings();
     _tracks_per_stack = track_generator_3D->getTracksPerStack();
 #ifndef THREED
-    _solve_3D = true;
+    _SOLVE_3D = true;
 #endif
   }
   else {
@@ -434,7 +434,7 @@ void Solver::setTrackGenerator(TrackGenerator* track_generator) {
     log_printf(ERROR, "OpenMOC has been compiled for 3D cases only, please "
                "recompile without the -DTHREED optimization flag.");
 #else
-    _solve_3D = false;
+    _SOLVE_3D = false;
 #endif
   }
 
@@ -683,7 +683,7 @@ void Solver::initializeExpEvaluators() {
 
   /* Determine number of exponential evaluators */
   _num_exp_evaluators_azim = _num_azim / 4;
-  if (_solve_3D)
+  if (_SOLVE_3D)
     _num_exp_evaluators_polar = _num_polar / 2;
   else
     _num_exp_evaluators_polar = 1;
@@ -713,7 +713,7 @@ void Solver::initializeExpEvaluators() {
   /* Initialize exponential interpolation table */
   for (int a=0; a < _num_exp_evaluators_azim; a++)
     for (int p=0; p < _num_exp_evaluators_polar; p++)
-      _exp_evaluators[a][p]->initialize(a, p, _solve_3D);
+      _exp_evaluators[a][p]->initialize(a, p, _SOLVE_3D);
 }
 
 
@@ -748,7 +748,7 @@ void Solver::initializeFSRs() {
   _num_groups = _geometry->getNumEnergyGroups();
   _num_materials = _geometry->getNumMaterials();
 
-  if (_solve_3D) {
+  if (_SOLVE_3D) {
     _fluxes_per_track = _num_groups;
   }
   else {
@@ -1048,7 +1048,7 @@ void Solver::initializeCmfd() {
   _cmfd->initializeGroupMap();
 
   /* Give CMFD number of FSRs and FSR property arrays */
-  _cmfd->setSolve3D(_solve_3D);
+  _cmfd->setSolve3D(_SOLVE_3D);
   _cmfd->setNumFSRs(_num_FSRs);
   _cmfd->setFSRVolumes(_FSR_volumes);
   _cmfd->setFSRMaterials(_FSR_materials);
@@ -1096,7 +1096,7 @@ void Solver::calculateInitialSpectrum(double threshold) {
   _geometry->initializeSpectrumCalculator(&spectrum_calculator);
 
   /* If 2D Solve, set z-direction mesh size to 1 and depth to 1.0 */
-  if (!_solve_3D) {
+  if (!_SOLVE_3D) {
     spectrum_calculator.setNumZ(1);
     spectrum_calculator.setBoundary(SURFACE_Z_MIN, REFLECTIVE);
     spectrum_calculator.setBoundary(SURFACE_Z_MAX, REFLECTIVE);
@@ -1108,7 +1108,7 @@ void Solver::calculateInitialSpectrum(double threshold) {
   spectrum_calculator.initializeGroupMap();
 
   /* Give the spectrum calculator the number of FSRs and FSR property arrays */
-  spectrum_calculator.setSolve3D(_solve_3D);
+  spectrum_calculator.setSolve3D(_SOLVE_3D);
   spectrum_calculator.setNumFSRs(_num_FSRs);
   spectrum_calculator.setFSRVolumes(_FSR_volumes);
   spectrum_calculator.setFSRMaterials(_FSR_materials);
@@ -2092,7 +2092,7 @@ void Solver::printInputParamsSummary() {
              _track_generator->getDesiredAzimSpacing());
   log_printf(NORMAL, "Number of polar angles = %d",
              _quad->getNumPolarAngles());
-  if (_solve_3D) {
+  if (_SOLVE_3D) {
     TrackGenerator3D* track_generator_3D =
       static_cast<TrackGenerator3D*>(_track_generator);
     log_printf(NORMAL, "Z-spacing = %f",

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -2126,7 +2126,7 @@ void Solver::printInputParamsSummary() {
     log_printf(NORMAL, "CMFD acceleration: ON");
     log_printf(NORMAL, "CMFD Mesh: %d x %d x %d", _cmfd->getNumX(),
                _cmfd->getNumY(), _cmfd->getNumZ());
-    if (_num_groups != _cmfd->getNumMOCGroups()) {
+    if (_num_groups != _cmfd->getNumCmfdGroups()) {
       log_printf(NORMAL, "CMFD Group Structure:");
       log_printf(NORMAL, "\t MOC Group \t CMFD Group");
       for (int g=0; g < _cmfd->getNumMOCGroups(); g++)

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1042,7 +1042,7 @@ void Solver::initializeCmfd() {
   else if (!_cmfd->isFluxUpdateOn())
     return;
 
-  /* Intialize the CMFD energy group structure */
+  /* Initialize the CMFD energy group structure */
   _cmfd->setSourceConvergenceThreshold(_converge_thresh*1.e-1); //FIXME
   _cmfd->setNumMOCGroups(_num_groups);
   _cmfd->initializeGroupMap();
@@ -1102,7 +1102,7 @@ void Solver::calculateInitialSpectrum(double threshold) {
     spectrum_calculator.setBoundary(SURFACE_Z_MAX, REFLECTIVE);
   }
 
-  /* Intialize the energy group structure */
+  /* Initialize the energy group structure */
   spectrum_calculator.setSourceConvergenceThreshold(threshold);
   spectrum_calculator.setNumMOCGroups(_num_groups);
   spectrum_calculator.initializeGroupMap();

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -184,7 +184,7 @@ protected:
 
 #ifndef THREED
   /** Boolean for whether to solve in 3D (true) or 2D (false) */
-  bool _solve_3D;
+  bool _SOLVE_3D;
 #endif
 
   /** Boolean to indicate whether there are any fixed sources */

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1046,24 +1046,37 @@ void TrackGenerator::initializeTrackReflections() {
       /* Get current track */
       Track* track = &_tracks_2D[a][i];
 
-      /* Set the foward boundary conditions */
+      /* Set the forward boundary conditions */
       if (a < _num_azim/4) {
         if (i < _num_y[a]) {
           track->setBCFwd(_geometry->getMaxXBoundaryType());
           track->setSurfaceOut(SURFACE_X_MAX);
+#ifdef MPIx
+          track->setDomainFwd(_geometry->getNeighborDomain(1, 0, 0));
+#endif
         }
         else {
           track->setBCFwd(_geometry->getMaxYBoundaryType());
           track->setSurfaceOut(SURFACE_Y_MAX);
+#ifdef MPIx
+          track->setDomainFwd(_geometry->getNeighborDomain(0, 1, 0));
+#endif
         }
 
         if (i < _num_x[a]) {
           track->setBCBwd(_geometry->getMinYBoundaryType());
           track->setSurfaceIn(SURFACE_Y_MIN);
+#ifdef MPIx
+          track->setDomainBwd(_geometry->getNeighborDomain(0, -1, 0));
+#endif
+
         }
         else {
           track->setBCBwd(_geometry->getMinXBoundaryType());
           track->setSurfaceIn(SURFACE_X_MIN);
+#ifdef MPIx
+          track->setDomainBwd(_geometry->getNeighborDomain(-1, 0, 0));
+#endif
         }
       }
 
@@ -1072,19 +1085,31 @@ void TrackGenerator::initializeTrackReflections() {
         if (i < _num_y[a]) {
           track->setBCFwd(_geometry->getMinXBoundaryType());
           track->setSurfaceOut(SURFACE_X_MIN);
+#ifdef MPIx
+          track->setDomainFwd(_geometry->getNeighborDomain(-1, 0, 0));
+#endif
         }
         else {
           track->setBCFwd(_geometry->getMaxYBoundaryType());
           track->setSurfaceOut(SURFACE_Y_MAX);
+#ifdef MPIx
+          track->setDomainFwd(_geometry->getNeighborDomain(0, 1, 0));
+#endif
         }
 
         if (i < _num_x[a]) {
           track->setBCBwd(_geometry->getMinYBoundaryType());
           track->setSurfaceIn(SURFACE_Y_MIN);
+#ifdef MPIx
+          track->setDomainBwd(_geometry->getNeighborDomain(0, -1, 0));
+#endif
         }
         else {
           track->setBCBwd(_geometry->getMaxXBoundaryType());
           track->setSurfaceIn(SURFACE_X_MAX);
+#ifdef MPIx
+          track->setDomainBwd(_geometry->getNeighborDomain(1, 0, 0));
+#endif
         }
       }
 
@@ -1173,12 +1198,11 @@ void TrackGenerator::segmentize() {
                    "may be missing.");
 
       /* Re-initialize CMFD lattice with 2D dimensions */
-      cmfd->setWidthZ(std::numeric_limits<double>::infinity());
       Point offset;
       offset.setX(cmfd->getLattice()->getOffset()->getX());
       offset.setY(cmfd->getLattice()->getOffset()->getY());
       offset.setZ(0.0);
-      cmfd->initializeLattice(&offset);
+      cmfd->initializeLattice(&offset, true);
     }
   }
 

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1201,7 +1201,7 @@ void TrackGenerator::segmentize() {
       Point offset;
       offset.setX(cmfd->getLattice()->getOffset()->getX());
       offset.setY(cmfd->getLattice()->getOffset()->getY());
-      offset.setZ(0.0);
+      offset.setZ(_z_coord);
       cmfd->initializeLattice(&offset, true);
     }
   }

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1617,7 +1617,6 @@ void TrackGenerator::generateFSRCentroids(FP_PRECISION* FSR_volumes) {
   /* Print FSR volumes, centroids and volume moments for debugging purposes */
   double total_volume[4] = {0.0};
   for (long r=0; r < num_FSRs; r++) {
-    Point* centroid = _geometry->getFSRCentroid(r);
     total_volume[0] += _FSR_volumes[r];
     total_volume[1] += _FSR_volumes[r] * centroids[r]->getX();
     total_volume[2] += _FSR_volumes[r] * centroids[r]->getY();
@@ -1627,10 +1626,10 @@ void TrackGenerator::generateFSRCentroids(FP_PRECISION* FSR_volumes) {
                " (%f %f %f)", r, _FSR_volumes[r], centroids[r]->getX(),
                centroids[r]->getY(), centroids[r]->getZ());
   }
+
   log_printf(DEBUG, "Total volume %f cm3, moments of volume (%f %f %f).",
              total_volume[0], total_volume[1], total_volume[2],
              total_volume[3]);
-
   delete [] centroids;
 }
 

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -348,6 +348,12 @@ FP_PRECISION* TrackGenerator::getFSRVolumes() {
                "no track traversed the FSRs. Use a finer track laydown to "
                "ensure every FSR is traversed.", num_zero_volume_fsrs);
 
+  /* Print out total domains' volumes for debugging purposes */
+  double total_volume = 0;
+  for (long r=0; r < num_FSRs; r++)
+    total_volume += _FSR_volumes[r];
+  log_printf(DEBUG, "Total volume %f cm3.", total_volume);
+
   return _FSR_volumes;
 }
 
@@ -1151,13 +1157,22 @@ void TrackGenerator::segmentize() {
   double max_z = _geometry->getRootUniverse()->getMaxZ();
   double min_z = _geometry->getRootUniverse()->getMinZ();
   if ((max_z - min_z) != std::numeric_limits<double>::infinity()) {
-    log_printf(WARNING, "The Geometry was set with non-inifinite z-boundaries"
-               " and supplied to a 2D TrackGenerator. The min-z boundary was "
-               "set to %5.2f and the max-z boundary was set to %5.2f. "
-               "Z-boundaries are assumed to be infinite in 2D "
+    log_printf(WARNING_ONCE, "The Geometry was set with non-inifinite "
+               "z-boundaries and supplied to a 2D TrackGenerator. The min-z "
+               "boundary wasset to %5.2f and the max-z boundary was set to "
+               "%5.2f. Z-boundaries are assumed to be infinite in 2D "
                "TrackGenerators.", min_z, max_z);
+
     Cmfd* cmfd = _geometry->getCmfd();
     if (cmfd != NULL) {
+
+      /* Check that CMFD has been initialized */
+      if (cmfd->getLattice() == NULL)
+        log_printf(ERROR, "CMFD has not been initialized before generating "
+                   "tracks. A call to geometry.initializeFlatSourceRegions() "
+                   "may be missing.");
+
+      /* Re-initialize CMFD lattice with 2D dimensions */
       cmfd->setWidthZ(std::numeric_limits<double>::infinity());
       Point offset;
       offset.setX(cmfd->getLattice()->getOffset()->getX());
@@ -1574,6 +1589,23 @@ void TrackGenerator::generateFSRCentroids(FP_PRECISION* FSR_volumes) {
     rs.execute();
     _segments_centered = true;
   }
+
+  /* Print FSR volumes, centroids and volume moments for debugging purposes */
+  double total_volume[4] = {0.0};
+  for (long r=0; r < num_FSRs; r++) {
+    Point* centroid = _geometry->getFSRCentroid(r);
+    total_volume[0] += _FSR_volumes[r];
+    total_volume[1] += _FSR_volumes[r] * centroids[r]->getX();
+    total_volume[2] += _FSR_volumes[r] * centroids[r]->getY();
+    total_volume[3] += _FSR_volumes[r] * centroids[r]->getZ();
+
+    log_printf(DEBUG, "FSR ID = %d has volume = %f, centroid"
+               " (%f %f %f)", r, _FSR_volumes[r], centroids[r]->getX(),
+               centroids[r]->getY(), centroids[r]->getZ());
+  }
+  log_printf(DEBUG, "Total volume %f cm3, moments of volume (%f %f %f).",
+             total_volume[0], total_volume[1], total_volume[2],
+             total_volume[3]);
 
   delete [] centroids;
 }

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -333,17 +333,20 @@ FP_PRECISION* TrackGenerator::getFSRVolumes() {
   volume_calculator.execute();
 
   /* Check to ensure all FSRs are crossed by at least one track */
+  long num_zero_volume_fsrs = 0;
   for (long i=0; i < num_FSRs; i++) {
     if (fabs(_FSR_volumes[i]) < FLT_EPSILON) {
-      log_printf(ERROR, "Zero volume calculated for FSR %d, point (%f, %f, %f)",
+      num_zero_volume_fsrs++;
+      log_printf(WARNING, "Zero volume calculated for FSR %d, point (%f, %f, %f)",
                  i, _geometry->getFSRPoint(i)->getX(),
                  _geometry->getFSRPoint(i)->getY(),
                  _geometry->getFSRPoint(i)->getZ());
-      log_printf(ERROR, "Zero volume calculated in an FSR region since no "
-               "track traversed the FSR. Use a finer track laydown to ensure "
-               "every FSR is traversed.");
     }
   }
+  if (num_zero_volume_fsrs > 0)
+    log_printf(NODAL, "Zero volume calculated in %ld FSR regions since "
+               "no track traversed the FSRs. Use a finer track laydown to "
+               "ensure every FSR is traversed.", num_zero_volume_fsrs);
 
   return _FSR_volumes;
 }

--- a/src/TrackGenerator3D.cpp
+++ b/src/TrackGenerator3D.cpp
@@ -1888,7 +1888,7 @@ void TrackGenerator3D::setLinkingTracks(TrackStackIndexes* tsi,
       tci_refl._polar = pc;
       tci_refl._lz    = nl + 2 * nz - lz - 1;
 
-      /* PERIODIC BC */
+      /* PERIODIC or INTERFACE BC */
       if (_geometry->getMaxZBoundaryType() == PERIODIC ||
           _geometry->getMaxZBoundaryType() == INTERFACE)
         tci_next._lz    = lz - nz;
@@ -1946,7 +1946,7 @@ void TrackGenerator3D::setLinkingTracks(TrackStackIndexes* tsi,
       tci_refl._lz    = nl - lz - 1;
       tci_refl._link = getNum3DTrackChainLinks(&tci_refl) - 1;
 
-      /* PERIODIC BC */
+      /* PERIODIC or INTERFACE BC */
       if (_geometry->getMinZBoundaryType() == PERIODIC ||
           _geometry->getMinZBoundaryType() == INTERFACE) {
         tci_next._lz    = lz + nz;
@@ -2098,7 +2098,7 @@ void TrackGenerator3D::setLinkingTracks(TrackStackIndexes* tsi,
       tci_refl._lz    = nl + 2 * nz - lz - 1;
       tci_refl._link = getNum3DTrackChainLinks(&tci_refl) - 1;
 
-      /* PERIODIC BC */
+      /* PERIODIC or INTERFACE BC */
       if (_geometry->getMaxZBoundaryType() == PERIODIC ||
           _geometry->getMaxZBoundaryType() == INTERFACE) {
         tci_next._lz    = lz - nz;
@@ -2156,7 +2156,7 @@ void TrackGenerator3D::setLinkingTracks(TrackStackIndexes* tsi,
       tci_refl._polar = pc;
       tci_refl._lz    = nl - lz - 1;
 
-      /* PERIODIC BC */
+      /* PERIODIC or INTERFACE BC */
       if (_geometry->getMinZBoundaryType() == PERIODIC ||
           _geometry->getMinZBoundaryType() == INTERFACE)
         tci_next._lz    = lz + nz;

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -731,7 +731,7 @@ void Universe::calculateBoundaries() {
 
   /* If a x-min boundary was not found, get the x-min from the bounding boxes
    * of the cells */
-  if (min_x == std::numeric_limits<double>::infinity()) {
+  if (min_x > FLT_INFINITY) {
     for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
       min_x = std::min(min_x, c_iter->second->getMinX());
   }
@@ -772,7 +772,7 @@ void Universe::calculateBoundaries() {
 
   /* If a x-max boundary was not found, get the x-max from the bounding boxes
    * of the cells */
-  if (max_x == -std::numeric_limits<double>::infinity()) {
+  if (max_x < -FLT_INFINITY) {
     for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
       max_x = std::max(max_x, c_iter->second->getMaxX());
   }
@@ -814,7 +814,7 @@ void Universe::calculateBoundaries() {
 
   /* If a y-min boundary was not found, get the y-min from the bounding boxes
    * of the cells */
-  if (min_y == std::numeric_limits<double>::infinity()) {
+  if (min_y > FLT_INFINITY) {
     for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
       min_y = std::min(min_y, c_iter->second->getMinY());
   }
@@ -855,7 +855,7 @@ void Universe::calculateBoundaries() {
 
   /* If a y-max boundary was not found, get the y-max from the bounding boxes
    * of the cells */
-  if (max_y == -std::numeric_limits<double>::infinity()) {
+  if (max_y < -FLT_INFINITY) {
     for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
       max_y = std::max(max_y, c_iter->second->getMaxY());
   }
@@ -896,7 +896,7 @@ void Universe::calculateBoundaries() {
 
   /* If a z-min boundary was not found, get the z-min from the bounding boxes
    * of the cells */
-  if (min_z == std::numeric_limits<double>::infinity()) {
+  if (min_z > FLT_INFINITY) {
     for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
       min_z = std::min(min_z, c_iter->second->getMinZ());
   }
@@ -937,7 +937,7 @@ void Universe::calculateBoundaries() {
 
   /* If a z-max boundary was not found, get the z-max from the bounding boxes
    * of the cells */
-  if (max_z == -std::numeric_limits<double>::infinity()) {
+  if (max_z < -FLT_INFINITY) {
     for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
       max_z = std::max(max_z, c_iter->second->getMaxZ());
   }

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -2254,9 +2254,9 @@ void Lattice::computeSizes(){
   }
 
   /* Compute the accumulated lengths along each axis */
-  _accumulate_x.resize(_num_x+1,0.0);
-  _accumulate_y.resize(_num_y+1,0.0);
-  _accumulate_z.resize(_num_z+1,0.0);
+  _accumulate_x.resize(_num_x+1, 0.0);
+  _accumulate_y.resize(_num_y+1, 0.0);
+  _accumulate_z.resize(_num_z+1, 0.0);
 
   for(int i=0; i<_num_x; i++)
     _accumulate_x[i+1] = _accumulate_x[i] + _widths_x[i];
@@ -2277,7 +2277,7 @@ void Lattice::printLatticeSizes() {
   printf("non_uniform=%d, \nNum_XYZ: %2d, %2d, %2d\n", _non_uniform, 
          _num_x, _num_y, _num_z);
   printf("offset: %f, %f, %f\n", _offset.getX(),_offset.getY(),_offset.getZ());
-  printf("cell_width_XYZ: %f, %f, %f\n", _width_x,_width_y,_width_z);
+  printf("cell_width_XYZ: %f, %f, %f\n", _width_x, _width_y, _width_z);
   printf("cell_widths_XYZ:\n");
   for(i=0; i<_num_x; i++)
     printf("i=%d, %f; ",i, _widths_x[i]);

--- a/src/linalg.cpp
+++ b/src/linalg.cpp
@@ -862,7 +862,7 @@ bool ddLinearSolve(Matrix* A, Matrix* M, Vector* X, Vector* B, double tol,
   CMFD_PRECISION* dd_array = dd.getArray();
   CMFD_PRECISION* x = X->getArray();
 
-  /* Stabalize matrix A to be diagonally dominant */
+  /* Stabilize matrix A to be diagonally dominant */
   CMFD_PRECISION* a = A->getA();
   CMFD_PRECISION* a_diag = A->getDiag();
   int* IA = A->getIA();
@@ -957,7 +957,7 @@ bool ddLinearSolve(Matrix* A, Matrix* M, Vector* X, Vector* B, double tol,
     bool converged = linearSolve(A, M, X, &RHS, tol, SOR_factor,
                                  convergence_data, comm);
     if (!converged)
-      log_printf(ERROR, "Stabalized linear solver inner iteration failed"
+      log_printf(ERROR, "Stabilized linear solver inner iteration failed"
                  " to converge");
 
     // Compute the new source

--- a/src/linalg.cpp
+++ b/src/linalg.cpp
@@ -134,7 +134,7 @@ double eigenvalueSolve(Matrix* A, Matrix* M, Vector* X, double k_eff,
     /* Copy the new source to the old source */
     new_source.copyTo(&old_source);
 
-    log_printf(INFO, "Matrix-Vector eigenvalue iter: %d, keff: %f, residual: "
+    log_printf(INFO_ONCE, "Matrix-Vector eigenvalue iter: %d, keff: %f, residual: "
                "%3.2e", iter, k_eff, residual);
 
     /* Check for convergence */
@@ -148,7 +148,7 @@ double eigenvalueSolve(Matrix* A, Matrix* M, Vector* X, double k_eff,
     }
   }
 
-  log_printf(INFO, "Matrix-Vector eigenvalue solve iterations: %d", iter);
+  log_printf(INFO_ONCE, "Matrix-Vector eigenvalue solve iterations: %d", iter);
   if (iter == MAX_LINALG_POWER_ITERATIONS)
     log_printf(ERROR, "Eigenvalue solve failed to converge in %d iterations",
                iter);
@@ -328,7 +328,7 @@ bool linearSolve(Matrix* A, Matrix* M, Vector* X, Vector* B, double tol,
     // Increment the interations counter
     iter++;
 
-    log_printf(INFO, "SOR iter: %d, residual: %3.2e, initial residual: %3.2e"
+    log_printf(DEBUG, "SOR iter: %d, residual: %3.2e, initial residual: %3.2e"
                ", ratio = %3.2e, tolerance: %3.2e, end? %d", iter, residual,
                initial_residual, residual / initial_residual, tol,
                (residual / initial_residual < 0.1 || residual < tol) &&
@@ -343,7 +343,7 @@ bool linearSolve(Matrix* A, Matrix* M, Vector* X, Vector* B, double tol,
     }
   }
 
-  log_printf(INFO, "linear solve iterations: %d", iter);
+  log_printf(DEBUG, "linear solve iterations: %d", iter);
 
   // Check if the maximum iterations were reached
   if (iter == MAX_LINEAR_SOLVE_ITERATIONS) {

--- a/src/linalg.cpp
+++ b/src/linalg.cpp
@@ -138,8 +138,8 @@ double eigenvalueSolve(Matrix* A, Matrix* M, Vector* X, double k_eff,
                "%3.2e", iter, k_eff, residual);
 
     /* Check for convergence */
-    if ((residual / initial_residual < 0.03) &&
-        iter > MIN_LINALG_POWER_ITERATIONS) {
+    if ((residual / initial_residual < 0.03 || residual < MIN_LINALG_TOLERANCE)
+        && iter > MIN_LINALG_POWER_ITERATIONS) {
       if (convergence_data != NULL) {
         convergence_data->cmfd_res_end = residual;
         convergence_data->cmfd_iters = iter;
@@ -400,6 +400,7 @@ void getCouplingTerms(DomainCommunicator* comm, int color, int*& coupling_sizes,
 
     int ng = comm->num_groups;
 
+    // Get numerical precision for communication
     MPI_Datatype flux_type;
     if (sizeof(CMFD_PRECISION) == 4)
       flux_type = MPI_FLOAT;

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -574,7 +574,7 @@ void log_printf(logLevel level, const char* format, ...) {
       {
 #ifdef MPIx
         if (_MPI_present) {
-          printf("%s", "[  ERROR  ] ");
+          printf("%s", "[  ERROR  ]  ");
           printf("%s", &msg_string[0]);
           fflush(stdout);
           MPI_Finalize();

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -569,8 +569,11 @@ void log_printf(logLevel level, const char* format, ...) {
     log_file.close();
 
     /* Write the log message to the shell */
+#ifdef SWIG  //FIXME Critical clause to avoid SEGFAULTS with too much output
+#pragma omp critical
+      {
+#endif
     if (level == ERROR) {
-      omp_set_lock(&log_error_lock);
       {
 #ifdef MPIx
         if (_MPI_present) {
@@ -580,14 +583,16 @@ void log_printf(logLevel level, const char* format, ...) {
           MPI_Abort(_MPI_comm, 0);
         }
 #endif
-        throw std::logic_error(msg_string.c_str());
+        throw std::logic_error(&msg_string[0]);
       }
-      omp_unset_lock(&log_error_lock);
     }
     else {
       printf("%s", &msg_string[0]);
       fflush(stdout);
     }
+#ifdef SWIG
+    }
+#endif
   }
 }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -225,47 +225,47 @@ void set_log_level(const char* new_level) {
 
   if (strcmp("DEBUG", new_level) == 0) {
     log_level = DEBUG;
-    log_printf(INFO, "Logging level set to DEBUG");
+    log_printf(INFO_ONCE, "Logging level set to DEBUG");
   }
   else if (strcmp("INFO", new_level) == 0) {
     log_level = INFO;
-    log_printf(INFO, "Logging level set to INFO");
+    log_printf(INFO_ONCE, "Logging level set to INFO");
   }
   else if (strcmp("NORMAL", new_level) == 0) {
     log_level = NORMAL;
-    log_printf(INFO, "Logging level set to NORMAL");
+    log_printf(INFO_ONCE, "Logging level set to NORMAL");
   }
   else if (strcmp("SEPARATOR", new_level) == 0) {
     log_level = SEPARATOR;
-    log_printf(INFO, "Logging level set to SEPARATOR");
+    log_printf(INFO_ONCE, "Logging level set to SEPARATOR");
   }
   else if (strcmp("HEADER", new_level) == 0) {
     log_level = HEADER;
-    log_printf(INFO, "Logging level set to HEADER");
+    log_printf(INFO_ONCE, "Logging level set to HEADER");
   }
   else if (strcmp("TITLE", new_level) == 0) {
     log_level = TITLE;
-    log_printf(INFO, "Logging level set to TITLE");
+    log_printf(INFO_ONCE, "Logging level set to TITLE");
   }
   else if (strcmp("WARNING", new_level) == 0) {
     log_level = WARNING;
-    log_printf(INFO, "Logging level set to WARNING");
+    log_printf(INFO_ONCE, "Logging level set to WARNING");
   }
   else if (strcmp("CRITICAL", new_level) == 0) {
     log_level = CRITICAL;
-    log_printf(INFO, "Logging level set to CRITICAL");
+    log_printf(INFO_ONCE, "Logging level set to CRITICAL");
   }
   else if (strcmp("RESULT", new_level) == 0) {
     log_level = RESULT;
-    log_printf(INFO, "Logging level set to RESULT");
+    log_printf(INFO_ONCE, "Logging level set to RESULT");
   }
   else if (strcmp("UNITTEST", new_level) == 0) {
     log_level = UNITTEST;
-    log_printf(INFO, "Logging level set to UNITTEST");
+    log_printf(INFO_ONCE, "Logging level set to UNITTEST");
   }
   else if (strcmp("ERROR", new_level) == 0) {
       log_level = ERROR;
-      log_printf(INFO, "Logging level set to ERROR");
+      log_printf(INFO_ONCE, "Logging level set to ERROR");
   }
 }
 
@@ -327,6 +327,24 @@ void log_printf(logLevel level, const char* format, ...) {
       }
     case (INFO):
       {
+        std::string msg = std::string(message);
+        std::string level_prefix = "[  INFO   ]  ";
+
+        /* If message is too long for a line, split into many lines */
+        if (int(msg.length()) > line_length)
+          msg_string = create_multiline_msg(level_prefix, msg);
+
+        /* Puts message on single line */
+        else
+          msg_string = level_prefix + msg + "\n";
+
+        break;
+      }
+    case (INFO_ONCE):
+      {
+        if (rank != 0)
+          return;
+
         std::string msg = std::string(message);
         std::string level_prefix = "[  INFO   ]  ";
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -580,8 +580,8 @@ void log_printf(logLevel level, const char* format, ...) {
         MPI_Abort(_MPI_comm, 0);
       }
 #endif
-      throw std::logic_error(&msg_string[0]);
       omp_unset_lock(&log_error_lock);
+      throw std::logic_error(&msg_string[0]);
     }
     else {
       printf("%s", &msg_string[0]);

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -577,9 +577,7 @@ void log_printf(logLevel level, const char* format, ...) {
           printf("%s", "[  ERROR  ]  ");
           printf("%s", &msg_string[0]);
           fflush(stdout);
-          MPI_Finalize();
           MPI_Abort(_MPI_comm, 0);
-          //FIXME Not best communicator to abort, but better than not returning.
         }
 #endif
         throw std::logic_error(msg_string.c_str());

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -433,6 +433,24 @@ void log_printf(logLevel level, const char* format, ...) {
 
         break;
       }
+    case (WARNING_ONCE):
+      {
+        if (rank != 0)
+          return;
+
+        std::string msg = std::string(message);
+        std::string level_prefix = "[ WARNING ]  ";
+
+        /* If message is too long for a line, split into many lines */
+        if (int(msg.length()) > line_length)
+          msg_string = create_multiline_msg(level_prefix, msg);
+
+        /* Puts message on single line */
+        else
+          msg_string = level_prefix + msg + "\n";
+
+        break;
+      }
     case (CRITICAL):
       {
         std::string msg = std::string(message);

--- a/src/log.h
+++ b/src/log.h
@@ -51,6 +51,9 @@ typedef enum {
   /** An informational but verbose message */
   INFO,
 
+  /** An informational verbose message - printed by rank 0 process only */
+  INFO_ONCE,
+
   /** A brief progress update on run progress */
   NORMAL,
 
@@ -66,11 +69,11 @@ typedef enum {
   /** A message sandwiched between two lines of characters */
   TITLE,
 
-  /** A message to warn the user - to be printed by rank 0 process only */
-  WARNING_ONCE,
-
   /** A message to warn the user */
   WARNING,
+
+  /** A message to warn the user - to be printed by rank 0 process only */
+  WARNING_ONCE,
 
   /** A message to warn of critical program conditions */
   CRITICAL,

--- a/src/log.h
+++ b/src/log.h
@@ -66,6 +66,9 @@ typedef enum {
   /** A message sandwiched between two lines of characters */
   TITLE,
 
+  /** A message to warn the user - to be printed by rank 0 process only */
+  WARNING_ONCE,
+
   /** A message to warn the user */
   WARNING,
 


### PR DESCRIPTION
This PR is meant to flush out all the improvements and fixes I've made before making the SIMD exponentials PR, which will require to update all tests results a priori. 

Major components :
1. 2D domain decomposition is enabled
2. Automatic adjustment of the CMFD mesh to the domain boundaries, either by adjusting or adding new cells depending on the mismatch. This should reduce the occurence of floating point errors on the mesh dimensions causing the code to believe there's a mismatch
3. "python setup.py clean" now actually cleans everything. The partial cleaning has played so many tricks on me while developing !!
4. Using domain decomposition from Python should work now. It only took "conda install mpi4py" for me
5. Less log output in domain decomposed simulations with the _ONCE log levels
6. Boundary flux checker has been slightly improved to check boundary conditions as well
7. CMFD cell neutron (im)balance checker can now check domain-decomposed CMFD meshes and can now check MOC neutron balance, and expect a zero sum. Before that, a zero sum was not expected since the new flux was used, and the scattering source is not converged with the new flux. 
8. A couple race conditions on the segment edges have been fixed. Admittedly, these were litteraly never happening.
9. A bug fix for SEG FAULTS when outputting too much stuff with the Python build
10. A bug fix for ERROR messages causing the code to hang with the Python build
9 and 10 are rolled back, using a critical openmp clause was freezing the test suite

Optimizations :
1. By sharing a division between multiple terms in the Gauss Seidel solver, it is now 14% faster
2. When transferring currents between '_boundary_fluxes" and "_start_fluxes", we were checking and resetting the vacuum boundary fluxes, this was not necessary. 
3. The CMFD current buffer is only allocated when needed : -0.2 ns per segment

@mit-crpg/openmoc-dev anyone to review please