### PR TITLE
Fix for FS diffusion coefficient in CMFD

### DIFF
--- a/profile/models/load-geometry/helper-code/group-structures.h
+++ b/profile/models/load-geometry/helper-code/group-structures.h
@@ -78,6 +78,32 @@ inline std::vector<std::vector<int> > get_group_structure(int num_groups,
       for (int g=60; g<70; g++)
         cmfd_group_structure.at(10).push_back(g+1);
     }
+    else if (num_cmfd_groups == 12) {
+      for (int g=0; g<5; g++)
+        cmfd_group_structure.at(0).push_back(g+1);
+      for (int g=5; g<15; g++)
+        cmfd_group_structure.at(1).push_back(g+1);
+      for (int g=15; g<27; g++)
+        cmfd_group_structure.at(2).push_back(g+1);
+      for (int g=27; g<46; g++)
+        cmfd_group_structure.at(3).push_back(g+1);
+      for (int g=46; g<49; g++)
+        cmfd_group_structure.at(4).push_back(g+1);
+      for (int g=49; g<52; g++)
+        cmfd_group_structure.at(5).push_back(g+1);
+      for (int g=52; g<54; g++)
+        cmfd_group_structure.at(6).push_back(g+1);
+      for (int g=54; g<56; g++)
+        cmfd_group_structure.at(7).push_back(g+1);
+      for (int g=56; g<58; g++)
+        cmfd_group_structure.at(8).push_back(g+1);
+      for (int g=58; g<60; g++)
+        cmfd_group_structure.at(9).push_back(g+1);
+      for (int g=60; g<65; g++)
+        cmfd_group_structure.at(10).push_back(g+1);
+      for (int g=65; g<70; g++)
+        cmfd_group_structure.at(11).push_back(g+1);
+    }
     else if (num_cmfd_groups == 14) {
       for (int g=0; g<2; g++)
         cmfd_group_structure.at(0).push_back(g+1);
@@ -107,32 +133,6 @@ inline std::vector<std::vector<int> > get_group_structure(int num_groups,
         cmfd_group_structure.at(12).push_back(g+1);
       for (int g=68; g<70; g++)
         cmfd_group_structure.at(13).push_back(g+1);
-    }
-    else if (num_cmfd_groups == 12) {
-      for (int g=0; g<5; g++)
-        cmfd_group_structure.at(0).push_back(g+1);
-      for (int g=5; g<15; g++)
-        cmfd_group_structure.at(1).push_back(g+1);
-      for (int g=15; g<27; g++)
-        cmfd_group_structure.at(2).push_back(g+1);
-      for (int g=27; g<46; g++)
-        cmfd_group_structure.at(3).push_back(g+1);
-      for (int g=46; g<49; g++)
-        cmfd_group_structure.at(4).push_back(g+1);
-      for (int g=49; g<52; g++)
-        cmfd_group_structure.at(5).push_back(g+1);
-      for (int g=52; g<54; g++)
-        cmfd_group_structure.at(6).push_back(g+1);
-      for (int g=54; g<56; g++)
-        cmfd_group_structure.at(7).push_back(g+1);
-      for (int g=56; g<58; g++)
-        cmfd_group_structure.at(8).push_back(g+1);
-      for (int g=58; g<60; g++)
-        cmfd_group_structure.at(9).push_back(g+1);
-      for (int g=60; g<65; g++)
-        cmfd_group_structure.at(10).push_back(g+1);
-      for (int g=65; g<70; g++)
-        cmfd_group_structure.at(11).push_back(g+1);
     }
     else if (num_cmfd_groups == 16) {
       for (int g=0; g<5; g++)
@@ -210,8 +210,6 @@ inline std::vector<std::vector<int> > get_group_structure(int num_groups,
       for (int g=64; g<70; g++)
         cmfd_group_structure.at(24).push_back(g+1);
     }
-    else
-      log_printf(ERROR, "CMFD group structure not found");
   }
   else if (num_groups == 40) {
     if (num_cmfd_groups == 2) {
@@ -230,10 +228,78 @@ inline std::vector<std::vector<int> > get_group_structure(int num_groups,
       for (int g=28; g<40; g++)
         cmfd_group_structure.at(3).push_back(g+1);
     }
-    else
-      log_printf(ERROR, "CMFD group structure not found");
   }
-
+  else if (num_groups == 25) {
+    if (num_cmfd_groups == 2) {
+      for (int g=0; g<19; g++)
+        cmfd_group_structure.at(0).push_back(g+1);
+      for (int g=19; g<25; g++)
+        cmfd_group_structure.at(1).push_back(g+1);
+    }
+    else if (num_cmfd_groups == 4) {
+      for (int g=0; g<5; g++)
+        cmfd_group_structure.at(0).push_back(g+1);
+      for (int g=5; g<9; g++)
+        cmfd_group_structure.at(1).push_back(g+1);
+      for (int g=9; g<19; g++)
+        cmfd_group_structure.at(2).push_back(g+1);
+      for (int g=19; g<25; g++)
+        cmfd_group_structure.at(3).push_back(g+1);
+    }
+    else if (num_cmfd_groups == 8) {
+      for (int g=0; g<5; g++)
+        cmfd_group_structure.at(0).push_back(g+1);
+      for (int g=5; g<9; g++)
+        cmfd_group_structure.at(1).push_back(g+1);
+      for (int g=9; g<13; g++)
+        cmfd_group_structure.at(2).push_back(g+1);
+      for (int g=13; g<19; g++)
+        cmfd_group_structure.at(3).push_back(g+1);
+      for (int g=19; g<21; g++)
+        cmfd_group_structure.at(4).push_back(g+1);
+      for (int g=21; g<22; g++)
+        cmfd_group_structure.at(5).push_back(g+1);
+      for (int g=22; g<23; g++)
+        cmfd_group_structure.at(6).push_back(g+1);
+      for (int g=23; g<25; g++)
+        cmfd_group_structure.at(7).push_back(g+1);
+    }
+    // CASMO-16 and -25 have different group boundaries for thermal energies
+    else if (num_cmfd_groups == 16) {
+      for (int g=0; g<5; g++)
+        cmfd_group_structure.at(0).push_back(g+1);
+      for (int g=5; g<9; g++)
+        cmfd_group_structure.at(1).push_back(g+1);
+      for (int g=9; g<12; g++)
+        cmfd_group_structure.at(2).push_back(g+1);
+      for (int g=12; g<13; g++)
+        cmfd_group_structure.at(3).push_back(g+1);
+      for (int g=13; g<14; g++)
+        cmfd_group_structure.at(4).push_back(g+1);
+      for (int g=14; g<15; g++)
+        cmfd_group_structure.at(5).push_back(g+1);
+      for (int g=15; g<16; g++)
+        cmfd_group_structure.at(6).push_back(g+1);
+      for (int g=16; g<17; g++)
+        cmfd_group_structure.at(7).push_back(g+1);
+      for (int g=17; g<18; g++)
+        cmfd_group_structure.at(8).push_back(g+1);
+      for (int g=18; g<19; g++)
+        cmfd_group_structure.at(9).push_back(g+1);
+      for (int g=19; g<20; g++)
+        cmfd_group_structure.at(10).push_back(g+1);
+      for (int g=20; g<21; g++)
+        cmfd_group_structure.at(11).push_back(g+1);
+      for (int g=21; g<22; g++)
+        cmfd_group_structure.at(12).push_back(g+1);
+      for (int g=22; g<23; g++)
+        cmfd_group_structure.at(13).push_back(g+1);
+      for (int g=23; g<24; g++)
+        cmfd_group_structure.at(14).push_back(g+1);
+      for (int g=24; g<25; g++)
+        cmfd_group_structure.at(15).push_back(g+1);
+    }
+  }
   else if (num_groups == 16) {
     if (num_cmfd_groups == 2) {
       for (int g=0; g<10; g++)
@@ -251,8 +317,24 @@ inline std::vector<std::vector<int> > get_group_structure(int num_groups,
       for (int g=12; g<16; g++)
         cmfd_group_structure.at(3).push_back(g+1);
     }
-    else
-      log_printf(ERROR, "CMFD group structure not found");
+    else if (num_cmfd_groups == 8) {
+      for (int g=0; g<1; g++)
+        cmfd_group_structure.at(0).push_back(g+1);
+      for (int g=1; g<2; g++)
+        cmfd_group_structure.at(1).push_back(g+1);
+      for (int g=2; g<3; g++)
+        cmfd_group_structure.at(2).push_back(g+1);
+      for (int g=3; g<10; g++)
+        cmfd_group_structure.at(3).push_back(g+1);
+      for (int g=10; g<12; g++)
+        cmfd_group_structure.at(4).push_back(g+1);
+      for (int g=12; g<13; g++)
+        cmfd_group_structure.at(5).push_back(g+1);
+      for (int g=13; g<14; g++)
+        cmfd_group_structure.at(6).push_back(g+1);
+      for (int g=14; g<16; g++)
+        cmfd_group_structure.at(7).push_back(g+1);
+    }
   }
   else if (num_groups == 8) {
     if (num_cmfd_groups == 2) {
@@ -271,13 +353,11 @@ inline std::vector<std::vector<int> > get_group_structure(int num_groups,
       for (int g=5; g<8; g++)
         cmfd_group_structure.at(3).push_back(g+1);
     }
-    else
-      log_printf(ERROR, "CMFD group structure not found");
   }
   else if (num_groups < num_cmfd_groups)
     log_printf(ERROR, "Number of CMFD groups must be lower than the number of"
                "MOC groups.");
-  else {
+  else if (cmfd_group_structure.at(0).size() == 0) {
     log_printf(WARNING_ONCE, "CMFD group structure requested is unknown, "
                "creating a condensed structure with a constant number of "
                "MOC groups in each CMFD group");

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -2011,8 +2011,8 @@ void CPUSolver::tallyScalarFlux(segment* curr_segment,
       FP_PRECISION delta_psi = (tau * track_flux[e] - length_2D *
               _reduced_sources(fsr_id, e)) * exponential;
       track_flux[e] -= delta_psi;
-      fsr_flux[e] += delta_psi * _quad->getWeightInline(azim_index,
-                                                        polar_index);
+      fsr_flux[e] += delta_psi * FP_PRECISION(_quad->getWeightInline(
+                                                     azim_index, polar_index));
     }
   }
   else {

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -1513,6 +1513,7 @@ CMFD_PRECISION Cmfd::computeLarsensEDCFactor(CMFD_PRECISION dif_coef,
   for (int a=0; a < _num_azim/2; a++) {
 
     CMFD_PRECISION wa = _quadrature->getAzimWeight(a);
+
     /* Loop over polar angles */
     for (int p = 0; p < _num_polar/2; p++) {
       mu = sqrt(1.0 - pow(_quadrature->getSinTheta(a,p), 2));

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -1065,7 +1065,7 @@ void Cmfd::getSurfaceDiffusionCoefficient(int cmfd_cell, int surface,
     /* Correct the diffusion coefficient with Larsen's effective diffusion
      * coefficient correction factor */
     if (!_linear_source)
-      dif_coef_next *= computeLarsensEDCFactor(dif_coef_next, delta);
+      dif_coef_next *= computeLarsensEDCFactor(dif_coef_next, delta_next);
 
     /* Compute the surface diffusion coefficient */
     dif_surf = 2.0 * dif_coef * dif_coef_next
@@ -1509,12 +1509,17 @@ CMFD_PRECISION Cmfd::computeLarsensEDCFactor(CMFD_PRECISION dif_coef,
   CMFD_PRECISION alpha, mu, expon;
   double rho = 0.0;
 
-  /* Loop over polar angles */
-  for (int p = 0; p < _num_polar/2; p++) {
-    mu = cos(asin(_quadrature->getSinTheta(0,p)));
-    expon = exp(-delta / (3 * dif_coef * mu));
-    alpha = (1 + expon) / (1 - expon) - 2 * (3 * dif_coef * mu) / delta;
-    rho += 2.0 * mu * _quadrature->getPolarWeight(0,p) * alpha;
+  /* Loop over azimuthal angles */
+  for (int a=0; a < _num_azim/2; a++) {
+
+    CMFD_PRECISION wa = _quadrature->getAzimWeight(a);
+    /* Loop over polar angles */
+    for (int p = 0; p < _num_polar/2; p++) {
+      mu = sqrt(1.0 - pow(_quadrature->getSinTheta(a,p), 2));
+      expon = exp(-delta / (3 * dif_coef * mu));
+      alpha = (1 + expon) / (1 - expon) - 2 * (3 * dif_coef * mu) / delta;
+      rho += 2.0 * mu * _quadrature->getPolarWeight(a,p) * wa * alpha;
+    }
   }
 
   /* Compute the correction factor */


### PR DESCRIPTION
- A bugfix for non uniform CMFD. Flat source cases with high aspect ratio cells had trouble converging when using the wrong spacing for the effective diffusion coefficient in CMFD
 
- Also by using all azimuthal angles rather than just the first one, I've observed much improved convergence for a 5 by 1 by 4 domain decomposed 3D assembly

- A few other CMFD group structures, for 25 MOC group cases. The CMFD 8g and 16g structures provide about 40% speed up to the CMFD for a 3D BEAVRS assembly case

- A speed up for the 3D FS solver. Integration time down to 4ns for a 70g 3D assembly on my machine