### PR TITLE
Fix Intel compiler OpenMP locks seg fault / deadlock

### DIFF
--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -95,7 +95,9 @@ def plot_tracks(track_generator, get_figure=False, plot_3D=False):
     directory = openmoc.get_output_directory() + subdirectory
 
     # Ensure that normal settings are used even if called from ipython
-    curr_rc = dict(matplotlib.rcParams)
+    deprecated = ['text.latex.unicode', 'examples.directory']
+    curr_rc = {k: matplotlib.rcParams[k] for k in matplotlib.rcParams.keys()
+               if matplotlib.__version__[0] < '3.0' or k not in deprecated}
     matplotlib.rcParams.update(curr_rc)
 
     # Make directory if it does not exist
@@ -194,7 +196,9 @@ def plot_segments(track_generator, get_figure=False, plot_3D=False):
     directory = openmoc.get_output_directory() + subdirectory
 
     # Ensure that normal settings are used even if called from ipython
-    curr_rc = dict(matplotlib.rcParams)
+    deprecated = ['text.latex.unicode', 'examples.directory']
+    curr_rc = {k: matplotlib.rcParams[k] for k in matplotlib.rcParams.keys()
+               if matplotlib.__version__[0] < '3.0' or k not in deprecated}
     matplotlib.rcParams.update(curr_rc)
 
     # Make directory if it does not exist
