### PR TITLE
Compatibility with Intel compiler

### DIFF
--- a/profile/Makefile
+++ b/profile/Makefile
@@ -109,10 +109,17 @@ endif
 # intel Compiler
 ifeq ($(COMPILER),intel)
   CC = icpc
-  source += VectorizedSolver.cpp
+  #source += VectorizedSolver.cpp
   CFLAGS += -DINTEL
-  CFLAGS += -I/opt/intel/composer_xe_2013_sp1.3.174/mkl/include
-  LDFLAGS += -mkl
+  #CFLAGS += -I/your/path/to/mkl/include
+  #LDFLAGS += -mkl
+endif
+
+# MPI wrapped intel Compiler
+ifeq ($(COMPILER),impi)
+  CC = mpiicpc
+  CFLAGS += -DINTEL
+  CFLAGS += -DMPIx
 endif
 
 # Clang Compiler
@@ -177,6 +184,9 @@ ifeq ($(OPTIMIZE),yes)
   ifeq ($(COMPILER),intel)
     CFLAGS += -O3 -xhost -fast -ansi-alias -no-prec-div -ipo
   endif
+  ifeq ($(COMPILER),impi)
+    CFLAGS += -O3 -xhost -ansi-alias -no-prec-div -ipo
+  endif
   ifeq ($(COMPILER),bluegene)
     CFLAGS += -O3 -ffast-math -fpic
   endif
@@ -196,6 +206,9 @@ ifeq ($(INFO),yes)
   ifeq ($(COMPILER),intel)
     CFLAGS += -qopt-report n=5 -qopt-report-phase=all
   endif
+  ifeq ($(COMPILER),impi)
+    CFLAGS += -qopt-report n=5 -qopt-report-phase=all
+  endif
   ifeq ($(COMPILER),gnu)
     CFLAGS += -fopt-info-all
   endif
@@ -209,21 +222,7 @@ endif
 
 # OpenMP flags
 ifeq ($(OPENMP),yes)
-  ifeq ($(COMPILER), gnu)
-    CFLAGS += -fopenmp
-  endif
-  ifeq ($(COMPILER), mpi)
-    CFLAGS += -fopenmp
-  endif
-  ifeq ($(COMPILER), bluegene)
-    CFLAGS += -fopenmp
-  endif
-  ifeq ($(COMPILER), intel)
-    CFLAGS += -openmp
-  endif
-  ifeq ($(COMPILER), clang)
-    CFLAGS += -fopenmp
-  endif
+  CFLAGS += -fopenmp
   CFLAGS += -DOPENMP
 endif
 

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -182,7 +182,7 @@ ifeq ($(OPTIMIZE),yes)
     CFLAGS += -O3 -ffast-math -fpic -march=native
   endif
   ifeq ($(COMPILER),intel)
-    CFLAGS += -O3 -xhost -fast -ansi-alias -no-prec-div -ipo
+    CFLAGS += -O3 -xhost -ansi-alias -no-prec-div -ipo
   endif
   ifeq ($(COMPILER),impi)
     CFLAGS += -O3 -xhost -ansi-alias -no-prec-div -ipo

