### PR TITLE
add small check for swig

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 The setup script for OpenMOC
 '''
 
-import os, site, string, sys
+import os, shutil, site, string, sys
 from distutils.errors import DistutilsOptionError
 import distutils.ccompiler
 import multiprocessing
@@ -113,6 +113,12 @@ class custom_install(install):
     self.profile_mode = False
     self.coverage_mode = False
     self.with_ccache = False
+
+    # Check that swig is installed:
+    swigLocation = shutil.which('swig')
+    if not swigLocation:
+        print("-> Please install swig before building <-")
+        sys.exit()
 
 
   def finalize_options(self):


### PR DESCRIPTION
setup.py does not currently check if swig is installed. It will proceed without warning, and only fail after attempting to compile some files swig should have created beforehand. This brief checks removes a potential inconvenience for users less experienced with compiling stuff.