@@ -890,7 +894,9 @@ def plot_energy_fluxes(solver, fsrs, group_bounds=None, norm=True,
     directory = openmoc.get_output_directory() + subdirectory
 
     # Ensure that normal settings are used even if called from ipython
-    curr_rc = dict(matplotlib.rcParams)
+    deprecated = ['text.latex.unicode', 'examples.directory']
+    curr_rc = {k: matplotlib.rcParams[k] for k in matplotlib.rcParams.keys()
+               if matplotlib.__version__[0] < '3.0' or k not in deprecated}
     matplotlib.rcParams.update(curr_rc)
 
     # Make directory if it does not exist
@@ -1320,7 +1326,10 @@ def plot_spatial_data(domains_to_data, plot_params, get_figure=False):
         else:
 
             # Ensure that normal settings are used even if called from ipython
-            curr_rc = dict(matplotlib.rcParams)
+            deprecated = ['text.latex.unicode', 'examples.directory']
+            curr_rc = {k: matplotlib.rcParams[k] for k in
+                       matplotlib.rcParams.keys() if matplotlib.__version__[0]
+                       < '3.0' or k not in deprecated}
             matplotlib.rcParams.update(curr_rc)
 
             fig = plt.figure()
@@ -1402,7 +1411,9 @@ def plot_quadrature(solver, get_figure=False):
     directory = openmoc.get_output_directory() + subdirectory
 
     # Ensure that normal settings are used even if called from ipython
-    curr_rc = dict(matplotlib.rcParams)
+    deprecated = ['text.latex.unicode', 'examples.directory']
+    curr_rc = {k: matplotlib.rcParams[k] for k in matplotlib.rcParams.keys()
+               if matplotlib.__version__[0] < '3.0' or k not in deprecated}
     matplotlib.rcParams.update(curr_rc)
 
     # Make directory if it does not exist

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -140,7 +140,12 @@ ifeq ($(DEBUG),yes)
   CFLAGS += -g
   CFLAGS += -fno-omit-frame-pointer
 else
-  CFLAGS += -Wno-unused-result
+  ifeq ($(COMPILER),gnu)
+    CFLAGS += -Wno-unused-result
+  endif
+  ifeq ($(COMPILER),mpi)
+    CFLAGS += -Wno-unused-result
+  endif
 endif
 
 # Profiling Flags

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -573,8 +573,11 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
         FP_PRECISION delta_psi = (tau[e] * track_flux[e] - length * src_flat[e])
              * exp_F1 - src_linear[e] * length * length * exp_F2;
 
+#ifdef ONLYVACUUMBC
         /* Limit delta psi to avoid negative track fluxes */
         delta_psi = std::min(float(delta_psi), track_flux[e]);
+        //FIXME Not vectorized. Performance issue
+#endif
 
         track_flux[e] -= delta_psi;
 
@@ -601,8 +604,11 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
       FP_PRECISION delta_psi = (tau[e] * track_flux[e] - length * src_flat[e])
            * exp_F1 - src_linear[e] * length * length * exp_F2;
 
+#ifdef ONLYVACUUMBC
       /* Limit delta psi to avoid negative track fluxes */
       delta_psi = std::min(float(delta_psi), track_flux[e]);
+      //FIXME Not vectorized. Performance issue
+#endif
 
       track_flux[e] -= delta_psi;
 

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -209,9 +209,12 @@ void CPULSSolver::initializeFixedSources() {
     source_z = fsr_iter->second[2];
 
     /* Warn the user if a fixed source has already been assigned to this FSR */
-    if (fabs(_fixed_sources_xyz(fsr_id,group,0) - source_x) > FLT_EPSILON ||
-        fabs(_fixed_sources_xyz(fsr_id,group,1) - source_y) > FLT_EPSILON ||
-        fabs(_fixed_sources_xyz(fsr_id,group,2) - source_z) > FLT_EPSILON)
+    if ((fabs(_fixed_sources_xyz(fsr_id,group,0)) > FLT_EPSILON &&
+         fabs(_fixed_sources_xyz(fsr_id,group,0) - source_x) > FLT_EPSILON) ||
+        (fabs(_fixed_sources_xyz(fsr_id,group,1)) > FLT_EPSILON &&
+         fabs(_fixed_sources_xyz(fsr_id,group,1) - source_y) > FLT_EPSILON) ||
+        (fabs(_fixed_sources_xyz(fsr_id,group,2)) > FLT_EPSILON &&
+         fabs(_fixed_sources_xyz(fsr_id,group,2) - source_z) > FLT_EPSILON))
       log_printf(WARNING, "Overriding fixed linear source %f %f %f in FSR ID=%d"
                  " group %d with %f %f %f", _fixed_sources_xyz(fsr_id,group, 0),
                  _fixed_sources_xyz(fsr_id,group,1),

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -741,6 +741,9 @@ void CPULSSolver::accumulateLinearFluxContribution(long fsr_id,
   }
 
   omp_unset_lock(&_FSR_locks[fsr_id]);
+#ifdef INTEL
+#pragma omp flush
+#endif
 
   /* Reset buffers to 0 */
   memset(fsr_flux, 0, 4 * num_groups_aligned * sizeof(FP_PRECISION));

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -2404,6 +2404,9 @@ void CPUSolver::accumulateScalarFluxContribution(long fsr_id,
     _scalar_flux(fsr_id,e) += weight * fsr_flux[e];
 
   omp_unset_lock(&_FSR_locks[fsr_id]);
+#ifdef INTEL
+#pragma omp flush
+#endif
 
   /* Reset buffers */
   memset(fsr_flux, 0, _NUM_GROUPS * sizeof(FP_PRECISION));

--- a/src/Cmfd.h
+++ b/src/Cmfd.h
@@ -617,6 +617,9 @@ inline void Cmfd::tallyCurrent(segment* curr_segment, float* track_flux,
           _edge_corner_currents[first_ind+g] += currents[g];
 
         omp_unset_lock(&_edge_corner_lock);
+#ifdef INTEL
+#pragma omp flush
+#endif
       }
     }
     else {
@@ -649,7 +652,9 @@ inline void Cmfd::tallyCurrent(segment* curr_segment, float* track_flux,
           _edge_corner_currents[first_ind+g] += currents[g];
 
         omp_unset_lock(&_edge_corner_lock);
-
+#ifdef INTEL
+#pragma omp flush
+#endif
       }
     }
   }

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -108,6 +108,9 @@ void Matrix::incrementValue(int cell_from, int group_from,
 
   /* Release Matrix cell mutual exclusion lock */
   omp_unset_lock(&_cell_locks[cell_to]);
+#ifdef INTEL
+#pragma omp flush
+#endif
 
   /* Set global modified flag to true */
   _modified = true;
@@ -153,6 +156,9 @@ void Matrix::setValue(int cell_from, int group_from,
 
   /* Release Matrix cell mutual exclusion lock */
   omp_unset_lock(&_cell_locks[cell_to]);
+#ifdef INTEL
+#pragma omp flush
+#endif
 
   /* Set global modified flag to true */
   _modified = true;

--- a/src/Quadrature.cpp
+++ b/src/Quadrature.cpp
@@ -1156,7 +1156,7 @@ DoubleVec GLPolarQuad::getLegendreRoots(size_t n) {
 
   bool all_roots_converged = false;
 
-  /* use the Alberth-Housholder_n method to nudge guesses towards roots */
+  /* use the Alberth-Householder_n method to nudge guesses towards roots */
   for (size_t iter=0; iter < MAX_LG_ITERS; ++iter) {
 
     /* set S tildes */

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -80,8 +80,8 @@ Solver::Solver(TrackGenerator* track_generator) {
   _calculate_residuals_by_reference = false;
   _negative_fluxes_allowed = false;
   _OTF_transport = false;
-
   _xs_log_level = ERROR;
+  _gpu_solver = false;
 
   //FIXME Parameters for xs modification, should be deleted
   _reset_iteration = -1;
@@ -1872,13 +1872,28 @@ void Solver::printTimerReport() {
   double time_per_integ_total = tot_time / num_integrations *
                                 (omp_get_max_threads() * num_ranks);
 
-  msg_string = "Integration time by segment-group-thread (sweep)";
-  msg_string.resize(53, '.');
-  log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), time_per_integration);
+  if (!_gpu_solver) {
+    msg_string = "Integration time by segment-group-thread (sweep)";
+    msg_string.resize(53, '.');
+    log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(),
+               time_per_integration);
 
-  msg_string = "Integration time by segment-group-thread (total)";
-  msg_string.resize(53, '.');
-  log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), time_per_integ_total);
+    msg_string = "Integration time by segment-group-thread (total)";
+    msg_string.resize(53, '.');
+    log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(),
+               time_per_integ_total);
+  }
+  else {
+    msg_string = "Integration time by segment-group-device (sweep)";
+    msg_string.resize(53, '.');
+    log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), time_per_integration
+               / omp_get_max_threads());
+
+    msg_string = "Integration time by segment-group-device (total)";
+    msg_string.resize(53, '.');
+    log_printf(RESULT, "%s%1.4E sec", msg_string.c_str(), time_per_integ_total
+               / omp_get_max_threads());
+  }
 
   /* Print footer with number of tracks, segments and fsrs */
   set_separator_character('-');