--- a/profile/models/run_time_standard/run_time_standard.cpp
+++ b/profile/models/run_time_standard/run_time_standard.cpp
@@ -130,8 +130,10 @@ int main(int argc, char* argv[]) {
     solver->printTimerReport();
 
   /* Extract reaction rates */
-  int my_rank;
+  int my_rank = 0;
+#ifdef MPIx
   MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+#endif
   std::string rxtype[4] = {"FISSION_RX", "TOTAL_RX", "ABSORPTION_RX", "FLUX_RX"};
                           
 

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -5144,7 +5144,8 @@ void Cmfd::tallyStartingCurrent(Point* point, double delta_x, double delta_y,
                delta_z);
 
   CMFD_PRECISION currents[_num_cmfd_groups]
-       __attribute__ ((aligned(VEC_ALIGNMENT))) = {0.0};
+       __attribute__ ((aligned(VEC_ALIGNMENT)));
+  memset(&currents[0], 0, _num_cmfd_groups * sizeof(CMFD_PRECISION));
 
   /* Tally currents to each CMFD group locally */
   for (int e=0; e < _num_moc_groups; e++) {

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -549,7 +549,8 @@ inline void Cmfd::tallyCurrent(segment* curr_segment, float* track_flux,
   if (tally_current) {
 
     CMFD_PRECISION currents[_num_cmfd_groups] 
-         __attribute__ ((aligned(VEC_ALIGNMENT))) = {0.0};
+         __attribute__ ((aligned(VEC_ALIGNMENT)));
+    memset(&currents[0], 0, _num_cmfd_groups * sizeof(CMFD_PRECISION));
     int local_cell_id = getLocalCMFDCell(cell_id);
 
     if (_SOLVE_3D) {

--- a/src/MOCKernel.cpp
+++ b/src/MOCKernel.cpp
@@ -377,8 +377,8 @@ void TransportKernel::execute(FP_PRECISION length, Material* mat, long fsr_id,
                                                    _direction);
 
   /* Allocate a buffer to store flux contribution of all cuts in this fsr */
-  FP_PRECISION fsr_flux[_num_groups] __attribute__ ((aligned (VEC_ALIGNMENT)))
-       = {0.0};
+  FP_PRECISION fsr_flux[_num_groups] __attribute__ ((aligned (VEC_ALIGNMENT)));
+  memset(&fsr_flux[0], 0, _num_groups * sizeof(FP_PRECISION));
 
   /* Apply MOC equations to segments */
   for (int i=0; i < num_cuts; i++) {

--- a/src/Material.h
+++ b/src/Material.h
@@ -22,7 +22,7 @@
 #include <malloc.h>
 #endif
 
-#ifdef ICPC
+#ifdef INTEL
 /** Aligned memory allocation for Intel's compiler */
 #define MM_MALLOC(size,alignment) _mm_malloc(size, alignment)
 

--- a/src/ParallelHashMap.h
+++ b/src/ParallelHashMap.h
@@ -489,7 +489,7 @@ bool ParallelHashMap<K,V>::contains(K& key) {
   do {
     table_ptr = _table;
     _announce[tid].value = table_ptr;
-#pragma omp flush(_announce)
+#pragma omp flush
   } while (table_ptr != _table);
 
   /* see if current table contains the thread */
@@ -530,7 +530,7 @@ V ParallelHashMap<K,V>::at(K& key) {
   do {
     table_ptr = _table;
     _announce[tid].value = table_ptr;
-#pragma omp flush(_announce)
+#pragma omp flush
   } while (table_ptr != _table);
 
   /* get value associated with the key in the underlying table */
@@ -695,7 +695,7 @@ void ParallelHashMap<K,V>::resize() {
 
   /* reassign pointer */
   _table = new_map;
-#pragma omp flush(_table)
+#pragma omp flush
 
   /* release all locks */
   for (size_t i=0; i<_num_locks; i++)
@@ -767,7 +767,7 @@ K* ParallelHashMap<K,V>::keys() {
   do {
     table_ptr = _table;
     _announce[tid].value = table_ptr;
-#pragma omp flush(_announce)
+#pragma omp flush
   } while (table_ptr != _table);
 
   /* get key list */
@@ -802,7 +802,7 @@ V* ParallelHashMap<K,V>::values() {
   do {
     table_ptr = _table;
     _announce[tid].value = table_ptr;
-#pragma omp flush(_announce)
+#pragma omp flush
   } while (table_ptr != _table);
 
   /* get value list */
@@ -863,7 +863,7 @@ void ParallelHashMap<K,V>::print_buckets() {
   do {
     table_ptr = _table;
     _announce[tid].value = table_ptr;
-#pragma omp flush(_announce)
+#pragma omp flush
   } while (table_ptr != _table);
 
   /* print buckets */

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1650,7 +1650,8 @@ void TrackGenerator::generateFSRCentroids(FP_PRECISION* FSR_volumes) {
   }
 
   /* Print FSR volumes, centroids and volume moments for debugging purposes */
-  double total_volume[4] = {0.0};
+  double total_volume[4];
+  memset(&total_volume[0], 0, 4 * sizeof(double));
   for (long r=0; r < num_FSRs; r++) {
     total_volume[0] += _FSR_volumes[r];
     total_volume[1] += _FSR_volumes[r] * centroids[r]->getX();

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -885,7 +885,8 @@ void TransportSweep::onTrack(Track* track, segment* segments) {
 
   int num_groups_aligned = (_num_groups / VEC_ALIGNMENT + 1) * VEC_ALIGNMENT;
   FP_PRECISION fsr_flux[4 * num_groups_aligned * num_polar] __attribute__
-       ((aligned (VEC_ALIGNMENT))) = {0.0};
+       ((aligned (VEC_ALIGNMENT)));
+  memset(&fsr_flux[0], 0, 4 * num_groups_aligned * sizeof(FP_PRECISION));
   FP_PRECISION* fsr_flux_x = &fsr_flux[num_groups_aligned];
   FP_PRECISION* fsr_flux_y = &fsr_flux[2*num_groups_aligned];
   FP_PRECISION* fsr_flux_z = &fsr_flux[3*num_groups_aligned];

--- a/src/pairwise_sum.h
+++ b/src/pairwise_sum.h
@@ -23,7 +23,7 @@ inline double pairwise_sum(T* vector, L length) {
   /* Base case: if length is less than 16, perform summation */
   if (length < 16) {
 
-    #pragma simd reduction(+:sum)
+#pragma omp simd reduction(+:sum)
     for (L i=0; i < length; i++)
       sum += vector[i];
   }


### PR DESCRIPTION
-Separates stack array initialization from declaration, since icpc 17 doesn't support it it seems

-Removes list of variables in the pragma omp flushes of the parallel hashmap. I don't know why this isn't accepted by icpc
While this change should slow down the code, I have measured runtime on a 3D assembly and didn't see any changes. 
Note that these flush clauses (#pragma omp flush(_announce)) were actually wrong, flushing a pointer to an array only flushes the pointer, not the array. 
So technically, the code is more correct now. 

-Add a separate choice in Makefile for the mpi wrapped intel compiler

ICPC 17 won't vectorize two loops that gcc vectorizes. These are not big computation loops, so it shouldn't make any difference. 