### PR TITLE
Fixed some conflicts between RunTime.h and changed Mesh.h.

### DIFF
--- a/profile/Makefile
+++ b/profile/Makefile
@@ -28,8 +28,8 @@ CMFD_PRECISION ?= single
 #case = models/simple-lattice/simple-lattice-3d.cpp
 #case = models/homogeneous/homogeneous.cpp
 #case = models/non-uniform-lattice/non-uniform-lattice.cpp
-#case ?= models/run_time_standard/run_time_standard.cpp
-case ?= models/assembly_5b/load-assembly.cpp
+case ?= models/run_time_standard/run_time_standard.cpp
+#case ?= models/assembly_5b/load-assembly.cpp
 #case ?= models/core_2/load-core.cpp
 
 source = \

--- a/profile/models/run_time_standard/run_time_standard.cpp
+++ b/profile/models/run_time_standard/run_time_standard.cpp
@@ -10,10 +10,10 @@ int main(int argc, char* argv[]) {
 
 #ifdef MPIx
   int provided;
-  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &provided);
   log_set_ranks(MPI_COMM_WORLD);
-  if (provided < MPI_THREAD_MULTIPLE) {
-    log_printf(ERROR, "Not enough thread support");  
+  if (provided < MPI_THREAD_SERIALIZED) {
+    log_printf(ERROR, "Not enough thread support level in the MPI library");  
   }
 #endif
   

--- a/profile/models/run_time_standard/run_time_standard.cpp
+++ b/profile/models/run_time_standard/run_time_standard.cpp
@@ -9,8 +9,12 @@
 int main(int argc, char* argv[]) {
 
 #ifdef MPIx
-  MPI_Init(&argc, &argv);
+  int provided;
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
   log_set_ranks(MPI_COMM_WORLD);
+  if (provided < MPI_THREAD_MULTIPLE) {
+    log_printf(ERROR, "Not enough thread support");  
+  }
 #endif
   
   int arg_index = 0;
@@ -158,7 +162,7 @@ int main(int argc, char* argv[]) {
 
   for(int m=0; m<runtime._non_uniform_mesh_lattices.size(); m++) {
     Mesh mesh(solver);
-    Vector3D rx_rates = mesh.getFormattedReactionRates
+    Vector3D rx_rates = mesh.getNonUniformFormattedReactionRates
         (runtime._non_uniform_mesh_lattices[m], 
         (RxType)runtime._output_types[m+runtime._output_mesh_lattices.size()]);
     if (my_rank == 0) {

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -239,8 +239,9 @@ Vector3D Mesh::getFormattedReactionRates(RxType rx, bool volume_average) {
  * @return The reaction rates in a 3D vector indexed by the lattice cell
  *         x, y, and z indexes
  */
-Vector3D Mesh::getFormattedReactionRates
-                 (std::vector<std::vector<double> > widths_offsets, RxType rx) {
+Vector3D Mesh::getNonUniformFormattedReactionRates
+                 (std::vector<std::vector<double> > widths_offsets, RxType rx,
+                  bool volume_average) {
   Vector3D rx_rates;
 
   /* Get the root universe */
@@ -322,7 +323,7 @@ Vector3D Mesh::getFormattedReactionRates
   setLattice(&wrap_lattice);
 
   /* get reaction rates of the whole geometry Lattice */
-  rx_rates = getFormattedReactionRates(rx);
+  rx_rates = getFormattedReactionRates(rx, volume_average);
 
   /* Truncate the reaction rates for user defined output_lattice */
   if(surface[0]) rx_rates.erase(rx_rates.begin());

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -61,8 +61,9 @@ public:
   std::vector<FP_PRECISION> getReactionRates(RxType rx,
                                              bool volume_average=false);
   Vector3D getFormattedReactionRates(RxType rx, bool volume_average=false);
-  Vector3D getFormattedReactionRates(std::vector<std::vector<double> > 
-                                     widths_offsets, RxType rx);
+  Vector3D getNonUniformFormattedReactionRates(std::vector<std::vector<double> > 
+                                               widths_offsets, RxType rx,
+                                               bool volume_average=false);
 
 
 };

--- a/src/RunTime.h
+++ b/src/RunTime.h
@@ -31,7 +31,7 @@
 #endif
 
 /* A Vector3D is simply a 3-dimensional std::vector of doubles */
-typedef std::vector<std::vector<std::vector<double> > > Vector3D;
+typedef std::vector<std::vector<std::vector<double> > > DoubleVector3D;
 
 /**
  * @brief Structure for run time options.
@@ -131,7 +131,7 @@ struct RuntimeParameters {
   std::vector<std::vector<int> > _output_mesh_lattices;
 
   /* widths and offsets of multiple output meshes with non-uniform lattice */
-  Vector3D _non_uniform_mesh_lattices;
+  DoubleVector3D _non_uniform_mesh_lattices;
 
   /* output reaction types for both uniform and non-uniform */
   std::vector<int> _output_types;


### PR DESCRIPTION
Since pull request #382, compiling errors occurred due to the conflicts between Runtime.h and Mesh.h. In this PR, things are fixed:

1) Fixed the macro definition Vector3D conflict in RunTime.h.
2) Fixed the overload function conflict of getFormattedReactionRates in Mesh.h. We can't have overloading and default parameters for a function at the same time. Changed one name.
3）Fixed the MPI/OpenMP hybrid running error in run_time_standard.cpp.