--- a/src/Solver.h
+++ b/src/Solver.h
@@ -318,6 +318,9 @@ protected:
   /** A string indicating the type of source approximation */
   std::string _source_type;
 
+  /** A boolean to know which type of solver is being used */
+  bool _gpu_solver;
+
   /**
    * @brief Initializes Track boundary angular flux and leakage and
    *        FSR scalar flux arrays.

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -446,6 +446,9 @@ void CentroidGenerator::onTrack(Track* track, segment* segments) {
 
     /* Unset the lock for this FSR */
     omp_unset_lock(&_FSR_locks[fsr]);
+#ifdef INTEL
+#pragma omp flush
+#endif
 
     x += cos_phi * sin_theta * curr_segment->_length;
     y += sin_phi * sin_theta * curr_segment->_length;
@@ -716,7 +719,7 @@ void LinearExpansionGenerator::onTrack(Track* track, segment* segments) {
     double yc = y + length * 0.5 * sin_phi * sin_theta;
     double zc = z + length * 0.5 * cos_theta;
 
-    /* Set the FSR src constants buffer to zero */
+    /* Allocate a buffer for the FSR source constants on the stack */
     double thread_src_constants[_NUM_GROUPS * _NUM_COEFFS]  __attribute__
        ((aligned (VEC_ALIGNMENT)));
 
@@ -810,6 +813,9 @@ void LinearExpansionGenerator::onTrack(Track* track, segment* segments) {
 
     /* Unset the lock for this FSR */
     omp_unset_lock(&_FSR_locks[fsr]);
+#ifdef INTEL
+#pragma omp flush
+#endif
   }
 
   /* Determine progress */

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -567,8 +567,9 @@ void LinearExpansionGenerator::execute() {
       double volume = _FSR_volumes[r];
       if (std::abs(det) < MIN_DET || volume < 1e-6) {
         if (volume > 0)
-          log_printf(INFO, "Unable to form linear source components in "
-                     "source region %d.", r);
+          log_printf(DEBUG, "Unable to form linear source components in "
+                     "source region %d : determinant %.2e volume %.2e", r, det,
+                     volume);
 #pragma omp atomic update
         _num_flat++;
         ilem[r*nc + 0] = 0.0;
@@ -617,8 +618,8 @@ void LinearExpansionGenerator::execute() {
         ilem[r*nc + 0] = 0.0;
         ilem[r*nc + 1] = 0.0;
         ilem[r*nc + 2] = 0.0;
-        log_printf(INFO, "Unable to form linear source components in "
-                   "source region %d.", r);
+        log_printf(DEBUG, "Unable to form linear source components in "
+                   "source region %d : determinant = %.2e", r, det);
 #pragma omp atomic update
         _num_flat++;
       }

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -2095,6 +2095,7 @@ int Lattice::getLatticeSurface(int cell, Point* point) {
   int lat_z = cell / (_num_x*_num_y);
 
   /* Create planes representing the boundaries of the lattice cell */
+  //NOTE This creates a benign race condition on the surface ids
   XPlane xplane(0.0);
   YPlane yplane(0.0);
   ZPlane zplane(0.0);

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -74,6 +74,9 @@ void Vector::incrementValue(int cell, int group, CMFD_PRECISION val) {
 
   /* Release Vector cell mutual exclusion lock */
   omp_unset_lock(&_cell_locks[cell]);
+#ifdef INTEL
+#pragma omp flush
+#endif
 }
 
 
@@ -115,6 +118,9 @@ void Vector::incrementValues(int cell, int group_first, int group_last,
 
   /* Release Vector cell mutual exclusion lock */
   omp_unset_lock(&_cell_locks[cell]);
+#ifdef INTEL
+#pragma omp flush
+#endif
 }
 
 
@@ -154,6 +160,9 @@ void Vector::setValue(int cell, int group, CMFD_PRECISION val) {
 
   /* Release Vector cell mutual exclusion lock */
   omp_unset_lock(&_cell_locks[cell]);
+#ifdef INTEL
+#pragma omp flush
+#endif
 }
 
 
@@ -194,6 +203,9 @@ void Vector::setValues(int cell, int group_first, int group_last,
 
   /* Release Vector cell mutual exclusion lock */
   omp_unset_lock(&_cell_locks[cell]);
+#ifdef INTEL
+#pragma omp flush
+#endif
 }
 
 

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -732,6 +732,8 @@ GPUSolver::GPUSolver(TrackGenerator* track_generator) :
 
   if (track_generator != NULL)
     setTrackGenerator(track_generator);
+
+  _gpu_solver = true;
 }
 
 
@@ -1569,6 +1571,7 @@ void GPUSolver::transportSweep() {
   log_printf(DEBUG, "Copied host to device flux.");
 
   /* Perform transport sweep on all tracks */
+  _timer->startTimer();
   transportSweepOnDevice<<<_B, _T, shared_mem>>>(scalar_flux, boundary_flux,
                                                  start_flux, reduced_sources,
                                                  _materials, _dev_tracks,
@@ -1576,6 +1579,8 @@ void GPUSolver::transportSweep() {
 
   cudaDeviceSynchronize();
   getLastCudaError();
+  _timer->stopTimer();
+  _timer->recordSplit("Transport Sweep");
   log_printf(DEBUG, "Finished sweep on GPU.\n");
 }
 


### PR DESCRIPTION
Building OpenMOC with ICPC creates a deadlock situation in 3 different locations, as if the omp_unset_lock routine was not working.

The locations :
- tallying to source constants arrays for the linear source
- tallying CMFD currents
- tallying to scalar flux arrays

The deadlock often leads to a seg fault instead of the threads just spinning. 
Using intel inspector confirmed the dead lock diagnosis.

By adding flush pragmas, the dead lock is avoided, as if, and it should not be the case, the status of the locks had to be flushed to cache to be seen by other threads. 

Other things in this PR
- less logs for linear source in low discretization cases
- disabled setting the track flux to always be positive as it precludes vectorization
- fix matplotlib deprecation warning
- create timer for the integration time of the GPU solver. To go from the CPU to GPU integration times, divide by the number of threads to get a per-device number