### PR TITLE
3D FS solver optimization, bugfix for parallel hashmap, better memory logs

### DIFF
--- a/profile/Makefile
+++ b/profile/Makefile
@@ -27,7 +27,6 @@ CMFD_PRECISION ?= single
 #case = models/load-geometry/load-geometry.cpp
 #case = models/simple-lattice/simple-lattice-3d.cpp
 #case = models/homogeneous/homogeneous.cpp
-#case = models/non-uniform-lattice/non-uniform-lattice.cpp
 case ?= models/run_time_standard/run_time_standard.cpp
 #case ?= models/assembly_1/load-assembly.cpp
 #case ?= models/core/load-core.cpp
@@ -81,8 +80,7 @@ single-assembly/single-c5g7-assembly.cpp \
 load-geometry/load-geometry.cpp \
 load-geometry/load-single-assembly.cpp \
 load-geometry/load-2D-full-core.cpp \
-load-geometry/load-full-core.cpp \
-non-uniform-lattice/non-uniform-lattice.cpp
+load-geometry/load-full-core.cpp
 
 #===============================================================================
 # Sets Flags
@@ -194,7 +192,7 @@ ifeq ($(OPTIMIZE),yes)
     CFLAGS += -O3 -ffast-math -fvectorize -fpic
   endif
   # Set the number of groups at compile time
-  #CFLAGS += -DNGROUPS=70
+  #CFLAGS += -DNGROUPS=361
   # Set the source to linear source at compile time
   #CFLAGS += -DLINEARSOURCE
   # Set the dimension to 3D at compile time

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -192,7 +192,7 @@ ifeq ($(OPTIMIZE),yes)
     CFLAGS += -O3 -ffast-math -fvectorize -fpic
   endif
   # Set the number of groups at compile time
-  #CFLAGS += -DNGROUPS=361
+  #CFLAGS += -DNGROUPS=70
   # Set the source to linear source at compile time
   #CFLAGS += -DLINEARSOURCE
   # Set the dimension to 3D at compile time

--- a/setup.py
+++ b/setup.py
@@ -337,7 +337,7 @@ def parallel_compile(self, sources, output_dir=None, macros=None,
       self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
 
   # Convert thread mapping to C/C++/CUDA objects to a list and return
-  list(pool.ThreadPool(num_cpus).imap(_single_compile, objects))
+  list(pool.ThreadPool(num_cpus).map(_single_compile, objects))
   return objects
 
 

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -521,7 +521,6 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
   FP_PRECISION length = curr_segment->_length;
   FP_PRECISION* sigma_t = curr_segment->_material->getSigmaT();
   FP_PRECISION* position = curr_segment->_starting_position;
-  ExpEvaluator* exp_evaluator = _exp_evaluators[azim_index][polar_index];
 
   if (_SOLVE_3D) {
 
@@ -557,8 +556,6 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
       expG_fractional(tau[e], &exp_G[e]);
     }
 
-    FP_PRECISION wgt = _quad->getWeightInline(azim_index, polar_index);
-
     // Compute the flux attenuation and tally contribution
 #pragma omp simd aligned(tau, src_flat, src_linear, fsr_flux, exp_G, fsr_flux_x\
      , fsr_flux_y, fsr_flux_z)
@@ -568,13 +565,12 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
       FP_PRECISION exp_F1 = 1.f - tau[e]*exp_G[e];
       FP_PRECISION exp_F2 = 2.f*exp_G[e] - exp_F1;
       FP_PRECISION exp_H = exp_F1 - exp_G[e];
-      exp_H *= length * track_flux[e] * tau[e] * wgt;
+      exp_H *= length * track_flux[e] * tau[e];
 
       /* Compute the change in flux across the segment */
       FP_PRECISION delta_psi = (tau[e] * track_flux[e] - length * src_flat[e])
            * exp_F1 - src_linear[e] * length * length * exp_F2;
       track_flux[e] -= delta_psi;
-      delta_psi *= wgt;
 
       /* Increment the fsr scalar flux and scalar flux moments */
       fsr_flux[e] += delta_psi;
