### PR TITLE
fast math in nvcc

### DIFF
--- a/config.py
+++ b/config.py
@@ -180,7 +180,7 @@ class configuration:
                                '-qsmp=omp', '-qpic']
     compiler_flags['nvcc'] =  ['--relocatable-device-code', 'true',
                                '-c', '-O3',  '-std=c++11',
-                               '--compiler-options', '-fpic']
+                               '--compiler-options', '-fpic', '--use_fast_math']
 
 
     ###########################################################################


### PR DESCRIPTION
Hey, so, I didn't know that nvcc had it's own equivalent of --ffast-math that just switches to denormal number underflow and slightly less exact division/sqrt. It gives a ~25% speedup on a C5G7 run with plenty of azimuthal angles, so, thought it may be worth a tiny PR.