### PR TITLE
NGROUPS compilation flag for GPU Solver

### DIFF
--- a/src/Cmfd.cpp
+++ b/src/Cmfd.cpp
@@ -731,6 +731,25 @@ void Cmfd::collapseXS() {
     communicateSplits(true);
 #endif
 
+  /* Report number of negative currents */
+  long num_negative_currents = _surface_currents->getNumNegativeValues();
+  int total_negative_CMFD_current_domains = (num_negative_currents > 0);
+#ifdef MPIx
+  if (_domain_communicator != NULL) {
+    long temp_sum_neg = num_negative_currents;
+    MPI_Allreduce(&temp_sum_neg, &num_negative_currents, 1, MPI_LONG, MPI_SUM,
+                  _domain_communicator->_MPI_cart);
+    int temp_sum_dom = total_negative_CMFD_current_domains;
+    MPI_Allreduce(&temp_sum_dom, &total_negative_CMFD_current_domains, 1,
+                  MPI_INT, MPI_SUM, _domain_communicator->_MPI_cart);
+  }
+#endif
+
+  if (_SOLVE_3D && num_negative_currents > 0)
+    log_printf(WARNING_ONCE, "Negative CMFD currents in %ld surfaces-groups in"
+               " %d domains.", num_negative_currents,
+               total_negative_CMFD_current_domains);
+
 #pragma omp parallel
   {
 

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -3585,6 +3585,9 @@ void Geometry::dumpToFile(std::string filename) {
 
   FILE* out;
   out = fopen(filename.c_str(), "w");
+  if (out == NULL)
+    log_printf(ERROR, "Geometry file %s cannot be written. Wrong folder?",
+               &filename[0]);
 
   /* Print number of energy groups */
   int num_groups = getNumEnergyGroups();
@@ -3949,7 +3952,9 @@ void Geometry::loadFromFile(std::string filename, bool twiddle) {
   if (_root_universe != NULL)
     delete _root_universe;
 
-  log_printf(NORMAL, "Reading Geometry from %s", filename.c_str());
+  log_printf(NORMAL, "Reading Geometry from %s", &filename[0]);
+  if (in == NULL)
+    log_printf(ERROR, "Geometry file %s was not found.", &filename[0]);
 
   std::map<int, Surface*> all_surfaces;
   std::map<int, Cell*> all_cells;

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -2053,6 +2053,8 @@ void Solver::dumpFSRFluxes(std::string fname) {
   /* Write the FSR fluxes file */
   FILE* out;
   out = fopen(filename.c_str(), "w");
+  if (out == NULL)
+    log_printf(ERROR, "Fluxes file %s could not be written.", &filename[0]);
 
   /* Write k-eff */
   fwrite(&_k_eff, sizeof(double), 1, out);

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1390,6 +1390,9 @@ void TrackGenerator::dumpSegmentsToFile() {
 
   FILE* out;
   out = fopen(_tracks_filename.c_str(), "w");
+  if (out == NULL)
+    log_printf(ERROR, "Segments file %s could not be written.",
+               &_tracks_filename[0]);
 
   /* Get a string representation of the Geometry's attributes. This is used to
    * check whether or not ray tracing has been performed for this Geometry */
@@ -1506,6 +1509,9 @@ bool TrackGenerator::readSegmentsFromFile() {
 
   int ret;
   FILE* in = fopen(_tracks_filename.c_str(), "r");
+  if (in == NULL)
+    log_printf(ERROR, "Segments file %s could not be found.",
+               &_tracks_filename[0]);
 
   int string_length;
 

--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -35,18 +35,26 @@
 #include "dev_exponential.h"
 #include "GPUQuery.h"
 
+/** If number of groups is known at compile time */
+#ifdef NGROUPS
+#define NUM_GROUPS (NGROUPS)
+#define _NUM_GROUPS (NGROUPS)
+#else
+#define _NUM_GROUPS (_num_groups)
+#endif
+
 /** Indexing macro for the scalar flux in each FSR and energy group */
-#define scalar_flux(tid,e) (scalar_flux[(tid)*num_groups + (e)])
+#define scalar_flux(tid,e) (scalar_flux[(tid)*NUM_GROUPS + (e)])
 
 /** Indexing macro for the old scalar flux in each FSR and energy group */
-#define old_scalar_flux(tid,e) (old_scalar_flux[(tid)*num_groups + (e)])
+#define old_scalar_flux(tid,e) (old_scalar_flux[(tid)*NUM_GROUPS + (e)])
 
 /** Indexing macro for the total source divided by the total cross-section,
  *  \f$ \frac{Q}{\Sigma_t} \f$, in each FSR and energy group */
-#define reduced_sources(tid,e) (reduced_sources[(tid)*num_groups + (e)])
+#define reduced_sources(tid,e) (reduced_sources[(tid)*NUM_GROUPS + (e)])
 
 /** Indexing scheme for fixed sources for each FSR and energy group */
-#define fixed_sources(r,e) (fixed_sources[(r)*num_groups + (e)])
+#define fixed_sources(r,e) (fixed_sources[(r)*NUM_GROUPS + (e)])
 
 /** Indexing macro for the azimuthal and polar weights */
 #define weights(i,p) (weights[(i)*num_polar_2 + (p)])

--- a/tools/ci/travis-install.sh
+++ b/tools/ci/travis-install.sh
@@ -36,7 +36,7 @@ export PYTHONPATH="$HOME/openmc/:$PYTHONPATH"
 # Install mpi4py and MPI-wrapped compilers for MPI configurations
 if [[ $MPI == 'y' ]]; then
     conda config --add channels conda-forge
-    conda install mpi4py openmpi-mpicc openmpi-mpicxx
+    conda install -y mpi4py openmpi-mpicc openmpi-mpicxx
     export LD_PRELOAD="$HOME/miniconda/envs/test-environment/lib/libmpi_cxx.so"
 # Get regular C++11-compatible compiler for non-MPI configurations
 else


### PR DESCRIPTION
Specifying the number of groups for the GPU Solver at compile time enables a x2 speedup on a 70g assembly case. 

On my workstation, my consumer grade GPU (K620) is now 30% faster than my expensive CPU (Xeon E5-2630)

Added a warning log for negative CMFD currents. These appear in 3D linear source while the source is converging, and should have disappeared by convergence. 

Better handling of file read/write errors.