@@ -585,6 +581,7 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
   }
   else {
 
+    ExpEvaluator* exp_evaluator = _exp_evaluators[azim_index][polar_index];
     const int num_polar_2 = _num_polar / 2;
 
     /* Compute the segment midpoint (with factor 2 for LS) */
@@ -683,10 +680,13 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
  * @brief Move from buffers to global arrays the contributions of one (or
  *        several for per-stack solving) segments.
  * @param fsr_id region index
+ * @param weight the quadrature weight (only for 3D ray tracing)
  * @param fsr_flux buffer storing contribution to the region's scalar flux
  */
 void CPULSSolver::accumulateLinearFluxContribution(long fsr_id,
-                                       FP_PRECISION* __restrict__ fsr_flux) {
+                                                   FP_PRECISION weight,
+                                                   FP_PRECISION* __restrict__
+                                                   fsr_flux) {
 
   int num_groups_aligned = (_num_groups / VEC_ALIGNMENT + 1) * VEC_ALIGNMENT;
   FP_PRECISION* fsr_flux_x = &fsr_flux[num_groups_aligned];
@@ -700,10 +700,10 @@ void CPULSSolver::accumulateLinearFluxContribution(long fsr_id,
   for (int e=0; e < _num_groups; e++) {
 
     // Add to global scalar flux vector
-    _scalar_flux(fsr_id, e) += fsr_flux[e];
-    _scalar_flux_xyz(fsr_id, e, 0) += fsr_flux_x[e];
-    _scalar_flux_xyz(fsr_id, e, 1) += fsr_flux_y[e];
-    _scalar_flux_xyz(fsr_id, e, 2) += fsr_flux_z[e];
+    _scalar_flux(fsr_id, e) += weight * fsr_flux[e];
+    _scalar_flux_xyz(fsr_id, e, 0) += weight * fsr_flux_x[e];
+    _scalar_flux_xyz(fsr_id, e, 1) += weight * fsr_flux_y[e];
+    _scalar_flux_xyz(fsr_id, e, 2) += weight * fsr_flux_z[e];
   }
 
   omp_unset_lock(&_FSR_locks[fsr_id]);

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -736,7 +736,7 @@ void CPULSSolver::addSourceToScalarFlux() {
     for (long r=0; r < _num_FSRs; r++) {
       volume = _FSR_volumes[r];
       if (volume < FLT_EPSILON)
-        volume = FLT_INFINITY;
+        volume = 1e30;
       sigma_t = _FSR_materials[r]->getSigmaT();
 
       for (int e=0; e < _num_groups; e++) {

--- a/src/CPULSSolver.h
+++ b/src/CPULSSolver.h
@@ -101,7 +101,8 @@ public:
                                     FP_PRECISION* fsr_flux_z,
                                     float* track_flux,
                                     FP_PRECISION direction[3]);
-  void accumulateLinearFluxContribution(long fsr_id, FP_PRECISION* fsr_flux);
+  void accumulateLinearFluxContribution(long fsr_id, FP_PRECISION weight,
+                                        FP_PRECISION* fsr_flux);
   void addSourceToScalarFlux();
 
   /* Transport stabilization routines */

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -2232,30 +2232,28 @@ void CPUSolver::tallyScalarFlux(segment* curr_segment,
   long fsr_id = curr_segment->_region_id;
   FP_PRECISION length = curr_segment->_length;
   FP_PRECISION* sigma_t = curr_segment->_material->getSigmaT();
-  ExpEvaluator* exp_evaluator = _exp_evaluators[azim_index][polar_index];
 
   if (_SOLVE_3D) {
-
-    FP_PRECISION length_2D = exp_evaluator->convertDistance3Dto2D(length);
 
 #pragma omp simd aligned(sigma_t, fsr_flux)
     for (int e=0; e < _num_groups; e++) {
 
-      FP_PRECISION tau = sigma_t[e] * length_2D;
+      FP_PRECISION tau = sigma_t[e] * length;
 
       /* Compute the exponential */
-      FP_PRECISION exponential = exp_evaluator->computeExponential(tau, 0);
+      FP_PRECISION exponential;
+      expF1_fractional(tau, &exponential);
 
       /* Compute attenuation and tally the contribution to the scalar flux */
-      FP_PRECISION delta_psi = (tau * track_flux[e] - length_2D *
+      FP_PRECISION delta_psi = (tau * track_flux[e] - length *
               _reduced_sources(fsr_id, e)) * exponential;
       track_flux[e] -= delta_psi;
-      fsr_flux[e] += delta_psi * FP_PRECISION(_quad->getWeightInline(
-                                                     azim_index, polar_index));
+      fsr_flux[e] += delta_psi;
     }
   }
   else {
 
+    ExpEvaluator* exp_evaluator = _exp_evaluators[azim_index][polar_index];
     const int num_polar_2 = _num_polar / 2;
 
     /* Compute tau in advance to simplify attenuation loop */
@@ -2302,10 +2300,13 @@ void CPUSolver::tallyScalarFlux(segment* curr_segment,
  * @brief Move the segment(s)' contributions to the scalar flux from the buffer
  * to the global scalar flux array.
  * @param fsr_id the id of the fsr
+ * @param weight the quadrature weight (only for 3D ray tracing)
  * @param fsr_flux the buffer containing the segment(s)' contribution
  */
 void CPUSolver::accumulateScalarFluxContribution(long fsr_id,
-                                         FP_PRECISION* __restrict__ fsr_flux) {
+                                                 FP_PRECISION weight,
+                                                 FP_PRECISION* __restrict__
+                                                 fsr_flux) {
 
   // Atomically increment the FSR scalar flux from the temporary array
   omp_set_lock(&_FSR_locks[fsr_id]);
@@ -2313,7 +2314,7 @@ void CPUSolver::accumulateScalarFluxContribution(long fsr_id,
   // Add to global scalar flux vector
 #pragma omp simd aligned(fsr_flux)
   for (int e=0; e < _num_groups; e++)
-    _scalar_flux(fsr_id,e) += fsr_flux[e];
+    _scalar_flux(fsr_id,e) += weight * fsr_flux[e];
 
   omp_unset_lock(&_FSR_locks[fsr_id]);
 

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -553,7 +553,7 @@ void CPUSolver::setupMPIBuffers() {
     int max_size_mb;
     MPI_Allreduce(&size_mb, &max_size_mb, 1, MPI_INT, MPI_MAX,
                   _geometry->getMPICart());
-    log_printf(NORMAL, "Max track fluxes transfer buffer storage = %.2f MB",
+    log_printf(INFO, "Max track fluxes transfer buffer storage = %.2f MB",
                max_size_mb / 1e6);
 
     /* Allocate track fluxes transfer buffers */

--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -159,7 +159,8 @@ public:
   void tallyScalarFlux(segment* curr_segment, int azim_index, int polar_index,
                        FP_PRECISION* fsr_flux, float* track_flux);
 
-  void accumulateScalarFluxContribution(long fsr_id, FP_PRECISION* fsr_flux);
+  void accumulateScalarFluxContribution(long fsr_id, FP_PRECISION weight,
+                                        FP_PRECISION* fsr_flux);
 
   void tallyCurrent(segment* curr_segment, int azim_index, int polar_index,
                     float* track_flux, bool fwd);

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -4096,10 +4096,10 @@ void Cmfd::printInputParamsSummary() {
 
   // Print other CMFD modifications
   if (_flux_limiting)
-    log_printf(INFO, "CMFD corrected diffusion coef. bounded by "
+    log_printf(INFO_ONCE, "CMFD corrected diffusion coef. bounded by "
                "regular diffusion coef.");
   if (_balance_sigma_t)
-    log_printf(INFO, "CMFD total cross sections adjusted for matching MOC "
+    log_printf(INFO_ONCE, "CMFD total cross sections adjusted for matching MOC "
                "reaction rates");
 
   // Print CMFD space and energy mesh information
@@ -4921,33 +4921,6 @@ int Cmfd::getLocalCMFDCell(int cmfd_cell) {
     local_cmfd_cell = -1;
 
   return local_cmfd_cell;
-}
-
-
-/**
- * @brief Converts a local CMFD cell ID into its global ID
- * @param cmfd_cell The local CMFD cell ID
- * @return The global CMFD cell ID
- */
-int Cmfd::getGlobalCMFDCell(int cmfd_cell) {
-
-  int x_start = 0;
-  int y_start = 0;
-  int z_start = 0;
-  if (_geometry->isDomainDecomposed()) {
-    if (_domain_communicator != NULL) {
-      x_start = _accumulate_lmx[_domain_communicator->_domain_idx_x];
-      y_start = _accumulate_lmy[_domain_communicator->_domain_idx_y];
-      z_start = _accumulate_lmz[_domain_communicator->_domain_idx_z];
-    }
-  }
-
-  int ix = cmfd_cell % _local_num_x;
-  int iy = (cmfd_cell % (_local_num_x * _local_num_y)) / _local_num_x;
-  int iz = cmfd_cell / (_local_num_x * _local_num_y);
-
-  return ((iz + z_start) * _num_y + iy + y_start) * _num_x
-                + ix + x_start;
 }
 
 

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -4097,7 +4097,7 @@ void Cmfd::printInputParamsSummary() {
   // Print other CMFD modifications
   if (_flux_limiting)
     log_printf(INFO, "CMFD corrected diffusion coef. bounded by "
-               " regular diffusion coef.");
+               "regular diffusion coef.");
   if (_balance_sigma_t)
     log_printf(INFO, "CMFD total cross sections adjusted for matching MOC "
                "reaction rates");

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -520,6 +520,31 @@ inline int Cmfd::findCmfdSurfaceOTF(int cell_id, double z, int surface_2D) {
 
 
 /**
+ * @brief Converts a local CMFD cell ID into its global ID
+ * @param cmfd_cell The local CMFD cell ID
+ * @return The global CMFD cell ID
+ */
+inline int Cmfd::getGlobalCMFDCell(int cmfd_cell) {
+
+  int x_start = 0;
+  int y_start = 0;
+  int z_start = 0;
+  if (_domain_communicator != NULL) {
+    x_start = _accumulate_lmx[_domain_communicator->_domain_idx_x];
+    y_start = _accumulate_lmy[_domain_communicator->_domain_idx_y];
+    z_start = _accumulate_lmz[_domain_communicator->_domain_idx_z];
+  }
+
+  int ix = cmfd_cell % _local_num_x;
+  int iy = (cmfd_cell % (_local_num_x * _local_num_y)) / _local_num_x;
+  int iz = cmfd_cell / (_local_num_x * _local_num_y);
+
+  return ((iz + z_start) * _num_y + iy + y_start) * _num_x
+                + ix + x_start;
+}
+
+
+/**
  * @brief Tallies the current contribution from this segment across the
  *        the appropriate CMFD mesh cell surface.
  * @param curr_segment the current Track segment

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -2511,9 +2511,6 @@ void Geometry::initializeAxialFSRs(std::vector<double> global_z_mesh) {
           extruded_FSR->_materials[n] = material;
         }
       }
-      /* Keep track of the number of FSRs in extruded FSRs */
-#pragma omp atomic update
-      total_number_fsrs_in_stack += extruded_FSR->_num_fsrs;
     }
     else {
 
@@ -2549,12 +2546,12 @@ void Geometry::initializeAxialFSRs(std::vector<double> global_z_mesh) {
           level = max_z;
       extruded_FSR->_mesh[s+1] = level;
       }
-
-      /* Keep track of the number of FSRs in extruded FSRs */
-#pragma omp atomic update
-      total_number_fsrs_in_stack += extruded_FSR->_num_fsrs;
     }
+    /* Keep track of the number of FSRs in extruded FSRs */
+#pragma omp atomic update
+    total_number_fsrs_in_stack += extruded_FSR->_num_fsrs;
   }
+
   delete [] extruded_FSRs;
 #ifdef MPIx
   if (_domain_decomposed)
@@ -2568,7 +2565,7 @@ void Geometry::initializeAxialFSRs(std::vector<double> global_z_mesh) {
       MPI_Allreduce(&total_number_fsrs_in_stack, &max_number_fsrs_in_stack, 1,
                     MPI_LONG, MPI_MAX, _MPI_cart);
 #endif
-  log_printf(INFO_ONCE, "Max storage for extruded FSRs = %.2f MB",
+  log_printf(INFO_ONCE, "Max storage for extruded FSRs per domain = %.2f MB",
              max_number_fsrs_in_stack * (sizeof(double) + sizeof(long) +
              sizeof(Material*)) / float(1e6));
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -2512,7 +2512,7 @@ void Geometry::initializeAxialFSRs(std::vector<double> global_z_mesh) {
         }
       }
       /* Keep track of the number of FSRs in extruded FSRs */
-#pragma omp atomic
+#pragma omp atomic update
       total_number_fsrs_in_stack += extruded_FSR->_num_fsrs;
     }
     else {
@@ -2551,7 +2551,7 @@ void Geometry::initializeAxialFSRs(std::vector<double> global_z_mesh) {
       }
 
       /* Keep track of the number of FSRs in extruded FSRs */
-#pragma omp atomic
+#pragma omp atomic update
       total_number_fsrs_in_stack += extruded_FSR->_num_fsrs;
     }
   }
@@ -3495,6 +3495,14 @@ std::vector<double> Geometry::getUniqueZPlanes() {
     double mid = (unique_heights[i-1] + unique_heights[i]) / 2;
     unique_z_planes.push_back(mid);
   }
+
+  /* Output the unique Z heights for debugging */
+  std::stringstream string;
+  string << unique_heights.size() - 1 << " unique Z domains with bounds: ";
+  for (int i=0; i < unique_heights.size(); i++)
+    string << unique_heights[i] << " ";
+  string << "(cm)";
+  log_printf(INFO, "%s", string.str().c_str());
 
   return unique_z_planes;
 }

--- a/src/MOCKernel.cpp
+++ b/src/MOCKernel.cpp
@@ -411,7 +411,7 @@ void TransportKernel::execute(FP_PRECISION length, Material* mat, long fsr_id,
   }
 
   /* Accumulate contribution of all cuts to FSR scalar flux */
-  _cpu_solver->accumulateScalarFluxContribution(fsr_id, fsr_flux);
+  _cpu_solver->accumulateScalarFluxContribution(fsr_id, 1, fsr_flux);
 }
 
 

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -638,7 +638,7 @@ void Material::setSigmaT(double* xs, int num_groups) {
 
     /* If the cross-section is near zero (e.g., within (-1E-10, 1E-10)) */
     if (fabs(xs[i]) < ZERO_SIGMA_T) {
-      log_printf(INFO, "Overriding zero cross-section in "
+      log_printf(INFO_ONCE, "Overriding zero cross-section in "
                  "group %d for Material %d with 1E-10", i, _id);
       _sigma_t[i] = FP_PRECISION(ZERO_SIGMA_T);
     }
@@ -664,7 +664,7 @@ void Material::setSigmaTByGroup(double xs, int group) {
 
     /* If the cross-section is near zero (e.g., within (-1E-10, 1E-10)) */
     if (fabs(xs) < ZERO_SIGMA_T) {
-      log_printf(INFO, "Overriding zero cross-section in "
+      log_printf(INFO_ONCE, "Overriding zero cross-section in "
                  "group %d for Material %d with 1E-10", group, _id);
       _sigma_t[group-1] = FP_PRECISION(ZERO_SIGMA_T);
     }

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -192,8 +192,8 @@ void Matrix::convertToCSR() {
   if (_DIAG != NULL)
     delete [] _DIAG;
 
-  log_printf(DEBUG, "Matrix CSR format storage %6.2f MB", (NNZ + _num_rows) *
-             (sizeof(CMFD_PRECISION) + sizeof(int)) / 1e6);
+  log_printf(INFO_ONCE, "Matrix CSR format storage %6.2f MB", (NNZ + _num_rows)
+             * (sizeof(CMFD_PRECISION) + sizeof(int)) / 1e6);
 
   /* Allocate memory for arrays */
   _A = new CMFD_PRECISION[NNZ];

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -193,7 +193,7 @@ void Matrix::convertToCSR() {
     delete [] _DIAG;
 
   log_printf(INFO_ONCE, "Matrix CSR format storage %6.2f MB", (NNZ + _num_rows)
-             * (sizeof(CMFD_PRECISION) + sizeof(int)) / 1e6);
+             * (sizeof(CMFD_PRECISION) + sizeof(int)) / float(1e6));
 
   /* Allocate memory for arrays */
   _A = new CMFD_PRECISION[NNZ];

--- a/src/ParallelHashMap.h
+++ b/src/ParallelHashMap.h
@@ -706,9 +706,12 @@ void ParallelHashMap<K,V>::resize() {
   delete [] value_list;
 
   /* wait for all threads to stop reading from the old table */
-  for (size_t i=0; i<_num_threads; i++)
-    while (_announce[i].value == old_table)
+  for (size_t i=0; i<_num_threads; i++) {
+    while (_announce[i].value == old_table) {
+#pragma omp flush
       continue;
+    }
+  }
 
   /* free memory associated with old table */
   delete old_table;

--- a/src/Progress.h
+++ b/src/Progress.h
@@ -35,10 +35,10 @@ class Progress {
 private:
 
   std::string _name;
-  int _counter;
+  long _counter;
   long _num_iterations;
   int _curr_interval;
-  std::vector<int> _intervals;
+  std::vector<long> _intervals;
   Geometry* _geometry;
   bool _mpi_comm;
 

--- a/src/TrackGenerator3D.cpp
+++ b/src/TrackGenerator3D.cpp
@@ -1337,7 +1337,7 @@ void TrackGenerator3D::segmentize() {
   _geometry->initializeFSRVectors();
   _contains_3D_segments = true;
 
-  log_printf(NORMAL, "Explicit 3D segments storage = %.2f MB", num_segments *
+  log_printf(INFO, "Explicit 3D segments storage = %.2f MB", num_segments *
              sizeof(segment) / 1e6);
 }
 
@@ -1607,7 +1607,7 @@ void TrackGenerator3D::allocateTemporarySegments() {
   double max_size_mb = (double) (max_size * _num_threads * sizeof(segment)) 
       / (double) (1e6);
  
-  log_printf(NORMAL, "Max temporary segment storage per domain = %6.2f MB",
+  log_printf(INFO, "Max temporary segment storage per domain = %6.2f MB",
              max_size_mb);
 
   /* Allocate new temporary segments */
@@ -1637,7 +1637,7 @@ void TrackGenerator3D::allocateTemporaryTracks() {
   /* Report memory usage */ 
   double size_mb = (double) (_num_threads * _max_num_tracks_per_stack
         * sizeof(Track3D)) / (double) 1e6;
-  log_printf(NORMAL, "Temporary Track storage per domain = %6.2f MB",
+  log_printf(INFO, "Temporary Track storage per domain = %6.2f MB",
              size_mb);
 
   /* Allocate new temporary tracks arrays */

--- a/src/TraverseSegments.cpp
+++ b/src/TraverseSegments.cpp
@@ -69,25 +69,23 @@ void TraverseSegments::loopOverTracks(MOCKernel* kernel) {
 void TraverseSegments::loopOverTracks2D(MOCKernel* kernel) {
 
   /* Loop over all parallel tracks for each azimuthal angle */
-  Track** tracks_2D = _track_generator->get2DTracks();
-  int num_azim = _track_generator->getNumAzim();
-  for (int a=0; a < num_azim/2; a++) {
-    int num_xy = _track_generator->getNumX(a) + _track_generator->getNumY(a);
+  Track** tracks_2D = _track_generator->get2DTracksArray();
+  long num_tracks = _track_generator->getNum2DTracks();
+
 #pragma omp for schedule(dynamic)
-    for (int i=0; i < num_xy; i++) {
+  for (long t=0; t < num_tracks; t++) {
 
-      Track* track_2D = &tracks_2D[a][i];
-      segment* segments = track_2D->getSegments();
+    Track* track_2D = tracks_2D[t];
+    segment* segments = track_2D->getSegments();
 
-      /* Operate on segments if necessary */
-      if (kernel != NULL) {
-        kernel->newTrack(track_2D);
-        traceSegmentsExplicit(track_2D, kernel);
-      }
-
-      /* Operate on the Track */
-      onTrack(track_2D, segments);
+    /* Operate on segments if necessary */
+    if (kernel != NULL) {
+      kernel->newTrack(track_2D);
+      traceSegmentsExplicit(track_2D, kernel);
     }
+
+    /* Operate on the Track */
+    onTrack(track_2D, segments);
   }
 }
 

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -2173,7 +2173,7 @@ int Lattice::getLatticeSurface(int cell, Point* point) {
 int Lattice::getLatticeSurfaceOTF(int cell, double z, int surface_2D) {
 
   /* Determine min and max z boundaries of the cell */
-  double lat_z = cell / (_num_x*_num_y);
+  int lat_z = cell / (_num_x*_num_y);
   double z_min = _accumulate_z[lat_z] + getMinZ();
   double z_max = z_min + _widths_z[lat_z];
 

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -316,7 +316,7 @@ boundaryType Universe::getMinZBoundaryType() {
 
 #ifdef ONLYVACUUMBC
   if (_min_z_bound != VACUUM && _min_z_bound != INTERFACE)
-    log_printf(ERROR, "OpenMOC was compiled specially for cases with only "
+    log_printf(WARNING, "OpenMOC was compiled specially for cases with only "
                "vacuum boundary conditions and a reflective or periodic "
                "boundary condition was found in universe %d.", _id);
 #endif
@@ -337,7 +337,7 @@ boundaryType Universe::getMaxZBoundaryType() {
 
 #ifdef ONLYVACUUMBC
   if (_max_z_bound != VACUUM && _max_z_bound != INTERFACE)
-    log_printf(ERROR, "OpenMOC was compiled specially for cases with only "
+    log_printf(WARNING, "OpenMOC was compiled specially for cases with only "
                "vacuum boundary conditions and a reflective or periodic "
                "boundary condition was found in universe %d.", _id);
 #endif

--- a/src/exponentials.h
+++ b/src/exponentials.h
@@ -127,19 +127,21 @@ inline void expG_fractional(FP_PRECISION x, FP_PRECISION* expG) {
   const FP_PRECISION d6 = 6.064409107557148 * 1E-5;
 
   FP_PRECISION num, den;
-  num = p5*x + p4;
-  num = num*x + p3;
-  num = num*x + p2;
-  num = num*x + p1;
-  num = num*x + p0;
-
   den = d6*x + d5;
   den = den*x + d4;
   den = den*x + d3;
   den = den*x + d2;
   den = den*x + d1;
   den = den*x + d0;
-  *expG = num/den;
+  den = 1.f/den;
+
+  num = p5*x + p4;
+  num = num*x + p3;
+  num = num*x + p2;
+  num = num*x + p1;
+  num = num*x + p0;
+
+  *expG = num*den;
 }
 
 
@@ -171,11 +173,6 @@ inline void expF1_fractional(FP_PRECISION x, FP_PRECISION* expF1) {
   const FP_PRECISION d6 = 1.9309063097411041 * 1E-4;
 
   FP_PRECISION num, den;
-  num = p5*x + p4;
-  num = num*x + p3;
-  num = num*x + p2;
-  num = num*x + p1;
-  num = num*x + p0;
 
   den = d6*x + d5;
   den = den*x + d4;
@@ -183,7 +180,15 @@ inline void expF1_fractional(FP_PRECISION x, FP_PRECISION* expF1) {
   den = den*x + d2;
   den = den*x + d1;
   den = den*x + d0;
-  *expF1 = num/den;
+  den = 1.f / den;
+
+  num = p5*x + p4;
+  num = num*x + p3;
+  num = num*x + p2;
+  num = num*x + p1;
+  num = num*x + p0;
+
+  *expF1 = num*den;
 }
 
 


### PR DESCRIPTION
3D FS solver is optimized, with a peak performance on 2*20 threads at 2.65 ns TPI

Every 50 runs approximately OpenMOC would just freeze in the segmentation phase, and it was also doing this every single time when over-suscribing CPUs. This was due to a problem in the parallel Hashmap, with an infinite while loop due to the data pointed to by _announce (an array for threads to declare they are reading from the map) not being refreshed. 

INFO log now consistently outputs FSR-dependent storage, which can be significant for cores with rings and sector discretization. That storage is significant when trying to use as few nodes as possible.

One small optimization for CMFD by inline getGlobalCMFDCell. That function call was in the top 10 on vTune despite its simplicity, not anymore. Not a significant runtime gain. 

Thread level parallelism for 2D solve is moved from a loop within tracks in each azimuthal angle to a loop on all tracks. This improves load balance. A very quick test indicated a roughly 15% speedup for the sweep part of a 70g 2D LS full core. 