### PR TITLE
Improve Python build, fix bugs and edge cases, CMFD performance

### DIFF
--- a/config.py
+++ b/config.py
@@ -59,6 +59,9 @@ class configuration:
     # Default floating point for the main openmoc module is single precision
     fp = 'single'
 
+    # The number of energy groups to compile for is by default not specified
+    num_groups = None
+
     # Compile using ccache (for developers needing fast recompilation)
     with_ccache = False
 
@@ -339,7 +342,6 @@ class configuration:
             macros[compiler][precision].append(('VEC_ALIGNMENT',
                                                 vector_alignment))
 
-
     # set extra flag for determining precision
     for compiler in macros:
         for precision in macros[compiler]:
@@ -367,6 +369,12 @@ class configuration:
         Create list of extensions for Python modules within the openmoc
         Python package based on the user-defined flags defined at compile time.
         """
+
+        # If user wishes to specify number of groups at compile time
+        if self.num_groups:
+            for k in self.compiler_flags:
+                self.compiler_flags[k].append('-DNGROUPS=' +
+                                              str(self.num_groups))
 
         # If the user wishes to compile using debug mode, append the debugging
         # flag to all lists of compiler flags for all distribution types

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ class custom_install(install):
     ('cc=', None, "Compiler (gcc, icpc, bgxlc, mpicc) for main openmoc module"),
     ('fp=', None, "Floating point precision (single or double) for " + \
                   "main openmoc module"),
+    ('ng=', None, "Specify number of groups (optional only for optimization)" + \
+                  " for main openmoc module"),
     ('with-cuda', None, "Build openmoc.cuda module for NVIDIA GPUs"),
     ('debug-mode', None, "Build with debugging symbols"),
     ('sanitizer-mode', None, "Build with address sanitizer"),
@@ -102,7 +104,7 @@ class custom_install(install):
     # Default compiler and precision level for the main openmoc module
     self.cc = 'gcc'
     self.fp = 'single'
-    self.mpi = True
+    self.ng = None
 
     # Set defaults for each of the newly defined compile time options
     self.with_cuda = False
@@ -129,6 +131,7 @@ class custom_install(install):
 
     # Set the configuration options specified to be the default
     # unless the corresponding flag was invoked by the user
+    config.num_groups = self.ng
     config.with_cuda = self.with_cuda
     config.debug_mode = self.debug_mode
     config.sanitizer_mode = self.sanitizer_mode
@@ -379,11 +382,11 @@ class custom_build_ext(build_ext):
 
 # Run the distutils setup method for the complete build
 dist = setup(name = 'openmoc',
-      version = '0.1.4b',
+      version = '0.4.0',
       description = 'An open source method of characteristics code for ' + \
                     'solving the 2D neutron distribution in nuclear reactors',
       url = 'https://github.com/mit-crpg/OpenMOC',
-      download_url = 'https://github.com/mit-crpg/OpenMOC/tarball/v0.1.4b',
+      download_url = 'https://github.com/mit-crpg/OpenMOC/tarball/v0.4.0',
 
       # Set the C/C++/CUDA extension modules built in setup_extension_modules()
       # in config.py based on the user-defined flags at compile time

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -61,7 +61,7 @@ void CPULSSolver::initializeFluxArrays() {
 
   try {
     /* Allocate an array for the FSR scalar flux */
-    long size = _num_FSRs * _num_groups * 3;
+    long size = _num_FSRs * _NUM_GROUPS * 3;
     long max_size = size;
 #ifdef MPIX
     if (_geometry->isDomainDecomposed())
@@ -100,7 +100,7 @@ void CPULSSolver::initializeSourceArrays() {
   if (_reduced_sources_xyz != NULL)
     delete [] _reduced_sources_xyz;
 
-  long size = _num_FSRs * _num_groups * 3;
+  long size = _num_FSRs * _NUM_GROUPS * 3;
 
   /* Allocate memory for all source arrays */
   try {
@@ -158,7 +158,7 @@ void CPULSSolver::initializeFixedSources() {
 
   /* Allocate the fixed sources array if not yet allocated */
   if (_fixed_sources_xyz.empty()) {
-    long size = _num_FSRs * _num_groups;
+    long size = _num_FSRs * _NUM_GROUPS;
     _fixed_sources_xyz.resize(size);
     for (long i=0; i<size; i++)
       _fixed_sources_xyz.at(i).resize(3, 0);
@@ -277,9 +277,9 @@ void CPULSSolver::setFixedSourceMomentByFSR(long fsr_id, int group,
                                             double src_x, double src_y,
                                             double src_z) {
 
-  if (group <= 0 || group > _num_groups)
+  if (group <= 0 || group > _NUM_GROUPS)
     log_printf(ERROR,"Unable to set fixed source for group %d in "
-               "in a %d energy group problem", group, _num_groups);
+               "in a %d energy group problem", group, _NUM_GROUPS);
 
   if (fsr_id < 0 || fsr_id >= _num_FSRs)
     log_printf(ERROR,"Unable to set fixed source for FSR %d with only "
@@ -308,7 +308,7 @@ void CPULSSolver::flattenFSRFluxes(FP_PRECISION value) {
 
 #pragma omp parallel for schedule(static)
   for (long r=0; r < _num_FSRs; r++) {
-    for (int e=0; e < _num_groups; e++) {
+    for (int e=0; e < _NUM_GROUPS; e++) {
       _scalar_flux_xyz(r,e,0) = 0.0;
       _scalar_flux_xyz(r,e,1) = 0.0;
       _scalar_flux_xyz(r,e,2) = 0.0;
@@ -329,7 +329,7 @@ double CPULSSolver::normalizeFluxes() {
 
 #pragma omp parallel for schedule(static)
   for (long r=0; r < _num_FSRs; r++) {
-    for (int e=0; e < _num_groups; e++) {
+    for (int e=0; e < _NUM_GROUPS; e++) {
       _scalar_flux_xyz(r,e,0) *= norm_factor;
       _scalar_flux_xyz(r,e,1) *= norm_factor;
       _scalar_flux_xyz(r,e,2) *= norm_factor;
@@ -367,7 +367,7 @@ void CPULSSolver::computeFSRSources(int iteration) {
       material = _FSR_materials[r];
       sigma_s = material->getSigmaS();
 
-      for (int g=0; g < _num_groups; g++) {
+      for (int g=0; g < _NUM_GROUPS; g++) {
 
         /* Initialize the fission sources to zero */
         double fission_source_x = 0.0;
@@ -377,25 +377,25 @@ void CPULSSolver::computeFSRSources(int iteration) {
         /* Compute fission sources */
         if (material->isFissionable()) {
           FP_PRECISION* fission_sources_x = _groupwise_scratch.at(tid);
-          for (int g_prime=0; g_prime < _num_groups; g_prime++)
+          for (int g_prime=0; g_prime < _NUM_GROUPS; g_prime++)
             fission_sources_x[g_prime] = material->getFissionMatrixByGroup(
                  g_prime+1,g+1) * _scalar_flux_xyz(r,g_prime,0);
           fission_source_x =
-              pairwise_sum<FP_PRECISION>(fission_sources_x, _num_groups);
+              pairwise_sum<FP_PRECISION>(fission_sources_x, _NUM_GROUPS);
 
           FP_PRECISION* fission_sources_y = _groupwise_scratch.at(tid);
-          for (int g_prime=0; g_prime < _num_groups; g_prime++)
+          for (int g_prime=0; g_prime < _NUM_GROUPS; g_prime++)
             fission_sources_y[g_prime] = material->getFissionMatrixByGroup(
                  g_prime+1,g+1) * _scalar_flux_xyz(r,g_prime,1);
           fission_source_y =
-              pairwise_sum<FP_PRECISION>(fission_sources_y, _num_groups);
+              pairwise_sum<FP_PRECISION>(fission_sources_y, _NUM_GROUPS);
 
           FP_PRECISION* fission_sources_z = _groupwise_scratch.at(tid);
-          for (int g_prime=0; g_prime < _num_groups; g_prime++)
+          for (int g_prime=0; g_prime < _NUM_GROUPS; g_prime++)
             fission_sources_z[g_prime] = material->getFissionMatrixByGroup(
                  g_prime+1,g+1) * _scalar_flux_xyz(r,g_prime,2);
           fission_source_z =
-              pairwise_sum<FP_PRECISION>(fission_sources_z, _num_groups);
+              pairwise_sum<FP_PRECISION>(fission_sources_z, _NUM_GROUPS);
 
           fission_source_x /= _k_eff;
           fission_source_y /= _k_eff;
@@ -403,35 +403,35 @@ void CPULSSolver::computeFSRSources(int iteration) {
         }
 
         /* Compute scatter + fission source for group g */
-        int first_scattering_index = g * _num_groups;
+        int first_scattering_index = g * _NUM_GROUPS;
 
         /* Compute scatter sources */
         FP_PRECISION* scatter_sources_x = _groupwise_scratch.at(tid);
-        for (int g_prime=0; g_prime < _num_groups; g_prime++) {
+        for (int g_prime=0; g_prime < _NUM_GROUPS; g_prime++) {
           int idx = first_scattering_index + g_prime;
           scatter_sources_x[g_prime] = sigma_s[idx] *
                _scalar_flux_xyz(r,g_prime,0);
         }
         double scatter_source_x =
-            pairwise_sum<FP_PRECISION>(scatter_sources_x, _num_groups);
+            pairwise_sum<FP_PRECISION>(scatter_sources_x, _NUM_GROUPS);
 
         FP_PRECISION* scatter_sources_y = _groupwise_scratch.at(tid);
-        for (int g_prime=0; g_prime < _num_groups; g_prime++) {
+        for (int g_prime=0; g_prime < _NUM_GROUPS; g_prime++) {
           int idx = first_scattering_index + g_prime;
           scatter_sources_y[g_prime] = sigma_s[idx] *
                _scalar_flux_xyz(r,g_prime,1);
         }
         double scatter_source_y =
-            pairwise_sum<FP_PRECISION>(scatter_sources_y, _num_groups);
+            pairwise_sum<FP_PRECISION>(scatter_sources_y, _NUM_GROUPS);
 
         FP_PRECISION* scatter_sources_z = _groupwise_scratch.at(tid);
-        for (int g_prime=0; g_prime < _num_groups; g_prime++) {
+        for (int g_prime=0; g_prime < _NUM_GROUPS; g_prime++) {
           int idx = first_scattering_index + g_prime;
           scatter_sources_z[g_prime] = sigma_s[idx] *
                _scalar_flux_xyz(r,g_prime,2);
         }
         double scatter_source_z =
-            pairwise_sum<FP_PRECISION>(scatter_sources_z, _num_groups);
+            pairwise_sum<FP_PRECISION>(scatter_sources_z, _NUM_GROUPS);
 
         /* Compute total (scatter + fission) source */
         src_x = scatter_source_x + fission_source_x;
@@ -524,13 +524,13 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
       center_x2[i] = 2 * position[i] + length * direction[i];
 
     // Compute the sources
-    FP_PRECISION src_flat[_num_groups]
+    FP_PRECISION src_flat[_NUM_GROUPS]
                  __attribute__ ((aligned(VEC_ALIGNMENT)));
-    FP_PRECISION src_linear[_num_groups]
+    FP_PRECISION src_linear[_NUM_GROUPS]
                  __attribute__ ((aligned(VEC_ALIGNMENT)));
 
 #pragma omp simd aligned(src_flat, src_linear)
-    for (int e=0; e < _num_groups; e++) {
+    for (int e=0; e < _NUM_GROUPS; e++) {
       src_flat[e] = _reduced_sources(fsr_id, e);
       for (int i=0; i<3; i++)
         src_flat[e] += _reduced_sources_xyz(fsr_id, e, i) * center_x2[i];
@@ -540,19 +540,19 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
     }
 
     // Compute the exponential term G, intermediate step to F1, F2, H
-    FP_PRECISION exp_G[_num_groups] __attribute__ ((aligned(VEC_ALIGNMENT)));
-    FP_PRECISION tau[_num_groups] __attribute__ ((aligned(VEC_ALIGNMENT)));
+    FP_PRECISION exp_G[_NUM_GROUPS] __attribute__ ((aligned(VEC_ALIGNMENT)));
+    FP_PRECISION tau[_NUM_GROUPS] __attribute__ ((aligned(VEC_ALIGNMENT)));
 
 #pragma omp simd aligned(sigma_t, tau, exp_G)
-    for (int e=0; e < _num_groups; e++) {
+    for (int e=0; e < _NUM_GROUPS; e++) {
       /* Bound tau by 1e-8 to limit error on the F2 term */
       tau[e] = std::max(FP_PRECISION(1e-8), length * sigma_t[e]);
       expG_fractional(tau[e], &exp_G[e]);
     }
 
     // Determine number of SIMD vector groups
-    const int num_vector_groups = _num_groups / VEC_LENGTH;
-    const int remainder = _num_groups - num_vector_groups * VEC_LENGTH;
+    const int num_vector_groups = _NUM_GROUPS / VEC_LENGTH;
+    const int remainder = _NUM_GROUPS - num_vector_groups * VEC_LENGTH;
 
     for (int v=0; v < num_vector_groups; v++) {
       int start_vector = v * VEC_LENGTH;
@@ -583,7 +583,7 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
     // Handle remainder of energy groups
 #pragma omp simd aligned(tau, src_flat, src_linear, fsr_flux, exp_G, fsr_flux_x\
      , fsr_flux_y, fsr_flux_z)
-    for (int e=num_vector_groups * VEC_LENGTH; e < _num_groups; e++) {
+    for (int e=num_vector_groups * VEC_LENGTH; e < _NUM_GROUPS; e++) {
 
       /* Compute exponential F1, F2 and H from G */
       FP_PRECISION exp_F1 = 1.f - tau[e]*exp_G[e];
@@ -614,65 +614,65 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
       center[i] = 2 * position[i] + length * direction[i];
 
     /* Compute tau in advance to simplify attenation loop */
-    FP_PRECISION tau[_num_groups * num_polar_2]
+    FP_PRECISION tau[_NUM_GROUPS * num_polar_2]
                  __attribute__ ((aligned(VEC_ALIGNMENT)));
 
 #pragma omp simd aligned(tau)
-    for (int pe=0; pe < num_polar_2 * _num_groups; pe++)
-      tau[pe] = sigma_t[pe % _num_groups] * length;
+    for (int pe=0; pe < num_polar_2 * _NUM_GROUPS; pe++)
+      tau[pe] = sigma_t[pe % _NUM_GROUPS] * length;
 
     /* Compute exponentials */
-    FP_PRECISION exp_F1[num_polar_2*_num_groups]
+    FP_PRECISION exp_F1[num_polar_2*_NUM_GROUPS]
                  __attribute__ ((aligned(VEC_ALIGNMENT)));
-    FP_PRECISION exp_F2[num_polar_2*_num_groups]
+    FP_PRECISION exp_F2[num_polar_2*_NUM_GROUPS]
                  __attribute__ ((aligned(VEC_ALIGNMENT)));
-    FP_PRECISION exp_H[num_polar_2*_num_groups]
+    FP_PRECISION exp_H[num_polar_2*_NUM_GROUPS]
                  __attribute__ ((aligned(VEC_ALIGNMENT)));
 
 #pragma omp simd aligned(tau, exp_F1, exp_F2, exp_H)
-    for (int pe=0; pe < num_polar_2 * _num_groups; pe++)
-      exp_evaluator->retrieveExponentialComponents(tau[pe], int(pe/_num_groups),
+    for (int pe=0; pe < num_polar_2 * _NUM_GROUPS; pe++)
+      exp_evaluator->retrieveExponentialComponents(tau[pe], int(pe/_NUM_GROUPS),
                                                    &exp_F1[pe], &exp_F2[pe],
                                                    &exp_H[pe]);
 
     /* Compute flat part of the source */
-    FP_PRECISION src_flat[_num_groups]
+    FP_PRECISION src_flat[_NUM_GROUPS]
                  __attribute__ ((aligned(VEC_ALIGNMENT)));
 
 #pragma omp simd aligned(src_flat)
-    for (int e=0; e < _num_groups; e++) {
+    for (int e=0; e < _NUM_GROUPS; e++) {
       src_flat[e] = _reduced_sources(fsr_id, e);
       for (int i=0; i<2; i++)
         src_flat[e] += _reduced_sources_xyz(fsr_id, e, i) * center[i];
     }
 
     /* Compute linear part of the source */
-    FP_PRECISION src_linear[num_polar_2 * _num_groups]
+    FP_PRECISION src_linear[num_polar_2 * _NUM_GROUPS]
                  __attribute__ ((aligned(VEC_ALIGNMENT)));
 
 #pragma omp simd aligned(src_linear)
-    for (int pe=0; pe < num_polar_2 * _num_groups; pe++) {
+    for (int pe=0; pe < num_polar_2 * _NUM_GROUPS; pe++) {
       FP_PRECISION sin_the = _quad->getSinThetaInline(azim_index,
-                                                      int(pe/_num_groups));
+                                                      int(pe/_NUM_GROUPS));
       src_linear[pe] = direction[0] * sin_the *
-            _reduced_sources_xyz(fsr_id, pe % _num_groups, 0);
+            _reduced_sources_xyz(fsr_id, pe % _NUM_GROUPS, 0);
       src_linear[pe] += direction[1] * sin_the *
-            _reduced_sources_xyz(fsr_id, pe % _num_groups, 1);
+            _reduced_sources_xyz(fsr_id, pe % _NUM_GROUPS, 1);
     }
 
     /* Compute attenuation of track angular flux */
-    FP_PRECISION delta_psi[_num_groups * num_polar_2]
+    FP_PRECISION delta_psi[_NUM_GROUPS * num_polar_2]
                  __attribute__ ((aligned(VEC_ALIGNMENT)));
 
 #pragma omp simd aligned(tau, src_flat, src_linear, delta_psi, exp_F1, exp_F2, exp_H)
-    for (int pe=0; pe < num_polar_2 * _num_groups; pe++) {
+    for (int pe=0; pe < num_polar_2 * _NUM_GROUPS; pe++) {
 
-      FP_PRECISION wgt = _quad->getWeightInline(azim_index, int(pe/_num_groups));
+      FP_PRECISION wgt = _quad->getWeightInline(azim_index, int(pe/_NUM_GROUPS));
       exp_H[pe] *=  wgt * tau[pe] * length * track_flux[pe];
 
       // Compute the change in flux across the segment
       delta_psi[pe] = (tau[pe] * track_flux[pe] - length
-            * src_flat[pe % _num_groups]) * exp_F1[pe] - length * length
+            * src_flat[pe % _NUM_GROUPS]) * exp_F1[pe] - length * length
             * src_linear[pe] * exp_F2[pe];
       track_flux[pe] -= delta_psi[pe];
       delta_psi[pe] *= wgt;
@@ -683,13 +683,13 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
     for (int p=0; p < num_polar_2; p++) {
 
 #pragma omp simd aligned(fsr_flux, fsr_flux_x, fsr_flux_y)
-      for (int e=0; e < _num_groups; e++) {
+      for (int e=0; e < _NUM_GROUPS; e++) {
 
-        fsr_flux[e] += delta_psi[p*_num_groups + e];
-        fsr_flux_x[e] += exp_H[p*_num_groups + e] * direction[0] +
-                                    delta_psi[p*_num_groups + e] * position[0];
-        fsr_flux_y[e] += exp_H[p*_num_groups + e] * direction[1] +
-                                    delta_psi[p*_num_groups + e] * position[1];
+        fsr_flux[e] += delta_psi[p*_NUM_GROUPS + e];
+        fsr_flux_x[e] += exp_H[p*_NUM_GROUPS + e] * direction[0] +
+                                    delta_psi[p*_NUM_GROUPS + e] * position[0];
+        fsr_flux_y[e] += exp_H[p*_NUM_GROUPS + e] * direction[1] +
+                                    delta_psi[p*_NUM_GROUPS + e] * position[1];
       }
     }
   }
@@ -712,7 +712,7 @@ void CPULSSolver::accumulateLinearFluxContribution(long fsr_id,
                                                    FP_PRECISION* __restrict__
                                                    fsr_flux) {
 
-  int num_groups_aligned = (_num_groups / VEC_ALIGNMENT + 1) * VEC_ALIGNMENT;
+  int num_groups_aligned = (_NUM_GROUPS / VEC_ALIGNMENT + 1) * VEC_ALIGNMENT;
   FP_PRECISION* fsr_flux_x = &fsr_flux[num_groups_aligned];
   FP_PRECISION* fsr_flux_y = &fsr_flux[2*num_groups_aligned];
   FP_PRECISION* fsr_flux_z = &fsr_flux[3*num_groups_aligned];
@@ -721,7 +721,7 @@ void CPULSSolver::accumulateLinearFluxContribution(long fsr_id,
   omp_set_lock(&_FSR_locks[fsr_id]);
 
 #pragma omp simd aligned(fsr_flux, fsr_flux_x, fsr_flux_y, fsr_flux_z)
-  for (int e=0; e < _num_groups; e++) {
+  for (int e=0; e < _NUM_GROUPS; e++) {
 
     // Add to global scalar flux vector
     _scalar_flux(fsr_id, e) += weight * fsr_flux[e];
@@ -763,7 +763,7 @@ void CPULSSolver::addSourceToScalarFlux() {
         volume = 1e30;
       sigma_t = _FSR_materials[r]->getSigmaT();
 
-      for (int e=0; e < _num_groups; e++) {
+      for (int e=0; e < _NUM_GROUPS; e++) {
 
         flux_const = FOUR_PI * 2;
 
@@ -773,29 +773,29 @@ void CPULSSolver::addSourceToScalarFlux() {
 
         _scalar_flux_xyz(r,e,0) /= volume;
         _scalar_flux_xyz(r,e,0) += flux_const * _reduced_sources_xyz(r,e,0)
-            * _FSR_source_constants[r*_num_groups*nc + e];
+            * _FSR_source_constants[r*_NUM_GROUPS*nc + e];
         _scalar_flux_xyz(r,e,0) += flux_const * _reduced_sources_xyz(r,e,1)
-            * _FSR_source_constants[r*_num_groups*nc + 2*_num_groups + e];
+            * _FSR_source_constants[r*_NUM_GROUPS*nc + 2*_NUM_GROUPS + e];
 
         _scalar_flux_xyz(r,e,1) /= volume;
         _scalar_flux_xyz(r,e,1) += flux_const * _reduced_sources_xyz(r,e,0)
-            * _FSR_source_constants[r*_num_groups*nc + 2*_num_groups + e];
+            * _FSR_source_constants[r*_NUM_GROUPS*nc + 2*_NUM_GROUPS + e];
         _scalar_flux_xyz(r,e,1) += flux_const * _reduced_sources_xyz(r,e,1)
-            * _FSR_source_constants[r*_num_groups*nc + _num_groups + e];
+            * _FSR_source_constants[r*_NUM_GROUPS*nc + _NUM_GROUPS + e];
 
         if (_SOLVE_3D) {
           _scalar_flux_xyz(r,e,0) += flux_const * _reduced_sources_xyz(r,e,2)
-              * _FSR_source_constants[r*_num_groups*nc + 3*_num_groups + e];
+              * _FSR_source_constants[r*_NUM_GROUPS*nc + 3*_NUM_GROUPS + e];
           _scalar_flux_xyz(r,e,1) += flux_const * _reduced_sources_xyz(r,e,2)
-              * _FSR_source_constants[r*_num_groups*nc + 4*_num_groups + e];
+              * _FSR_source_constants[r*_NUM_GROUPS*nc + 4*_NUM_GROUPS + e];
 
           _scalar_flux_xyz(r,e,2) /= volume;
           _scalar_flux_xyz(r,e,2) += flux_const * _reduced_sources_xyz(r,e,0)
-              * _FSR_source_constants[r*_num_groups*nc + 3*_num_groups + e];
+              * _FSR_source_constants[r*_NUM_GROUPS*nc + 3*_NUM_GROUPS + e];
           _scalar_flux_xyz(r,e,2) += flux_const * _reduced_sources_xyz(r,e,1)
-              * _FSR_source_constants[r*_num_groups*nc + 4*_num_groups + e];
+              * _FSR_source_constants[r*_NUM_GROUPS*nc + 4*_NUM_GROUPS + e];
           _scalar_flux_xyz(r,e,2) += flux_const * _reduced_sources_xyz(r,e,2)
-              * _FSR_source_constants[r*_num_groups*nc + 5*_num_groups + e];
+              * _FSR_source_constants[r*_NUM_GROUPS*nc + 5*_NUM_GROUPS + e];
         }
 
         _scalar_flux_xyz(r,e,0) /= sigma_t[e];
@@ -858,10 +858,10 @@ void CPULSSolver::computeStabilizingFlux() {
       /* Extract total cross-sections */
       FP_PRECISION* sigma_t = _FSR_materials[r]->getSigmaT();
 
-      for (int e=0; e < _num_groups; e++) {
+      for (int e=0; e < _NUM_GROUPS; e++) {
 
         /* Extract the in-scattering (diagonal) element */
-        FP_PRECISION sigma_s = scattering_matrix[e*_num_groups+e];
+        FP_PRECISION sigma_s = scattering_matrix[e*_NUM_GROUPS+e];
 
         /* For negative cross-sections, add the absolute value of the
            in-scattering rate to the stabilizing flux */
@@ -878,7 +878,7 @@ void CPULSSolver::computeStabilizingFlux() {
 
     /* Treat each group */
 #pragma omp parallel for
-    for (int e=0; e < _num_groups; e++) {
+    for (int e=0; e < _NUM_GROUPS; e++) {
 
       /* Look for largest absolute scattering ratio */
       FP_PRECISION max_ratio = 0.0;
@@ -911,7 +911,7 @@ void CPULSSolver::computeStabilizingFlux() {
     /* Apply the global multiplicative factor */
 #pragma omp parallel for
     for (long r=0; r < _num_FSRs; r++)
-      for (int e=0; e < _num_groups; e++)
+      for (int e=0; e < _NUM_GROUPS; e++)
         for (int i=0; i <3; i++)
           _stabilizing_flux_xyz(r, e, i) = _scalar_flux_xyz(r, e, i)
              * mult_factor;
@@ -942,10 +942,10 @@ void CPULSSolver::stabilizeFlux() {
       /* Extract total cross-sections */
       FP_PRECISION* sigma_t = _FSR_materials[r]->getSigmaT();
 
-      for (int e=0; e < _num_groups; e++) {
+      for (int e=0; e < _NUM_GROUPS; e++) {
 
         /* Extract the in-scattering (diagonal) element */
-        FP_PRECISION sigma_s = scattering_matrix[e*_num_groups+e];
+        FP_PRECISION sigma_s = scattering_matrix[e*_NUM_GROUPS+e];
 
         /* For negative cross-sections, add the stabilizing flux
            and divide by the diagonal matrix element used to form it so that
@@ -964,7 +964,7 @@ void CPULSSolver::stabilizeFlux() {
 
     /* Treat each group */
 #pragma omp parallel for
-    for (int e=0; e < _num_groups; e++) {
+    for (int e=0; e < _NUM_GROUPS; e++) {
 
       /* Look for largest absolute scattering ratio */
       FP_PRECISION max_ratio = 0.0;
@@ -995,7 +995,7 @@ void CPULSSolver::stabilizeFlux() {
     /* Apply the damping factor */
 #pragma omp parallel for
     for (long r=0; r < _num_FSRs; r++) {
-      for (int e=0; e < _num_groups; e++) {
+      for (int e=0; e < _NUM_GROUPS; e++) {
         for (int i=0; i <3; i++) {
           _scalar_flux_xyz(r, e, i) += _stabilizing_flux_xyz(r, e, i);
           _scalar_flux_xyz(r, e, i) *= _stabilization_factor;

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -552,7 +552,6 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
 
     // Determine number of SIMD vector groups
     const int num_vector_groups = _NUM_GROUPS / VEC_LENGTH;
-    const int remainder = _NUM_GROUPS - num_vector_groups * VEC_LENGTH;
 
     for (int v=0; v < num_vector_groups; v++) {
       int start_vector = v * VEC_LENGTH;

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -546,8 +546,8 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
 #pragma omp simd aligned(sigma_t, tau, exp_G)
     for (int e=0; e < _NUM_GROUPS; e++) {
       /* Bound tau by 1e-8 to limit error on the F2 term */
-      tau[e] = std::max(FP_PRECISION(1e-8), length * sigma_t[e]);
-      expG_fractional(tau[e], &exp_G[e]);
+      tau[e] = length * sigma_t[e];
+      expG_fractional(std::max(FP_PRECISION(1e-8), tau[e]), &exp_G[e]);
     }
 
     // Determine number of SIMD vector groups

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -2242,7 +2242,6 @@ void CPUSolver::tallyScalarFlux(segment* curr_segment,
     // vectorization of the loop by the compiler
     // Determine number of SIMD vector groups
     const int num_vector_groups = _NUM_GROUPS / VEC_LENGTH;
-    const int remainder = _NUM_GROUPS - num_vector_groups * VEC_LENGTH;
 
     for (int v=0; v < num_vector_groups; v++) {
       int start_vector = v * VEC_LENGTH;

--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -22,7 +22,9 @@
 #undef track_flux
 /** Optimization macro to facilitate SIMD vectorization */
 #ifdef NGROUPS
-#define _num_groups (NGROUPS)
+#define _NUM_GROUPS (NGROUPS)
+#else
+#define _NUM_GROUPS (_num_groups)
 #endif
 
 /** Indexing macro for the angular fluxes for each polar angle and energy

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -83,11 +83,11 @@ Cell::Cell(int id, const char* name) {
   _num_instances = 0;
 
   _rotated = false;
-  memset(&_rotation, 0., 3*sizeof(double));
-  memset(&_rotation_matrix, 0., 9*sizeof(double));
+  memset(&_rotation, 0, 3*sizeof(double));
+  memset(&_rotation_matrix, 0, 9*sizeof(double));
 
   _translated = false;
-  memset(&_translation, 0., 3*sizeof(double));
+  memset(&_translation, 0, 3*sizeof(double));
 
   _num_rings = 0;
   _num_sectors = 0;

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -1001,8 +1001,9 @@ void Cell::setTranslation(double* translation, int num_axes) {
 /**
  * @brief Set the Cell's number of rings.
  * @param num_rings the number of rings in this Cell
+ * @param inner_radius add (0,0,r) ZCylinder to ringify around (default none)
  */
-void Cell::setNumRings(int num_rings) {
+void Cell::setNumRings(int num_rings, double inner_radius) {
   if (num_rings < 0)
     log_printf(ERROR, "Unable to give %d rings to Cell %d since this is "
                "a negative number", num_rings, _id);
@@ -1011,6 +1012,15 @@ void Cell::setNumRings(int num_rings) {
     _num_rings = 0;
   else
     _num_rings = num_rings;
+
+  if (inner_radius >= 0) {
+    // Create an inner Z cylinder at coordinate (0, 0)
+    ZCylinder* zcylinder = new ZCylinder(0, 0, inner_radius);
+    zcylinder->setName("innermost ring cylinder");
+
+    // The cell is defined as being outside this cylinder
+    addSurface(+1, zcylinder);
+  }
 }
 
 

--- a/src/Cell.h
+++ b/src/Cell.h
@@ -175,7 +175,7 @@ public:
   void incrementNumInstances();
   void setRotation(double* rotation, int num_axes, std::string units="degrees");
   void setTranslation(double* translation, int num_axes);
-  void setNumRings(int num_rings);
+  void setNumRings(int num_rings, double inner_radius=-1);
   void setNumSectors(int num_sectors);
   void setParent(Cell* parent);
   void addSurface(int halfspace, Surface* surface);

--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -5362,7 +5362,7 @@ void Cmfd::tallyStartingCurrent(Point* point, double delta_x, double delta_y,
 
   CMFD_PRECISION currents[_num_cmfd_groups]
        __attribute__ ((aligned(VEC_ALIGNMENT)));
-  memset(&currents[0], 0, _num_cmfd_groups * sizeof(CMFD_PRECISION));
+  memset(currents, 0, _num_cmfd_groups * sizeof(CMFD_PRECISION));
 
   /* Tally currents to each CMFD group locally */
   for (int e=0; e < _num_moc_groups; e++) {

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -121,6 +121,9 @@ private:
   /** Number of cells in z direction */
   int _num_z;
 
+  /** Sweep number on MOC side */
+  int _moc_iteration;
+
   /** Number of energy groups */
   int _num_moc_groups;
 
@@ -345,7 +348,7 @@ private:
   /* Private worker functions */
   CMFD_PRECISION computeLarsensEDCFactor(CMFD_PRECISION dif_coef,
                                          CMFD_PRECISION delta);
-  void constructMatrices(int moc_iteration);
+  void constructMatrices();
   void collapseXS();
   void updateMOCFlux();
   void rescaleFlux();
@@ -370,8 +373,7 @@ private:
   double getDistanceToCentroid(Point* centroid, int cell_id, int local_cell_id,
                                int stencil_index);
   void getSurfaceDiffusionCoefficient(int cmfd_cell, int surface,
-        int group, int moc_iteration, CMFD_PRECISION& dif_surf,
-        CMFD_PRECISION& dif_surf_corr);
+        int group, CMFD_PRECISION& dif_surf, CMFD_PRECISION& dif_surf_corr);
   CMFD_PRECISION getDiffusionCoefficient(int cmfd_cell, int group);
   CMFD_PRECISION getSurfaceWidth(int surface, int global_ind);
   CMFD_PRECISION getPerpendicularSurfaceWidth(int surface, int global_ind);

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -389,7 +389,7 @@ private:
   void unpackSplitCurrents(bool faces);
   void copyFullSurfaceCurrents();
   void checkNeutronBalance(bool pre_split=true, bool old_source=false);
-  void printProlongationFactors(int iteration);
+  void printProlongationFactors();
 
 public:
 

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -579,7 +579,7 @@ inline void Cmfd::tallyCurrent(segment* curr_segment, float* track_flux,
 
     CMFD_PRECISION currents[_num_cmfd_groups]
          __attribute__ ((aligned(VEC_ALIGNMENT)));
-    memset(&currents[0], 0, _num_cmfd_groups * sizeof(CMFD_PRECISION));
+    memset(currents, 0, _num_cmfd_groups * sizeof(CMFD_PRECISION));
     int local_cell_id = getLocalCMFDCell(cell_id);
 
     if (_SOLVE_3D) {

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -4235,11 +4235,13 @@ void Geometry::loadFromFile(std::string filename, bool twiddle) {
         i_subnodes.push_back(num_subnodes+1);
 
       /* Remove zero values from subnode vector, and go up in region tree */
-      for (iter=i_subnodes.begin(); iter<i_subnodes.end(); iter++) {
+      for (iter=i_subnodes.begin(); iter<i_subnodes.end(); ) {
         if ((*iter) == 0) {
           i_subnodes.erase(iter);
           all_cells[key]->goUpOneRegionLogical();
         }
+        else
+          iter++;
       }
 
       /* Add surface */

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -3221,8 +3221,8 @@ void Geometry::initializeSpectrumCalculator(Cmfd* spectrum_calculator) {
   offset.setY(min_y + (max_y - min_y)/2.0);
   offset.setZ(min_z + (max_z - min_z)/2.0);
 
-  spectrum_calculator->initializeLattice(&offset);
   spectrum_calculator->setGeometry(this);
+  spectrum_calculator->initializeLattice(&offset);
 
 #ifdef MPIx
   if (_domain_decomposed) {

--- a/src/MOCKernel.cpp
+++ b/src/MOCKernel.cpp
@@ -382,7 +382,7 @@ void TransportKernel::execute(FP_PRECISION length, Material* mat, long fsr_id,
 
   /* Allocate a buffer to store flux contribution of all cuts in this fsr */
   FP_PRECISION fsr_flux[_num_groups] __attribute__ ((aligned (VEC_ALIGNMENT)));
-  memset(&fsr_flux[0], 0, _num_groups * sizeof(FP_PRECISION));
+  memset(fsr_flux, 0, _num_groups * sizeof(FP_PRECISION));
 
   /* Apply MOC equations to segments */
   for (int i=0; i < num_cuts; i++) {

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -145,6 +145,11 @@ std::vector<FP_PRECISION> Mesh::getReactionRates(RxType rx,
         for (int g=0; g < num_groups; g++)
           xs_array[g] = 1.0;
         break;
+      case VOLUME:
+        xs_array = temp_array;
+        for (int g=0; g < num_groups; g++)
+          xs_array[g] = 1.0 / fluxes[r*num_groups + g] / num_groups;
+        break;
       default:
         log_printf(ERROR, "Unrecognized reaction type in Mesh object");
     }
@@ -167,6 +172,8 @@ std::vector<FP_PRECISION> Mesh::getReactionRates(RxType rx,
     for (int i=0; i<rx_rates.size(); i++)
       if (volumes_lattice.at(i) > FLT_EPSILON)
         rx_rates.at(i) /= volumes_lattice.at(i);
+      else if (std::abs(rx_rates.at(i)) > 0)
+        log_printf(WARNING, "Zero volume lattice cell %d in mesh tally", i);
 
   /* If domain decomposed, do a reduction */
 #ifdef MPIx

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -30,7 +30,9 @@ enum RxType {
 
   ABSORPTION_RX,
 
-  FLUX_RX
+  FLUX_RX,
+
+  VOLUME
 };
 
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1213,6 +1213,12 @@ void Solver::calculateInitialSpectrum(double threshold) {
   spectrum_calculator.setAzimSpacings(_quad->getAzimSpacings(), _num_azim);
   spectrum_calculator.initialize();
 
+  TrackGenerator3D* track_generator_3D =
+    dynamic_cast<TrackGenerator3D*>(_track_generator);
+  if (track_generator_3D != NULL)
+    spectrum_calculator.setPolarSpacings(_quad->getPolarSpacings(), _num_azim,
+         _num_polar);
+
   /* Solve the system */
   log_printf(NORMAL, "Computing K-eff");
   _k_eff = spectrum_calculator.computeKeff(0);

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1683,7 +1683,7 @@ void Solver::computeEigenvalue(int max_iters, residualType res_type) {
       int linear_iters_1 = convergence_data->linear_iters_1;
       int linear_iters_end = convergence_data->linear_iters_end;
       log_printf(NORMAL, "%3d  %1.6f  %5d  %1.6f  %1.3f  %1.6f  %1.6f"
-                 "  %3d  %1.6f  %1.6f  %3d  %3d    %1.6f", i, _k_eff,
+                 "  %3d  %1.6f  %1.6f  %3d  %3d    %.4e", i, _k_eff,
                  dk, residual, dr, cmfd_res_1, cmfd_res_end,
                  cmfd_iters, linear_res_1, linear_res_end,
                  linear_iters_1, linear_iters_end, pf);

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -542,6 +542,14 @@ public:
     _OTF_transport = true;
     log_printf(NORMAL, "Using On-The-Fly transport");
   }
+
+  /**
+   * @brief Return the number of energy groups
+   * @return the number of energy groups
+   */
+  inline int getNumEnergyGroups() {
+    return _num_groups;
+  }
 };
 
 

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1666,11 +1666,17 @@ void TrackGenerator::generateFSRCentroids(FP_PRECISION* FSR_volumes) {
   /* Print FSR volumes, centroids and volume moments for debugging purposes */
   double total_volume[4];
   memset(total_volume, 0, 4 * sizeof(double));
+  FP_PRECISION min_volume = 1e10;
+  FP_PRECISION max_volume = 0.;
+
   for (long r=0; r < num_FSRs; r++) {
     total_volume[0] += _FSR_volumes[r];
     total_volume[1] += _FSR_volumes[r] * centroids[r]->getX();
     total_volume[2] += _FSR_volumes[r] * centroids[r]->getY();
     total_volume[3] += _FSR_volumes[r] * centroids[r]->getZ();
+
+    min_volume = std::min(_FSR_volumes[r], min_volume);
+    max_volume = std::max(_FSR_volumes[r], max_volume);
 
     log_printf(DEBUG, "FSR ID = %d has volume = %.6f, centroid"
                " (%.3f %.3f %.3f)", r, _FSR_volumes[r], centroids[r]->getX(),
@@ -1680,6 +1686,8 @@ void TrackGenerator::generateFSRCentroids(FP_PRECISION* FSR_volumes) {
   log_printf(DEBUG, "Total volume %.6f cm3, moments of volume "
              "(%.4e %.4e %.4e).", total_volume[0], total_volume[1],
              total_volume[2], total_volume[3]);
+  log_printf(DEBUG, "Average / min / max volumes of FSRs : %.2e / %.2e / %.2e",
+             total_volume[0] / num_FSRs, min_volume, max_volume);
   delete [] centroids;
 }
 

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1665,7 +1665,7 @@ void TrackGenerator::generateFSRCentroids(FP_PRECISION* FSR_volumes) {
 
   /* Print FSR volumes, centroids and volume moments for debugging purposes */
   double total_volume[4];
-  memset(&total_volume[0], 0, 4 * sizeof(double));
+  memset(total_volume, 0, 4 * sizeof(double));
   for (long r=0; r < num_FSRs; r++) {
     total_volume[0] += _FSR_volumes[r];
     total_volume[1] += _FSR_volumes[r] * centroids[r]->getX();

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -820,7 +820,8 @@ void TrackGenerator::generateTracks() {
     initializeTracks();
 
     /* Initialize the track file directory and read in tracks if they exist */
-    initializeTrackFileDirectory();
+    //NOTE Useful for 2D simulations, currently broken
+    //initializeTrackFileDirectory();
 
     /* If track file not present, generate segments */
     if (_use_input_file == false) {

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -10,6 +10,7 @@
  */
 MaxOpticalLength::MaxOpticalLength(TrackGenerator* track_generator)
                                  : TraverseSegments(track_generator) {
+  _min_tau = 1e6;
   _max_tau = 0;
 }
 
@@ -39,6 +40,8 @@ void MaxOpticalLength::execute() {
       loopOverTracks(NULL);
   }
   _track_generator->setMaxOpticalLength(_max_tau);
+  log_printf(INFO, "Min/max optical lengths in geometry %.2e / %.2e", _min_tau,
+             _max_tau);
 }
 
 
@@ -65,6 +68,10 @@ void MaxOpticalLength::onTrack(Track* track, segment* segments) {
     if (tau > _max_tau) {
 #pragma omp critical
       _max_tau = std::max(_max_tau, tau);
+    }
+    if (tau < _min_tau) {
+#pragma omp critical
+      _min_tau = std::min(_min_tau, tau);
     }
   }
 }

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -543,8 +543,7 @@ void LinearExpansionGenerator::execute() {
       double volume = _FSR_volumes[r];
       if (std::abs(det) < MIN_DET || volume < 1e-6) {
         log_printf(INFO, "Unable to form linear source components in "
-                   "source region %d. Switching to flat source in that "
-                   "source region.", r);
+                   "source region %d.", r);
 #pragma omp atomic update
         _num_flat++;
         ilem[r*nc + 0] = 0.0;
@@ -596,8 +595,7 @@ void LinearExpansionGenerator::execute() {
         ilem[r*nc + 1] = 0.0;
         ilem[r*nc + 2] = 0.0;
         log_printf(INFO, "Unable to form linear source components in "
-                   "source region %d. Switching to flat source in that "
-                   "source region.", r);
+                   "source region %d.", r);
 #pragma omp atomic update
         _num_flat++;
       }
@@ -664,7 +662,7 @@ void LinearExpansionGenerator::onTrack(Track* track, segment* segments) {
     double theta = track_3D->getTheta();
     sin_theta = sin(theta);
     cos_theta = cos(theta);
-    int polar_index = track_3D->getPolarIndex();
+    polar_index = track_3D->getPolarIndex();
     wgt *= _quadrature->getPolarSpacing(azim_index, polar_index)
         *_quadrature->getPolarWeight(azim_index, polar_index);
   }

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -474,7 +474,7 @@ LinearExpansionGenerator::LinearExpansionGenerator(CPULSSolver* solver)
   _FSR_locks = track_generator->getFSRLocks();
   _quadrature = track_generator->getQuadrature();
 #ifndef NGROUPS
-  _NUM_GROUPS = track_generator->getGeometry()->getNumEnergyGroups();
+  _NUM_GROUPS = solver->getNumEnergyGroups();
 #endif
 
   /* Determine the number of linear coefficients */
@@ -929,7 +929,7 @@ void TransportSweep::onTrack(Track* track, segment* segments) {
   /* Allocate a temporary flux buffer on the stack (free) and initialize it */
   /* Select right size for buffer */
 #ifndef NGROUPS
-  int _NUM_GROUPS = _track_generator->getGeometry()->getNumEnergyGroups();
+  int _NUM_GROUPS = _cpu_solver->getNumEnergyGroups();
 #endif
 #ifndef LINEARSOURCE
   int num_moments = 1;
@@ -944,7 +944,7 @@ void TransportSweep::onTrack(Track* track, segment* segments) {
   /* Allocate an aligned buffer on the stack */
   FP_PRECISION fsr_flux[num_moments * num_groups_aligned] __attribute__
        ((aligned (VEC_ALIGNMENT)));
-  memset(&fsr_flux[0], 0, num_moments * num_groups_aligned * sizeof(FP_PRECISION));
+  memset(fsr_flux, 0, num_moments * num_groups_aligned * sizeof(FP_PRECISION));
   FP_PRECISION* fsr_flux_x = &fsr_flux[num_groups_aligned];
   FP_PRECISION* fsr_flux_y = &fsr_flux[2*num_groups_aligned];
   FP_PRECISION* fsr_flux_z = &fsr_flux[3*num_groups_aligned];

--- a/src/TrackTraversingAlgorithms.h
+++ b/src/TrackTraversingAlgorithms.h
@@ -44,6 +44,7 @@ class CPULSSolver;
  */
 class MaxOpticalLength: public TraverseSegments {
 private:
+  FP_PRECISION _min_tau;
   FP_PRECISION _max_tau;
 
 public:

--- a/src/TrackTraversingAlgorithms.h
+++ b/src/TrackTraversingAlgorithms.h
@@ -168,7 +168,7 @@ private:
   double* _src_constants;
   Quadrature* _quadrature;
   CPULSSolver* _solver;
-  int _NUM_GROUPS;
+  int _num_groups;
 #ifndef THREED
   int _NUM_COEFFS;
 #endif
@@ -203,7 +203,7 @@ private:
   CPUSolver* _cpu_solver;
   CPULSSolver* _ls_solver;
   Geometry* _geometry;
-  int _NUM_GROUPS;
+  int _num_groups;
   FP_PRECISION** _thread_fsr_fluxes;
   FP_PRECISION** _thread_scratch_pads;
 

--- a/src/TrackTraversingAlgorithms.h
+++ b/src/TrackTraversingAlgorithms.h
@@ -168,7 +168,7 @@ private:
   double* _src_constants;
   Quadrature* _quadrature;
   CPULSSolver* _solver;
-  int _num_groups;
+  int _NUM_GROUPS;
 #ifndef THREED
   int _NUM_COEFFS;
 #endif
@@ -203,7 +203,7 @@ private:
   CPUSolver* _cpu_solver;
   CPULSSolver* _ls_solver;
   Geometry* _geometry;
-  int _num_groups;
+  int _NUM_GROUPS;
   FP_PRECISION** _thread_fsr_fluxes;
   FP_PRECISION** _thread_scratch_pads;
 

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -249,16 +249,6 @@ void Vector::copyTo(Vector* vector) {
 
 
 /**
- * @brief Get a value at location described by a given cell and group index.
- * @param cell The cell location index.
- * @param group The group location index.
- */
-CMFD_PRECISION Vector::getValue(int cell, int group) {
-  return _array[cell*_num_groups + group];
-}
-
-
-/**
  * @brief Get the array describing the vector.
  * @return The array describing the vector.
  */

--- a/src/Vector.h
+++ b/src/Vector.h
@@ -57,7 +57,6 @@ class Vector {
   void copyTo(Vector* vector);
 
   /* Getter functions */
-  CMFD_PRECISION getValue(int cell, int group);
   CMFD_PRECISION* getArray();
   int getNumX();
   int getNumY();
@@ -72,6 +71,16 @@ class Vector {
   void setValues(int cell, int group_start, int group_end,
                  CMFD_PRECISION* vals);
   void setAll(CMFD_PRECISION val);
+
+/**
+ * @brief Get a value at location described by a given cell and group index.
+ * @param cell The cell location index.
+ * @param group The group location index.
+ */
+  inline CMFD_PRECISION getValue(int cell, int group) {
+    return _array[cell*_num_groups + group];
+  }
+
 };
 
 #endif  // SRC_VECTOR_H_

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -600,9 +600,14 @@ void log_printf(logLevel level, const char* format, ...) {
       throw std::logic_error(&msg_string[0]);
     }
     else {
+     //Note lock output in Python build for thread safety
+#ifdef SWIG
+      omp_set_lock(&log_error_lock);
+#endif
       printf("%s", &msg_string[0]);
-#ifndef SWIG
       fflush(stdout);
+#ifdef SWIG
+      omp_unset_lock(&log_error_lock);
 #endif
     }
   }

--- a/src/pairwise_sum.h
+++ b/src/pairwise_sum.h
@@ -20,8 +20,8 @@ inline double pairwise_sum(T* vector, L length) {
 
   double sum = 0;
 
-  /* Base case: if length is less than 16, perform summation */
-  if (length < 16) {
+  /* Base case: if length is less than SIMD vector length, perform summation */
+  if (length < VEC_LENGTH) {
 
 #pragma omp simd reduction(+:sum)
     for (L i=0; i < length; i++)

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -5,6 +5,7 @@ source=openmoc, tests
 [report]
 # Files to exclude from coverage testing
 omit =
+    tests/openmoc/openmoc/openmoc.py
     openmoc/openmoc/openmoc.py
     openmoc/openmoc.py
 

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -4,7 +4,9 @@ source=openmoc, tests
 
 [report]
 # Files to exclude from coverage testing
-omit = openmoc/openmoc/openmoc.py
+omit =
+    openmoc/openmoc/openmoc.py
+    openmoc/openmoc.py
 
 # Regexes for lines to exclude from consideration
 exclude_lines =

--- a/tests/test_axial_segmentation/results_true.dat
+++ b/tests/test_axial_segmentation/results_true.dat
@@ -1,0 +1,2 @@
+# Iterations: 30
+keff:  5.06621E-01

--- a/tests/test_axial_segmentation/test_axial_segmentation.py
+++ b/tests/test_axial_segmentation/test_axial_segmentation.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import numpy as np
+sys.path.insert(0, os.pardir)
+sys.path.insert(0, os.path.join(os.pardir, 'openmoc'))
+import openmoc
+from testing_harness import TestHarness
+from input_set import AxialExtendedInput
+
+
+class AxialSegmentationTestHarness(TestHarness):
+    """An eigenvalue calculation in a 3D lattice with 7-group C5G7 data."""
+
+    def __init__(self):
+        super(AxialSegmentationTestHarness, self).__init__()
+        self.input_set = AxialExtendedInput()
+        self.num_polar = 2
+        self.azim_spacing = 0.24
+        self.z_spacing = 0.9
+
+
+    def _create_trackgenerator(self):
+        """Instantiate a TrackGenerator."""
+        geometry = self.input_set.geometry
+        geometry.initializeFlatSourceRegions()
+        self.track_generator = \
+            openmoc.TrackGenerator3D(geometry, self.num_azim, self.num_polar,
+                                     self.azim_spacing, self.z_spacing)
+        self.track_generator.setSegmentFormation(openmoc.OTF_TRACKS)
+
+        # Add segmentation zones, missing some intentionally
+        seg_zones = np.array([0., 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20])
+        self.track_generator.setSegmentationZones(seg_zones);
+
+
+    def _generate_tracks(self):
+        """Generate Tracks and segments."""
+        # Need to use more than 1 thread, and lose reproducibility of FSR
+        # numbering, in order to have temporary tracks and segments array of
+        # the correct size for the multi-threaded solver.
+        self.track_generator.setNumThreads(self.num_threads)
+        self.track_generator.generateTracks()
+
+
+    def _run_openmoc(self):
+        self.solver.computeEigenvalue(max_iters=30)
+
+    def _get_results(self, num_iters=True, keff=True, fluxes=False,
+                     num_fsrs=False, num_tracks=False, num_segments=False,
+                     hash_output=False):
+        """Digest info in the solver"""
+        return super(AxialSegmentationTestHarness, self)._get_results(
+                num_iters=num_iters, keff=keff, fluxes=fluxes,
+                num_fsrs=num_fsrs, num_tracks=num_tracks,
+                num_segments=num_segments, hash_output=hash_output)
+
+if __name__ == '__main__':
+    harness = AxialSegmentationTestHarness()
+    harness.main()

--- a/tests/test_rings/results_true.dat
+++ b/tests/test_rings/results_true.dat
@@ -1,3 +1,3 @@
-# FSRs: 8
+# FSRs: 7
 # tracks: 116
-# segments: 700
+# segments: 620

--- a/tests/test_rings/test_rings.py
+++ b/tests/test_rings/test_rings.py
@@ -26,11 +26,14 @@ class RingTestHarness(TestHarness):
         for i, cell_id in enumerate(cells):
             cells[cell_id].setNumRings(i*2 + 3)
 
+            # Create rings starting from a given radius in the moderator
+            if i==1:
+                cells[cell_id].setNumRings(i*2 + 3, 0.3)
+
     def _get_results(self, num_iters=False, keff=False, fluxes=False,
                      num_fsrs=True, num_segments=True, num_tracks=True,
                      hash_output=False):
         """Digest info from geometry and return as a string."""
-
         return super(RingTestHarness, self)._get_results(
                 num_iters=num_iters, keff=keff, fluxes=fluxes,
                 num_fsrs=num_fsrs, num_segments=num_segments,


### PR DESCRIPTION
Most solvers now dont require specifying the number of groups at compile time to get good performance
Specifying the number of groups is now possible in the Python build

Treatment of residual in CMFD is improved leading to 20% speedup on 2D core and 3D assembly (PWR)

Volume tally using Meshes