### PR TITLE
fix compilation on python>3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -317,7 +317,7 @@ def parallel_compile(self, sources, output_dir=None, macros=None,
       self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
 
   # Convert thread mapping to C/C++/CUDA objects to a list and return
-  list(pool.ThreadPool(num_cpus).imap(_single_compile, objects))
+  list(pool.ThreadPool(num_cpus).map(_single_compile, objects))
   return objects
 
 


### PR DESCRIPTION
Hi,

#390 found that compiles fail on python 3.6. Apparently @wuwenbin2006 had similar issues. It seems that Pool.imap causes a deadlock, but the ever so slightly slower Pool.map does not. These are used in setup.py for parallel compilation. Maybe this is worth reporting to the python bug trackers.

Oddly enough, I'm still experiencing unit test failures with subtle differences in k_eff. For instance on test_1d_gradient I get results that are 2 pcm higher than the reference case. Similar small discrepancies exist around the sixth decimal place on other unit tests like test_tracking_pin_cell. Sounds like single floats are being used somewhere where they used to not, or vice-versa.

Anyways, it compiles now!