### PR TITLE
Add simple & easy way to use X, Y and Z symmetries

### DIFF
--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -378,6 +378,7 @@ int Cell::getNumSectors() {
 
 /**
  * @brief Return the minimum reachable x-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the minimum x-coordinate
  */
 double Cell::getMinX() {
@@ -398,18 +399,13 @@ double Cell::getMinX() {
       std::abs(min_x) == std::numeric_limits<double>::infinity())
     min_x = getParent()->getMinX();
 
-  /* If region has an infinite min_x, it could be that the fill contains the
-     boundaries */
-  if (_cell_type == FILL && _fill != NULL &&
-      std::abs(min_x) == std::numeric_limits<double>::infinity())
-    min_x = static_cast<Universe*>(_fill)->getMinX();
-
   return min_x;
 }
 
 
 /**
  * @brief Return the maximum reachable x-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the maximum x-coordinate
  */
 double Cell::getMaxX() {
@@ -430,18 +426,13 @@ double Cell::getMaxX() {
       std::abs(max_x) == std::numeric_limits<double>::infinity())
     max_x = getParent()->getMaxX();
 
-  /* If region has an infinite max_x, it could be that the fill contains the
-     boundaries */
-  if (_cell_type == FILL && _fill != NULL &&
-      std::abs(max_x) == std::numeric_limits<double>::infinity())
-    max_x = static_cast<Universe*>(_fill)->getMaxX();
-
   return max_x;
 }
 
 
 /**
  * @brief Return the minimum reachable y-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the minimum y-coordinate
  */
 double Cell::getMinY() {
@@ -462,18 +453,13 @@ double Cell::getMinY() {
       std::abs(min_y) == std::numeric_limits<double>::infinity())
     min_y = getParent()->getMinY();
 
-  /* If region has an infinite min_y, it could be that the fill contains the
-     boundaries */
-  if (_cell_type == FILL && _fill != NULL &&
-      std::abs(min_y) == std::numeric_limits<double>::infinity())
-    min_y = static_cast<Universe*>(_fill)->getMinY();
-
   return min_y;
 }
 
 
 /**
  * @brief Return the maximum reachable y-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the maximum y-coordinate
  */
 double Cell::getMaxY() {
@@ -494,18 +480,13 @@ double Cell::getMaxY() {
       std::abs(max_y) == std::numeric_limits<double>::infinity())
     max_y = getParent()->getMaxY();
 
-  /* If region has an infinite max_y, it could be that the fill contains the
-     boundaries */
-  if (_cell_type == FILL && _fill != NULL &&
-      std::abs(max_y) == std::numeric_limits<double>::infinity())
-    max_y = static_cast<Universe*>(_fill)->getMaxY();
-
   return max_y;
 }
 
 
 /**
  * @brief Return the minimum reachable z-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the minimum z-coordinate
  */
 double Cell::getMinZ() {
@@ -526,18 +507,13 @@ double Cell::getMinZ() {
       std::abs(min_z) == std::numeric_limits<double>::infinity())
     min_z = getParent()->getMinZ();
 
-  /* If region has an infinite min_z, it could be that the fill contains the
-     boundaries */
-  if (_cell_type == FILL && _fill != NULL &&
-      std::abs(min_z) == std::numeric_limits<double>::infinity())
-    min_z = static_cast<Universe*>(_fill)->getMinZ();
-
   return min_z;
 }
 
 
 /**
  * @brief Return the maximum reachable z-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the maximum z-coordinate
  */
 double Cell::getMaxZ() {
@@ -558,12 +534,6 @@ double Cell::getMaxZ() {
       std::abs(max_z) == std::numeric_limits<double>::infinity())
     max_z = getParent()->getMaxZ();
 
-  /* If region has an infinite max_z, it could be that the fill contains the
-     boundaries */
-  if (_cell_type == FILL && _fill != NULL &&
-      std::abs(max_z) == std::numeric_limits<double>::infinity())
-    max_z = static_cast<Universe*>(_fill)->getMaxZ();
-
   return max_z;
 }
 
@@ -571,6 +541,7 @@ double Cell::getMaxZ() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the minimum reachable x-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the minimum x-coordinate
  */
 boundaryType Cell::getMinXBoundaryType() {
@@ -587,11 +558,6 @@ boundaryType Cell::getMinXBoundaryType() {
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMinXBoundaryType();
 
-  /* If no boundary was found in the region, it may be that the boundary
-     is defined in the cell's fill */
-  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
-    boundary = static_cast<Universe*>(_fill)->getMinXBoundaryType();
-
   return boundary;
 }
 
@@ -599,6 +565,7 @@ boundaryType Cell::getMinXBoundaryType() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the maximum reachable x-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the maximum x-coordinate
  */
 boundaryType Cell::getMaxXBoundaryType() {
@@ -615,11 +582,6 @@ boundaryType Cell::getMaxXBoundaryType() {
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMaxXBoundaryType();
 
-  /* If no boundary was found in the region, it may be that the boundary
-     is defined in the cell's fill */
-  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
-    boundary = static_cast<Universe*>(_fill)->getMaxXBoundaryType();
-
   return boundary;
 }
 
@@ -627,6 +589,7 @@ boundaryType Cell::getMaxXBoundaryType() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the minimum reachable y-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the minimum y-coordinate
  */
 boundaryType Cell::getMinYBoundaryType() {
@@ -643,11 +606,6 @@ boundaryType Cell::getMinYBoundaryType() {
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMinYBoundaryType();
 
-  /* If no boundary was found in the region, it may be that the boundary
-     is defined in the cell's fill */
-  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
-    boundary = static_cast<Universe*>(_fill)->getMinYBoundaryType();
-
   return boundary;
 }
 
@@ -655,6 +613,7 @@ boundaryType Cell::getMinYBoundaryType() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the maximum reachable y-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the maximum y-coordinate
  */
 boundaryType Cell::getMaxYBoundaryType() {
@@ -671,11 +630,6 @@ boundaryType Cell::getMaxYBoundaryType() {
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMaxYBoundaryType();
 
-  /* If no boundary was found in the region, it may be that the boundary
-     is defined in the cell's fill */
-  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
-    boundary = static_cast<Universe*>(_fill)->getMaxYBoundaryType();
-
   return boundary;
 }
 
@@ -683,6 +637,7 @@ boundaryType Cell::getMaxYBoundaryType() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the minimum reachable z-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the minimum z-coordinate
  */
 boundaryType Cell::getMinZBoundaryType() {
@@ -699,11 +654,6 @@ boundaryType Cell::getMinZBoundaryType() {
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMinZBoundaryType();
 
-  /* If no boundary was found in the region, it may be that the boundary
-     is defined in the cell's fill */
-  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
-      boundary = static_cast<Universe*>(_fill)->getMinZBoundaryType();
-
   return boundary;
 }
 
@@ -711,6 +661,7 @@ boundaryType Cell::getMinZBoundaryType() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the maximum reachable z-coordinate in the Cell.
+ * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the maximum z-coordinate
  */
 boundaryType Cell::getMaxZBoundaryType() {
@@ -726,11 +677,6 @@ boundaryType Cell::getMaxZBoundaryType() {
      is in the Parent cell's region */
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMaxZBoundaryType();
-
-  /* If no boundary was found in the region, it may be that the boundary
-     is defined in the cell's fill */
-  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
-      boundary = static_cast<Universe*>(_fill)->getMaxZBoundaryType();
 
   return boundary;
 }

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -398,6 +398,12 @@ double Cell::getMinX() {
       std::abs(min_x) == std::numeric_limits<double>::infinity())
     min_x = getParent()->getMinX();
 
+  /* If region has an infinite min_x, it could be that the fill contains the
+     boundaries */
+  if (_cell_type == FILL && _fill != NULL &&
+      std::abs(min_x) == std::numeric_limits<double>::infinity())
+    min_x = static_cast<Universe*>(_fill)->getMinX();
+
   return min_x;
 }
 
@@ -423,6 +429,12 @@ double Cell::getMaxX() {
   if (getParent() != NULL &&
       std::abs(max_x) == std::numeric_limits<double>::infinity())
     max_x = getParent()->getMaxX();
+
+  /* If region has an infinite max_x, it could be that the fill contains the
+     boundaries */
+  if (_cell_type == FILL && _fill != NULL &&
+      std::abs(max_x) == std::numeric_limits<double>::infinity())
+    max_x = static_cast<Universe*>(_fill)->getMaxX();
 
   return max_x;
 }
@@ -450,6 +462,12 @@ double Cell::getMinY() {
       std::abs(min_y) == std::numeric_limits<double>::infinity())
     min_y = getParent()->getMinY();
 
+  /* If region has an infinite min_y, it could be that the fill contains the
+     boundaries */
+  if (_cell_type == FILL && _fill != NULL &&
+      std::abs(min_y) == std::numeric_limits<double>::infinity())
+    min_y = static_cast<Universe*>(_fill)->getMinY();
+
   return min_y;
 }
 
@@ -475,6 +493,12 @@ double Cell::getMaxY() {
   if (getParent() != NULL &&
       std::abs(max_y) == std::numeric_limits<double>::infinity())
     max_y = getParent()->getMaxY();
+
+  /* If region has an infinite max_y, it could be that the fill contains the
+     boundaries */
+  if (_cell_type == FILL && _fill != NULL &&
+      std::abs(max_y) == std::numeric_limits<double>::infinity())
+    max_y = static_cast<Universe*>(_fill)->getMaxY();
 
   return max_y;
 }
@@ -502,6 +526,12 @@ double Cell::getMinZ() {
       std::abs(min_z) == std::numeric_limits<double>::infinity())
     min_z = getParent()->getMinZ();
 
+  /* If region has an infinite min_z, it could be that the fill contains the
+     boundaries */
+  if (_cell_type == FILL && _fill != NULL &&
+      std::abs(min_z) == std::numeric_limits<double>::infinity())
+    min_z = static_cast<Universe*>(_fill)->getMinZ();
+
   return min_z;
 }
 
@@ -528,6 +558,12 @@ double Cell::getMaxZ() {
       std::abs(max_z) == std::numeric_limits<double>::infinity())
     max_z = getParent()->getMaxZ();
 
+  /* If region has an infinite max_z, it could be that the fill contains the
+     boundaries */
+  if (_cell_type == FILL && _fill != NULL &&
+      std::abs(max_z) == std::numeric_limits<double>::infinity())
+    max_z = static_cast<Universe*>(_fill)->getMaxZ();
+
   return max_z;
 }
 
@@ -550,6 +586,11 @@ boundaryType Cell::getMinXBoundaryType() {
      is in the Parent cell's region */
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMinXBoundaryType();
+
+  /* If no boundary was found in the region, it may be that the boundary
+     is defined in the cell's fill */
+  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
+    boundary = static_cast<Universe*>(_fill)->getMinXBoundaryType();
 
   return boundary;
 }
@@ -574,6 +615,11 @@ boundaryType Cell::getMaxXBoundaryType() {
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMaxXBoundaryType();
 
+  /* If no boundary was found in the region, it may be that the boundary
+     is defined in the cell's fill */
+  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
+    boundary = static_cast<Universe*>(_fill)->getMaxXBoundaryType();
+
   return boundary;
 }
 
@@ -596,6 +642,11 @@ boundaryType Cell::getMinYBoundaryType() {
      is in the Parent cell's region */
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMinYBoundaryType();
+
+  /* If no boundary was found in the region, it may be that the boundary
+     is defined in the cell's fill */
+  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
+    boundary = static_cast<Universe*>(_fill)->getMinYBoundaryType();
 
   return boundary;
 }
@@ -620,6 +671,11 @@ boundaryType Cell::getMaxYBoundaryType() {
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMaxYBoundaryType();
 
+  /* If no boundary was found in the region, it may be that the boundary
+     is defined in the cell's fill */
+  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
+    boundary = static_cast<Universe*>(_fill)->getMaxYBoundaryType();
+
   return boundary;
 }
 
@@ -642,6 +698,11 @@ boundaryType Cell::getMinZBoundaryType() {
      is in the Parent cell's region */
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMinZBoundaryType();
+
+  /* If no boundary was found in the region, it may be that the boundary
+     is defined in the cell's fill */
+  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
+      boundary = static_cast<Universe*>(_fill)->getMinZBoundaryType();
 
   return boundary;
 }
@@ -666,9 +727,13 @@ boundaryType Cell::getMaxZBoundaryType() {
   if (getParent() != NULL && boundary == BOUNDARY_NONE)
     boundary = getParent()->getMaxZBoundaryType();
 
+  /* If no boundary was found in the region, it may be that the boundary
+     is defined in the cell's fill */
+  if (_cell_type == FILL && _fill != NULL && boundary == BOUNDARY_NONE)
+      boundary = static_cast<Universe*>(_fill)->getMaxZBoundaryType();
+
   return boundary;
 }
-
 
 
 /**
@@ -1080,7 +1145,7 @@ void Cell::addSurface(int halfspace, Surface* surface) {
   * @param surface a pointer to the Surface
   */
  void Cell::addSurfaceInRegion(int halfspace, Surface* surface) {
- 
+
    /* Create a new halfspace */
    Halfspace* new_halfspace = new Halfspace(halfspace, surface);
 
@@ -1116,7 +1181,7 @@ void Cell::removeSurface(Surface* surface) {
   * @param region_type the logical operation
   */
  void Cell::addLogicalNode(int region_type) {
- 
+
    /* Create new region if void */
    if (_region == NULL) {
      if (region_type == INTERSECTION) {
@@ -1364,8 +1429,8 @@ void Cell::sectorize(std::vector<Cell*>& subcells) {
         sector->addSurface(-1, planes.at(0));
     }
     else {
-      /* For _num_sectors==2, planes[0] and planes[1] are actually the same but 
-         opposite direction, so the two adjacent sectors will have the same 
+      /* For _num_sectors==2, planes[0] and planes[1] are actually the same but
+         opposite direction, so the two adjacent sectors will have the same
          Halfspace value, which will cause trouble when a point is on the plane.
          This is to avoid this trouble. */
       int halfspace = (i==0? +1 : -1);
@@ -1672,7 +1737,7 @@ std::string Cell::toString() {
   std::map<int, Halfspace*> _surfaces = getSurfaces();
   string << ", Surfaces: ";
   for (iter = _surfaces.begin(); iter != _surfaces.end(); ++iter)
-    string << std::showpos << "\nhalfspace = " << iter->second->_halfspace 
+    string << std::showpos << "\nhalfspace = " << iter->second->_halfspace
            << ", " << iter->second->_surface->toString();
 
   return string.str();

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -378,7 +378,6 @@ int Cell::getNumSectors() {
 
 /**
  * @brief Return the minimum reachable x-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the minimum x-coordinate
  */
 double Cell::getMinX() {
@@ -405,7 +404,6 @@ double Cell::getMinX() {
 
 /**
  * @brief Return the maximum reachable x-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the maximum x-coordinate
  */
 double Cell::getMaxX() {
@@ -432,7 +430,6 @@ double Cell::getMaxX() {
 
 /**
  * @brief Return the minimum reachable y-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the minimum y-coordinate
  */
 double Cell::getMinY() {
@@ -459,7 +456,6 @@ double Cell::getMinY() {
 
 /**
  * @brief Return the maximum reachable y-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the maximum y-coordinate
  */
 double Cell::getMaxY() {
@@ -486,7 +482,6 @@ double Cell::getMaxY() {
 
 /**
  * @brief Return the minimum reachable z-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the minimum z-coordinate
  */
 double Cell::getMinZ() {
@@ -513,7 +508,6 @@ double Cell::getMinZ() {
 
 /**
  * @brief Return the maximum reachable z-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the maximum z-coordinate
  */
 double Cell::getMaxZ() {
@@ -541,7 +535,6 @@ double Cell::getMaxZ() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the minimum reachable x-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the minimum x-coordinate
  */
 boundaryType Cell::getMinXBoundaryType() {
@@ -565,7 +558,6 @@ boundaryType Cell::getMinXBoundaryType() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the maximum reachable x-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the maximum x-coordinate
  */
 boundaryType Cell::getMaxXBoundaryType() {
@@ -589,7 +581,6 @@ boundaryType Cell::getMaxXBoundaryType() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the minimum reachable y-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the minimum y-coordinate
  */
 boundaryType Cell::getMinYBoundaryType() {
@@ -613,7 +604,6 @@ boundaryType Cell::getMinYBoundaryType() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the maximum reachable y-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the maximum y-coordinate
  */
 boundaryType Cell::getMaxYBoundaryType() {
@@ -637,7 +627,6 @@ boundaryType Cell::getMaxYBoundaryType() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the minimum reachable z-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the minimum z-coordinate
  */
 boundaryType Cell::getMinZBoundaryType() {
@@ -661,7 +650,6 @@ boundaryType Cell::getMinZBoundaryType() {
 /**
  * @brief Return the boundary condition (REFLECTIVE, VACUUM, or INTERFACE) at
  *        the maximum reachable z-coordinate in the Cell.
- * @param search_fill whether to search the fill universe (default=true)
  * @return the boundary condition at the maximum z-coordinate
  */
 boundaryType Cell::getMaxZBoundaryType() {

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -3671,8 +3671,7 @@ void Cmfd::initializeLattice(Point* offset, bool is_2D) {
   }
 
   /* Handle use of X,Y and Z symmetries */
-  std::vector<bool> symmetries = _geometry->getSymmetries();
-  if (symmetries[0]) {
+  if (_geometry->getSymmetry(0)) {
 
     // Compute current width of CMFD mesh
     double width_x = 0;
@@ -3681,7 +3680,7 @@ void Cmfd::initializeLattice(Point* offset, bool is_2D) {
 
     // If CMFD mesh was meant for full geometry, adapt it
     if (std::abs(width_x - _width_x * 2) < FLT_EPSILON) {
-      if (initial_size % 2 == 0)
+      if (_cell_widths_x.size() % 2 == 0)
         _cell_widths_x.resize(_cell_widths_x.size() / 2);
       else {
         _cell_widths_x.resize(_cell_widths_x.size() / 2 + 1);
@@ -3689,7 +3688,7 @@ void Cmfd::initializeLattice(Point* offset, bool is_2D) {
       }
     }
   }
-  if (symmetries[1]) {
+  if (_geometry->getSymmetry(1)) {
 
     // Compute current width of CMFD mesh
     double width_y = 0;
@@ -3698,7 +3697,7 @@ void Cmfd::initializeLattice(Point* offset, bool is_2D) {
 
     // If CMFD mesh was meant for full geometry, adapt it
     if (std::abs(width_y - _width_y * 2) < FLT_EPSILON) {
-      if (initial_size % 2 == 0)
+      if (_cell_widths_y.size() % 2 == 0)
         _cell_widths_y.resize(_cell_widths_y.size() / 2);
       else {
         _cell_widths_y.resize(_cell_widths_y.size() / 2 + 1);
@@ -3706,7 +3705,7 @@ void Cmfd::initializeLattice(Point* offset, bool is_2D) {
       }
     }
   }
-  if (symmetries[2]) {
+  if (_geometry->getSymmetry(2)) {
 
     // Compute current width of CMFD mesh
     double width_z = 0;
@@ -3715,7 +3714,7 @@ void Cmfd::initializeLattice(Point* offset, bool is_2D) {
 
     // If CMFD mesh was meant for full geometry, adapt it
     if (std::abs(width_z - _width_z * 2) < FLT_EPSILON) {
-      if (initial_size % 2 == 0)
+      if (_cell_widths_z.size() % 2 == 0)
         _cell_widths_z.resize(_cell_widths_z.size() / 2);
       else {
         _cell_widths_z.resize(_cell_widths_z.size() / 2 + 1);

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -852,7 +852,7 @@ void Cmfd::collapseXS() {
           if (fabs(trans_tally_group) > fabs(rxn_tally_group) * FLT_EPSILON) {
             CMFD_PRECISION flux_avg_sigma_t = trans_tally_group /
                 rxn_tally_group;
-            _diffusion_tally[i][e] += rxn_tally_group / 
+            _diffusion_tally[i][e] += rxn_tally_group /
                 (3.0 * flux_avg_sigma_t);
           }
         }
@@ -1333,7 +1333,7 @@ void Cmfd::constructMatrices(int moc_iteration) {
           delta = getSurfaceWidth(s, global_ind);
 
           /* Set transport term on diagonal */
-          getSurfaceDiffusionCoefficient(i, s, e, moc_iteration, dif_surf, 
+          getSurfaceDiffusionCoefficient(i, s, e, moc_iteration, dif_surf,
                                           dif_surf_corr);
 
           /* Record the corrected diffusion coefficient */
@@ -1422,7 +1422,7 @@ void Cmfd::updateMOCFlux() {
 
         /* Save max update ratio among fsrs and groups in a cell */
         if (_convergence_data != NULL)
-            if (std::abs(log(update_ratio)) > 
+            if (std::abs(log(update_ratio)) >
                 std::abs(log(thread_max_update_ratio)))
               thread_max_update_ratio = update_ratio;
 
@@ -1450,7 +1450,7 @@ void Cmfd::updateMOCFlux() {
     if (_convergence_data != NULL) {
 #pragma omp critical
       {
-        if (std::abs(log(thread_max_update_ratio)) > 
+        if (std::abs(log(thread_max_update_ratio)) >
             std::abs(log(_convergence_data->pf)))
               _convergence_data->pf = thread_max_update_ratio;
       }
@@ -3670,6 +3670,60 @@ void Cmfd::initializeLattice(Point* offset, bool is_2D) {
     setBoundary(SURFACE_Z_MAX, REFLECTIVE);
   }
 
+  /* Handle use of X,Y and Z symmetries */
+  std::vector<bool> symmetries = _geometry->getSymmetries();
+  if (symmetries[0]) {
+
+    // Compute current width of CMFD mesh
+    double width_x = 0;
+    for (int i=0; i<_cell_widths_x.size(); i++)
+      width_x = width_x + _cell_widths_x[i];
+
+    // If CMFD mesh was meant for full geometry, adapt it
+    if (std::abs(width_x - _width_x * 2) < FLT_EPSILON) {
+      if (initial_size % 2 == 0)
+        _cell_widths_x.resize(_cell_widths_x.size() / 2);
+      else {
+        _cell_widths_x.resize(_cell_widths_x.size() / 2 + 1);
+        _cell_widths_x[_cell_widths_x.size() - 1] /= 2;
+      }
+    }
+  }
+  if (symmetries[1]) {
+
+    // Compute current width of CMFD mesh
+    double width_y = 0;
+    for (int i=0; i<_cell_widths_y.size(); i++)
+      width_y = width_y + _cell_widths_y[i];
+
+    // If CMFD mesh was meant for full geometry, adapt it
+    if (std::abs(width_y - _width_y * 2) < FLT_EPSILON) {
+      if (initial_size % 2 == 0)
+        _cell_widths_y.resize(_cell_widths_y.size() / 2);
+      else {
+        _cell_widths_y.resize(_cell_widths_y.size() / 2 + 1);
+        _cell_widths_y[_cell_widths_y.size() - 1] /= 2;
+      }
+    }
+  }
+  if (symmetries[2]) {
+
+    // Compute current width of CMFD mesh
+    double width_z = 0;
+    for (int i=0; i<_cell_widths_z.size(); i++)
+      width_z = width_z + _cell_widths_z[i];
+
+    // If CMFD mesh was meant for full geometry, adapt it
+    if (std::abs(width_z - _width_z * 2) < FLT_EPSILON) {
+      if (initial_size % 2 == 0)
+        _cell_widths_z.resize(_cell_widths_z.size() / 2);
+      else {
+        _cell_widths_z.resize(_cell_widths_z.size() / 2 + 1);
+        _cell_widths_z[_cell_widths_z.size() - 1] /= 2;
+      }
+    }
+  }
+
   if (_non_uniform) {
     setNumX(_cell_widths_x.size());
     setNumY(_cell_widths_y.size());
@@ -4213,7 +4267,7 @@ void Cmfd::copyFullSurfaceCurrents() {
  *          - in MOC at the boundaries, as the incoming currents are not
  *          tallied (except at ite 0, they are null)
  *          - in MOC at the reflective boundaries when tracks hit edges and
- *          corners as the contributions are double tallied (not a bug, only 
+ *          corners as the contributions are double tallied (not a bug, only
  *          a problem for this routine, see NOTE for where to modify code)
  * @param pre_split whether edge currents are not split (default true)
  * @param moc_balance whether to check the MOC balance over the cell or
@@ -4638,8 +4692,8 @@ void Cmfd::packBuffers() {
  * @details comm The cartesian MPI domain communicator object that is
  *          configured for the CMFD exchange
  *          send_buffers A 2D array of floating point data. The outer dimension
- *          corresponds to each face of the domain, while the inner dimension 
- *          is the serialized buffer corresponding to the number of 2D cells 
+ *          corresponds to each face of the domain, while the inner dimension
+ *          is the serialized buffer corresponding to the number of 2D cells
  *          to exchange times the number of energy groups.
  *          recv_buffers A 2D array of floating point data. The outer dimension
  *          corresponds to each face of the domain,  while the inner dimension

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -31,7 +31,7 @@ Geometry::Geometry() {
   _domain_index_x = 1;
   _domain_index_y = 1;
   _domain_index_z = 1;
-  _symmetries.resize(3);
+  _symmetries.resize(3, false);
   _domain_FSRs_counted = false;
   _contains_FSR_centroids = false;
   _twiddle = false;
@@ -742,10 +742,10 @@ void Geometry::useSymmetry(bool X_symmetry, bool Y_symmetry, bool Z_symmetry) {
 
 /**
  * @brief Get the symmetries used to restrict the domain
- * @return _symmetries pointer to an array containing the symmetries used
+ * @return a boolean indicating if the symmetry along this axis is used
  */
-std::vector<bool> Geometry::getSymmetries() {
-  return _symmetries;
+bool Geometry::getSymmetry(int axis) {
+  return _symmetries[axis];
 }
 
 
@@ -3151,9 +3151,8 @@ void Geometry::initializeCmfd() {
   else
     offset.setZ(0.);
 
-  _cmfd->initializeLattice(&offset);
-
   _cmfd->setGeometry(this);
+  _cmfd->initializeLattice(&offset);
 
 #ifdef MPIx
   if (_domain_decomposed) {

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -31,6 +31,7 @@ Geometry::Geometry() {
   _domain_index_x = 1;
   _domain_index_y = 1;
   _domain_index_z = 1;
+  _symmetries.resize(3);
   _domain_FSRs_counted = false;
   _contains_FSR_centroids = false;
   _twiddle = false;
@@ -690,6 +691,11 @@ void Geometry::useSymmetry(bool X_symmetry, bool Y_symmetry, bool Z_symmetry) {
                ", re-compile without the ONLYVACUUMBC flag.")
 #endif
 
+  // Keep track of symmetries used
+  _symmetries[0] = X_symmetry;
+  _symmetries[1] = Y_symmetry;
+  _symmetries[2] = Z_symmetry;
+
   if (X_symmetry) {
     // Get center plane
     double mid_x = (_root_universe->getMaxX() + _root_universe->getMinX()) / 2;
@@ -731,6 +737,15 @@ void Geometry::useSymmetry(bool X_symmetry, bool Y_symmetry, bool Z_symmetry) {
 
   // Reset boundaries to trigger boundary calculation again
   _root_universe->resetBoundaries();
+}
+
+
+/**
+ * @brief Get the symmetries used to restrict the domain
+ * @return _symmetries pointer to an array containing the symmetries used
+ */
+std::vector<bool> Geometry::getSymmetries() {
+  return _symmetries;
 }
 
 

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -183,21 +183,24 @@ private:
   std::vector<long> _num_domain_FSRs;
 
 #ifdef MPIx
-  /* MPI communicator, used to transfer information across domain for both 
+  /* MPI communicator, used to transfer information across domain for both
    * ray-tracing and solving the MOC equations */
   MPI_Comm _MPI_cart;
 #endif
 
-  /* Number of modular track laydowns within a domain, in the X, Y and 
+  /* Number of modular track laydowns within a domain, in the X, Y and
      Z directions */
   int _num_modules_x;
   int _num_modules_y;
   int _num_modules_z;
 
+  /* Symmetries in X,Y and Z axis used to restrict the computation domain */
+  std::vector<bool> _symmetries;
+
   /* Wether to read bites backwards or forward (for BGQ) */
   bool _twiddle;
 
-  /* Whether the geometry was loaded from a .geo file or created in the input 
+  /* Whether the geometry was loaded from a .geo file or created in the input
    * file. This matters for memory de-allocation purposes. */
   bool _loaded_from_file;
 
@@ -214,7 +217,10 @@ public:
   int getNumXModules();
   int getNumYModules();
   int getNumZModules();
+
+  /* Handle symmetry axis used to restrict the computation domain */
   void useSymmetry(bool X_symmetry, bool Y_symmetry, bool Z_symmetry);
+  std::vector<bool> getSymmetries();
 
   /* Get parameters */
   double getWidthX();
@@ -322,8 +328,8 @@ public:
                                          const char* domain_type);
   std::string toString();
   void printString();
-  void printFSRsToFile(const char* plane="xy", int gridsize=1000, 
-                       double offset=0.0, double* bounds_x = NULL, 
+  void printFSRsToFile(const char* plane="xy", int gridsize=1000,
+                       double offset=0.0, double* bounds_x = NULL,
                        double* bounds_y = NULL, double* bounds_z = NULL);
 
   void initializeCmfd();

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -220,7 +220,7 @@ public:
 
   /* Handle symmetry axis used to restrict the computation domain */
   void useSymmetry(bool X_symmetry, bool Y_symmetry, bool Z_symmetry);
-  std::vector<bool> getSymmetries();
+  bool getSymmetry(int axis);
 
   /* Get parameters */
   double getWidthX();

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -214,6 +214,7 @@ public:
   int getNumXModules();
   int getNumYModules();
   int getNumZModules();
+  void useSymmetry(bool X_symmetry, bool Y_symmetry, bool Z_symmetry);
 
   /* Get parameters */
   double getWidthX();
@@ -258,7 +259,7 @@ public:
   MPI_Comm getMPICart();
 #endif
 
-  /* Get CMFD parameters */
+  /* More complex getter methods */
   Cmfd* getCmfd();
   std::vector<std::string>& getFSRsToKeys();
   std::vector<int>& getFSRsToMaterialIDs();
@@ -282,7 +283,7 @@ public:
   int getNeighborDomain(int offset_x, int offset_y, int offset_z);
 #endif
 
-  /* Set CMFD parameters */
+  /* Setter methods */
   void setCmfd(Cmfd* cmfd);
   void setFSRCentroid(long fsr, Point* centroid);
   void setOverlaidMesh(double axial_mesh_height, int num_x=0,

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -483,7 +483,7 @@ void TrackGenerator::setNumThreads(int num_threads) {
 #endif
 
   if (num_threads > 1)
-    log_printf(NODAL, "CPUs on rank %d process: %s", rank, 
+    log_printf(NODAL, "CPUs on rank %d process: %s", rank,
                str_cpus.str().c_str());
 }
 
@@ -1222,8 +1222,8 @@ void TrackGenerator::segmentize() {
   /* Check to ensure the Geometry is infinite in axial direction */
   double max_z = _geometry->getRootUniverse()->getMaxZ();
   double min_z = _geometry->getRootUniverse()->getMinZ();
-  if ((max_z - min_z) < FLT_INFINITY) {
-    log_printf(WARNING_ONCE, "The Geometry was set with non-inifinite "
+  if (max_z - min_z < FLT_INFINITY) {
+    log_printf(WARNING_ONCE, "The Geometry was set with non-infinite "
                "z-boundaries and supplied to a 2D TrackGenerator. The min-z "
                "boundary was set to %5.2f and the max-z boundary was set to "
                "%5.2f. Z-boundaries are assumed to be infinite in 2D "
@@ -1460,7 +1460,7 @@ void TrackGenerator::dumpSegmentsToFile() {
 
 
 /**
- * @brief Write information of all Extruded FSRs to a file 
+ * @brief Write information of all Extruded FSRs to a file
  //TODO Use implementation in 3D track generator
  * @param out file to write to
  */
@@ -1776,7 +1776,7 @@ bool TrackGenerator::getPeriodic() {
 
 /**
  * @brief Sets a flag to record all segment information in the tracking file.
- * @param dump_segments whether or not to record segment information in the 
+ * @param dump_segments whether or not to record segment information in the
  *        tracking file: true to record, false not to record
  */
 void TrackGenerator::setDumpSegments(bool dump_segments) {

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -743,7 +743,7 @@ void Universe::calculateBoundaries() {
   Surface* surf;
   int halfspace;
 
-  /* Calculate the boundary condition at the minimum reachable x-coordinate in 
+  /* Calculate the boundary condition at the minimum reachable x-coordinate in
    * the Universe and store it in _min_x_bound */
   _min_x_bound = BOUNDARY_NONE;
 
@@ -774,8 +774,16 @@ void Universe::calculateBoundaries() {
   /* If a x-min boundary was not found, get the x-min from the bounding boxes
    * of the cells */
   if (min_x > FLT_INFINITY) {
-    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
-      min_x = std::min(min_x, c_iter->second->getMinX());
+    double cell_min_x = min_x;
+    boundaryType cell_min_x_bound = BOUNDARY_NONE;
+    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
+      cell_min_x = c_iter->second->getMinX();
+      cell_min_x_bound = c_iter->second->getMinXBoundaryType();
+      if (cell_min_x_bound != BOUNDARY_NONE && cell_min_x < min_x) {
+        min_x = cell_min_x;
+        _min_x_bound = cell_min_x_bound;
+      }
+    }
   }
 
   _min_x = min_x;
@@ -784,7 +792,7 @@ void Universe::calculateBoundaries() {
    * in _max_x */
   double max_x = -std::numeric_limits<double>::infinity();
 
-  /* Calculate the boundary condition at the maximum reachable x-coordinate in 
+  /* Calculate the boundary condition at the maximum reachable x-coordinate in
    * the Universe and store it in _max_x_bound */
   _max_x_bound = BOUNDARY_NONE;
 
@@ -815,8 +823,16 @@ void Universe::calculateBoundaries() {
   /* If a x-max boundary was not found, get the x-max from the bounding boxes
    * of the cells */
   if (max_x < -FLT_INFINITY) {
-    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
-      max_x = std::max(max_x, c_iter->second->getMaxX());
+    double cell_max_x = max_x;
+    boundaryType cell_max_x_bound = BOUNDARY_NONE;
+    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
+      cell_max_x = c_iter->second->getMaxX();
+      cell_max_x_bound = c_iter->second->getMaxXBoundaryType();
+      if (cell_max_x_bound != BOUNDARY_NONE && cell_max_x > max_x) {
+        max_x = cell_max_x;
+        _max_x_bound = cell_max_x_bound;
+      }
+    }
   }
 
   _max_x = max_x;
@@ -826,7 +842,7 @@ void Universe::calculateBoundaries() {
    * in _min_y */
   double min_y = std::numeric_limits<double>::infinity();
 
-  /* Calculate the boundary condition at the minimum reachable y-coordinate in 
+  /* Calculate the boundary condition at the minimum reachable y-coordinate in
    * the Universe and store it in _min_y_bound */
   _min_y_bound = BOUNDARY_NONE;
 
@@ -857,8 +873,16 @@ void Universe::calculateBoundaries() {
   /* If a y-min boundary was not found, get the y-min from the bounding boxes
    * of the cells */
   if (min_y > FLT_INFINITY) {
-    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
-      min_y = std::min(min_y, c_iter->second->getMinY());
+    double cell_min_y = min_y;
+    boundaryType cell_min_y_bound = BOUNDARY_NONE;
+    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
+      cell_min_y = c_iter->second->getMinY();
+      cell_min_y_bound = c_iter->second->getMinYBoundaryType();
+      if (cell_min_y_bound != BOUNDARY_NONE && cell_min_y < min_y) {
+        min_y = cell_min_y;
+        _min_y_bound = cell_min_y_bound;
+      }
+    }
   }
 
   _min_y = min_y;
@@ -867,7 +891,7 @@ void Universe::calculateBoundaries() {
    * in _max_y */
   double max_y = -std::numeric_limits<double>::infinity();
 
-  /* Calculate the boundary condition at the maximum reachable y-coordinate in 
+  /* Calculate the boundary condition at the maximum reachable y-coordinate in
    * the Universe and store it in _max_y_bound */
   _max_y_bound = BOUNDARY_NONE;
 
@@ -898,8 +922,16 @@ void Universe::calculateBoundaries() {
   /* If a y-max boundary was not found, get the y-max from the bounding boxes
    * of the cells */
   if (max_y < -FLT_INFINITY) {
-    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
-      max_y = std::max(max_y, c_iter->second->getMaxY());
+    double cell_max_y = max_y;
+    boundaryType cell_max_y_bound = BOUNDARY_NONE;
+    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
+      cell_max_y = c_iter->second->getMaxY();
+      cell_max_y_bound = c_iter->second->getMaxYBoundaryType();
+      if (cell_max_y_bound != BOUNDARY_NONE && cell_max_y > max_y) {
+        max_y = cell_max_y;
+        _max_y_bound = cell_max_y_bound;
+      }
+    }
   }
 
   _max_y = max_y;
@@ -939,8 +971,16 @@ void Universe::calculateBoundaries() {
   /* If a z-min boundary was not found, get the z-min from the bounding boxes
    * of the cells */
   if (min_z > FLT_INFINITY) {
-    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
-      min_z = std::min(min_z, c_iter->second->getMinZ());
+    double cell_min_z = min_z;
+    boundaryType cell_min_z_bound = BOUNDARY_NONE;
+    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
+      cell_min_z = c_iter->second->getMinZ();
+      cell_min_z_bound = c_iter->second->getMinZBoundaryType();
+      if (cell_min_z_bound != BOUNDARY_NONE && cell_min_z < min_z) {
+        min_z = cell_min_z;
+        _min_z_bound = cell_min_z_bound;
+      }
+    }
   }
 
   _min_z = min_z;
@@ -980,13 +1020,26 @@ void Universe::calculateBoundaries() {
   /* If a z-max boundary was not found, get the z-max from the bounding boxes
    * of the cells */
   if (max_z < -FLT_INFINITY) {
-    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter)
-      max_z = std::max(max_z, c_iter->second->getMaxZ());
+    double cell_max_z = max_z;
+    boundaryType cell_max_z_bound = BOUNDARY_NONE;
+    for (c_iter = _cells.begin(); c_iter != _cells.end(); ++c_iter) {
+      cell_max_z = c_iter->second->getMaxZ();
+      cell_max_z_bound = c_iter->second->getMaxZBoundaryType();
+      if (cell_max_z_bound != BOUNDARY_NONE && cell_max_z > max_z) {
+        max_z = cell_max_z;
+        _max_z_bound = cell_max_z_bound;
+      }
+    }
   }
 
   _max_z = max_z;
-
   _boundaries_inspected = true;
+
+  // Fix Z bounds for 2D cases
+  if (_min_z > FLT_INFINITY)
+    _min_z = -std::numeric_limits<double>::infinity();
+  if (_max_z < -FLT_INFINITY)
+    _max_z = std::numeric_limits<double>::infinity();
 }
 
 
@@ -1313,7 +1366,7 @@ std::map<int, double> Lattice::getUniqueRadius
     for (int j = _universes.at(k).size()-1; j > -1;  j--) {
       for (int i = 0; i < _universes.at(k).at(j).size(); i++) {
         universe = _universes.at(k).at(j).at(i).second;
-        unique_radius[universe->getId()] = 
+        unique_radius[universe->getId()] =
           std::max(unique_radius[universe->getId()],
           sqrt(_widths_x[i]*_widths_x[i]/4.0 + _widths_y[j]*_widths_y[j]/4.0));
       }
@@ -1629,12 +1682,12 @@ void Lattice::subdivideCells(double max_radius) {
 
   /* Subdivide all Cells */
   for (iter = universes.begin(); iter != universes.end(); ++iter) {
-    log_printf(DEBUG, "univ_ID: %d, radius: %f, max_radius: %f", 
+    log_printf(DEBUG, "univ_ID: %d, radius: %f, max_radius: %f",
                iter->first, unique_radius[iter->first], max_radius);
 
-    /* If the  local universe equivalent radius is smaller than max_radius 
+    /* If the  local universe equivalent radius is smaller than max_radius
        parameter, over-ride it*/
-    iter->second->subdivideCells(std::min(unique_radius[iter->first], 
+    iter->second->subdivideCells(std::min(unique_radius[iter->first],
                                           max_radius));
   }
 }
@@ -1719,7 +1772,7 @@ bool Lattice::containsPoint(Point* point) {
  * @details This method first find the Lattice cell, then searches the
  *          Universe inside that Lattice cell. If LocalCoords is outside
  *          the bounds of the Lattice, this method will return NULL.
- * @param coords the LocalCoords of interest. Coordinates of coords and  
+ * @param coords the LocalCoords of interest. Coordinates of coords and
  *        lattice._offset share the same origin.
  * @return a pointer to the Cell this LocalCoord is in or NULL
  */
@@ -1740,7 +1793,7 @@ Cell* Lattice::findCell(LocalCoords* coords) {
     return NULL;
   }
 
-  /* Compute local position of Point in the next level Universe. The offset of 
+  /* Compute local position of Point in the next level Universe. The offset of
      Lattice should be considered. */
   double next_x = coords->getX()
                   - (getMinX() + _widths_x[lat_x]/2. + _accumulate_x[lat_x]);
@@ -1823,7 +1876,7 @@ double Lattice::minSurfaceDist(Point* point, double azim, double polar) {
 
   /* Get the min distance for Z PLANE  */
   double dist_z;
-  if (fabs(u_z) > FLT_EPSILON && 
+  if (fabs(u_z) > FLT_EPSILON &&
       _width_z != std::numeric_limits<double>::infinity()) {
     double plane_z = _accumulate_z[lat_z] + getMinZ();
     dist_z = (plane_z - point->getZ()) / u_z;
@@ -1886,7 +1939,7 @@ int Lattice::getLatY(Point* point) {
 
   /* Compute the y index for the Lattice cell this point is in */
   for (int i=0; i<_num_y; i++) {
-    if (dist_to_bottom >= _accumulate_y[i] && 
+    if (dist_to_bottom >= _accumulate_y[i] &&
       dist_to_bottom < _accumulate_y[i+1]) {
       lat_y = i;
       break;
@@ -1926,7 +1979,7 @@ int Lattice::getLatZ(Point* point) {
 
   /* Compute the y index for the Lattice cell this point is in */
   for (int i=0; i<_num_z; i++) {
-    if (dist_to_bottom >= _accumulate_z[i] && 
+    if (dist_to_bottom >= _accumulate_z[i] &&
         dist_to_bottom < _accumulate_z[i+1]) {
       lat_z = i;
       break;
@@ -1973,7 +2026,7 @@ std::string Lattice::toString() {
     for (int i=0; i<_num_z; i++)
       string << _widths_z[i] << "  ";
   }
-  else  
+  else
     string << ", x width = " << _width_x
            << ", y width = " << _width_y
            << ", z width = " << _width_z;
@@ -2046,7 +2099,7 @@ int Lattice::getLatticeSurface(int cell, Point* point) {
   XPlane xplane(0.0);
   YPlane yplane(0.0);
   ZPlane zplane(0.0);
-  
+
   /* Bools indicating if point is on each surface */
   bool on_min_x, on_max_x, on_min_y, on_max_y, on_min_z, on_max_z;
 
@@ -2269,7 +2322,7 @@ int Lattice::getLatticeSurfaceOTF(int cell, double z, int surface_2D) {
  * @param widths_y y-direction widths of non-uniform meshes
  * @param widths_z z-direction widths of non-uniform meshes
  */
-void Lattice::setWidths(std::vector<double> widths_x, 
+void Lattice::setWidths(std::vector<double> widths_x,
                   std::vector<double> widths_y, std::vector<double> widths_z) {
   _non_uniform = true;
   _widths_x = widths_x;
@@ -2279,7 +2332,7 @@ void Lattice::setWidths(std::vector<double> widths_x,
 
 
 /**
- * @brief Set _widths_x, _widths_y, _widths_z for uniform case, compute 
+ * @brief Set _widths_x, _widths_y, _widths_z for uniform case, compute
  *        accumulate variables.
  */
 void Lattice::computeSizes() {

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -837,7 +837,6 @@ void Universe::calculateBoundaries() {
 
   _max_x = max_x;
 
-
   /* Calculate the minimum reachable y-coordinate in the geometry and store it
    * in _min_y */
   double min_y = std::numeric_limits<double>::infinity();

--- a/tests/input_set.py
+++ b/tests/input_set.py
@@ -851,7 +851,7 @@ class AxialExtendedInput(InputSet):
         root_universe = openmoc.Universe()
         root_universe.addCell(root_cell)
 
-        self.geometry=openmoc.Geometry() 
+        self.geometry=openmoc.Geometry()
         self.geometry.setRootUniverse(root_universe)
 
         super(AxialExtendedInput, self).create_geometry()

--- a/tests/test_complex_region_bounds/test_complex_region_bounds.py
+++ b/tests/test_complex_region_bounds/test_complex_region_bounds.py
@@ -18,6 +18,13 @@ class ComplexRegionBoundsTestHarness(TestHarness):
 
     def _run_openmoc(self):
         """Instantiate a complex region Geometry."""
+#                                ----------------
+#                              /                 \
+#             --------------- c2 (p22,p23) - u2 - c2a (p11)
+#           /               /
+#  u_r <- c_r (p1,p2) - u1 - c1 (p11,p12,p13)
+#           \             \
+#            ------------- c3
         root_universe = openmoc.Universe(name='root universe')
         root_cell = openmoc.Cell(name='root cell')
         u1 = openmoc.Universe(name='universe 1')
@@ -102,7 +109,7 @@ class ComplexRegionBoundsTestHarness(TestHarness):
 
     def _generate_tracks(self):
         pass
-        
+
     def _create_solver(self):
         pass
 
@@ -117,7 +124,7 @@ class ComplexRegionBoundsTestHarness(TestHarness):
         # Read the file into a list of strings for each line
         with open(logfilename[0], 'r') as myfile:
             lines = myfile.readlines()
-        
+
         # Concatenate all strings in the file into a single string
         # Exclude the first line which is the time and date
         outstr = ''.join(lines[1:])

--- a/tests/test_forward_3D_lattice_symmetry/results_true.dat
+++ b/tests/test_forward_3D_lattice_symmetry/results_true.dat
@@ -1,0 +1,3 @@
+# Iterations: 44
+keff:  4.03117E-01
+# FSRs: 256

--- a/tests/test_forward_3D_lattice_symmetry/test_forward_3D_lattice_symmetry.py
+++ b/tests/test_forward_3D_lattice_symmetry/test_forward_3D_lattice_symmetry.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+import os
+import sys
+sys.path.insert(0, os.pardir)
+sys.path.insert(0, os.path.join(os.pardir, 'openmoc'))
+import openmoc
+from testing_harness import TestHarness
+from input_set import SimpleLatticeInput
+
+
+class SimpleLatticeTestHarness(TestHarness):
+    """An eigenvalue calculation in a 3D lattice with 7-group C5G7 data."""
+
+    def __init__(self):
+        super(SimpleLatticeTestHarness, self).__init__()
+        self.input_set = SimpleLatticeInput(num_dimensions=3)
+        self.num_polar = 4
+        self.azim_spacing = 0.12
+        self.z_spacing = 0.14
+        self.tolerance = 1E-4
+
+
+    def _create_geometry(self):
+        """Initialize CMFD and add it to the Geometry. Add symmetries"""
+
+        super(SimpleLatticeTestHarness, self)._create_geometry()
+
+        # Declare symmetries to use in computation (domain is not actually
+        # symmetric)
+        self.input_set.geometry.useSymmetry(True, True, True)
+
+        # Initialize CMFD
+        cmfd = openmoc.Cmfd()
+        cmfd.setLatticeStructure(2,2,2)
+        cmfd.setGroupStructure([[1,2,3], [4,5,6,7]])
+        cmfd.setKNearest(3)
+
+        # Add CMFD to the Geometry
+        self.input_set.geometry.setCmfd(cmfd)
+
+
+    def _create_trackgenerator(self):
+        """Instantiate a TrackGenerator."""
+        geometry = self.input_set.geometry
+        geometry.initializeFlatSourceRegions()
+        self.track_generator = \
+            openmoc.TrackGenerator3D(geometry, self.num_azim, self.num_polar,
+                                     self.azim_spacing, self.z_spacing)
+        self.track_generator.setSegmentFormation(openmoc.OTF_STACKS)
+
+
+    def _generate_tracks(self):
+        """Generate Tracks and segments."""
+        # Need to use more than 1 thread, and lose reproducibility of FSR
+        # numbering, in order to have temporary tracks and segments array of
+        # the correct size for the multi-threaded solver.
+        self.track_generator.setNumThreads(self.num_threads)
+        self.track_generator.generateTracks()
+
+
+    def _create_solver(self):
+        """Instantiate a CPULSSolver."""
+        self.solver = openmoc.CPULSSolver(self.track_generator)
+        self.solver.setNumThreads(self.num_threads)
+        self.solver.setConvergenceThreshold(self.tolerance)
+
+
+    def _get_results(self, num_iters=True, keff=True, fluxes=False,
+                     num_fsrs=True, num_tracks=False, num_segments=False,
+                     hash_output=False):
+        """Digest info in the solver"""
+        return super(SimpleLatticeTestHarness, self)._get_results(
+                num_iters=num_iters, keff=keff, fluxes=fluxes,
+                num_fsrs=num_fsrs, num_tracks=num_tracks,
+                num_segments=num_segments, hash_output=hash_output)
+
+if __name__ == '__main__':
+    harness = SimpleLatticeTestHarness()
+    harness.main()


### PR DESCRIPTION
With geometry.useSymmetry(symmetry in X, symmetry in Y, symmetry Z), the user can simulate a half/quarter or an eighth of the system when appropriate levels of symmetry are present. 

One limitation is that geometries have to be defined with a root cell contained inside of a root universe.
That root cell has to contain the boundaries of the problem