### PR TITLE
Optimizations and fix for communication angular fluxes in the case where all boundaries are vacuum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ tests/test_geometry_dump/geometry_file.geo
 tests/test_geometry_dump/geometry_file_second.geo
 tests/test_geometry_load/geometry_file.geo
 tests/test_geometry_print/geometry.txt
+tests/*.coverage
 .pytest_cache/
 
 
@@ -139,6 +140,7 @@ docs/build
 docs/build/*
 docs/doxygen/xml
 docs/doxyge/xml/*
+docs/*zip
 
 # BGQ
 *.lst

--- a/src/CPULSSolver.cpp
+++ b/src/CPULSSolver.cpp
@@ -607,10 +607,6 @@ void CPULSSolver::tallyLSScalarFlux(segment* curr_segment, int azim_index,
       fsr_flux_y[e] += exp_H * direction[1] + delta_psi * position[1];
       fsr_flux_z[e] += exp_H * direction[2] + delta_psi * position[2];
     }
-
-    /* Ensure track flux remains positive */
-    for (int e=0; e < _NUM_GROUPS; e++)
-      track_flux[e] = std::max(0.f, track_flux[e]);
   }
   else {
 //FIXME Implement strip mining for the 2D linear source solver

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -1277,7 +1277,7 @@ void CPUSolver::transferAllInterfaceFluxes() {
                   /* Remember that track flux has been placed in send buffer
                    * to avoid sending a wrong track flux when packing buffer */
                   //NOTE Track fluxes are always communicated in the same order
-                  if (_moc_iteration == 0)
+                  if (_num_iterations == 0)
                     _track_flux_sent.at(dir).at(track_id) = true;
                 }
               }

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -655,7 +655,9 @@ void CPUSolver::setupMPIBuffers() {
     }
 
     /* Determine which Tracks communicate with each neighbor domain */
+#ifndef ONLYVACUUMBC
 #pragma omp parallel for
+#endif
     for (long t=0; t<_tot_num_tracks; t++) {
 
       Track* track;
@@ -693,6 +695,7 @@ void CPUSolver::setupMPIBuffers() {
           }
           _boundary_tracks.at(neighbor).at(slot) = 2*t + d;
 #ifdef ONLYVACUUMBC
+          //NOTE _boundary_tracks needs to be ordered if ONLYVACUUMBC is used
           _domain_connections.at(d).at(t) = domains[d];
 #endif
         }
@@ -942,6 +945,7 @@ void CPUSolver::packBuffers(std::vector<long> &packing_indexes) {
 
   /* Fill send buffers for every domain */
   int num_domains = packing_indexes.size();
+#pragma omp parallel for num_threads(num_domains)
   for (int i=0; i < num_domains; i++) {
 
     /* Reset send buffers : start at beginning if the buffer has not been
@@ -949,7 +953,7 @@ void CPUSolver::packBuffers(std::vector<long> &packing_indexes) {
     int start_idx = _send_buffers_index.at(i) * _track_message_size +
                     _fluxes_per_track + 1;
     int max_idx = _track_message_size * TRACKS_PER_BUFFER;
-#pragma omp parallel for
+#pragma omp parallel for num_threads(_num_threads / num_domains)
     for (int idx = start_idx; idx < max_idx; idx += _track_message_size) {
       long* track_info_location =
         reinterpret_cast<long*>(&_send_buffers.at(i)[idx]);
@@ -972,7 +976,7 @@ void CPUSolver::packBuffers(std::vector<long> &packing_indexes) {
          _send_buffers_index.at(i));
 
 #ifndef ONLYVACUUMBC
-#pragma omp parallel for
+#pragma omp parallel for num_threads(_num_threads / num_domains)
 #endif
     for (int b=0; b < max_buffer_idx; b++) {
 
@@ -1099,21 +1103,6 @@ void CPUSolver::transferAllInterfaceFluxes() {
         _MPI_req[i*2] = MPI_REQUEST_NULL;
         _MPI_req[i*2 + 1] = MPI_REQUEST_NULL;
       }
-    }
-
-    if (_num_iterations == 0) {
-      /* Block for communication round to complete, to adjust buffer sizes */
-      MPI_Waitall(2 * num_domains, _MPI_req, MPI_STATUSES_IGNORE);
-
-      for (int i=0; i < num_domains; i++) {
-        if (active_communication) {
-          /* Adjust receiving buffer if incoming message is large */
-          if (_receive_size.at(i) > _receive_buffers.at(i).size() /
-              _track_message_size)
-            _receive_buffers.at(i).resize(_receive_size.at(i) *
-                                          _track_message_size);
-        }
-      }
 #endif
     }
 
@@ -1140,8 +1129,8 @@ void CPUSolver::transferAllInterfaceFluxes() {
 
         if (first_track != -1) {
 #else
-        /* Send/receive fluxes if there are fluxes to be sent, if buffers are
-           the right size and if they haven't been sent already */
+        /* Send/receive fluxes if there are fluxes to be sent, if the size of
+           the message is known and if they haven't been sent already */
         if (active_communication) {
 #endif
           /* Send outgoing flux */
@@ -1157,6 +1146,16 @@ void CPUSolver::transferAllInterfaceFluxes() {
 
           /* Receive incoming flux */
           if (_receive_size.at(i) > 0 && !_MPI_receives[i]) {
+
+#ifdef ONLYVACUUMBC
+            /* Adjust receiving buffer if incoming message is too large */
+            if (_num_iterations == 0)
+              if (_receive_size.at(i) > _receive_buffers.at(i).size() /
+                                        _track_message_size)
+                _receive_buffers.at(i).resize(_receive_size.at(i) *
+                                              _track_message_size);
+#endif
+
             MPI_Irecv(&_receive_buffers.at(i)[0], _track_message_size *
                       _receive_size.at(i), MPI_FLOAT, domain, 1, MPI_cart,
                       &_MPI_requests[i*2+1]);
@@ -1277,7 +1276,9 @@ void CPUSolver::transferAllInterfaceFluxes() {
 
                   /* Remember that track flux has been placed in send buffer
                    * to avoid sending a wrong track flux when packing buffer */
-                  _track_flux_sent.at(dir).at(track_id) = true;
+                  //NOTE Track fluxes are always communicated in the same order
+                  if (_moc_iteration == 0)
+                    _track_flux_sent.at(dir).at(track_id) = true;
                 }
               }
             }
@@ -1299,12 +1300,6 @@ void CPUSolver::transferAllInterfaceFluxes() {
     _timer->stopTimer();
     _timer->recordSplit("Unpacking time");
   }
-
-#ifdef ONLYVACUUMBC
-  /* Reset book-keeping on which track fluxes have been sent already */
-  std::fill(_track_flux_sent.at(0).begin(), _track_flux_sent.at(0).end(), 0);
-  std::fill(_track_flux_sent.at(1).begin(), _track_flux_sent.at(1).end(), 0);
-#endif
 
   /* Join MPI at the end of communication */
   MPI_Barrier(MPI_cart);

--- a/src/TrackGenerator.cpp
+++ b/src/TrackGenerator.cpp
@@ -1247,6 +1247,15 @@ void TrackGenerator::segmentize() {
       log_printf(ERROR, "A geometry with an axial domain domain decomposition "
                  "has been supplied to a 2D ray tracer.");
 #endif
+
+    /* Check that the track generator is ray tracing within bounds */
+    if (_z_coord < min_z || _z_coord > max_z) {
+      log_printf(WARNING_ONCE, "The track generator z-coordinate (%.2e cm) "
+                 "lies outside the geometry bounds [%.2e %.2e] cm. Z"
+                 "-coordinate moved to %.2e cm", _z_coord, min_z, max_z,
+                 (min_z + max_z) / 2);
+      _z_coord = (min_z + max_z) / 2;
+    }
   }
 
 #ifdef MPIx

--- a/src/Universe.cpp
+++ b/src/Universe.cpp
@@ -1488,6 +1488,11 @@ void Lattice::setNonUniform(bool non_uniform) {
  */
 void Lattice::setWidthsX(std::vector<double> widthsx) {
   _widths_x = widthsx;
+
+  /* Set to non-uniform if the user forgot */
+  _non_uniform = true;
+  if (_universes.size() == 0)
+    _num_x = widthsx.size();
 }
 
 
@@ -1497,6 +1502,11 @@ void Lattice::setWidthsX(std::vector<double> widthsx) {
  */
 void Lattice::setWidthsY(std::vector<double> widthsy) {
   _widths_y = widthsy;
+
+  /* Set to non-uniform if the user forgot */
+  _non_uniform = true;
+  if (_universes.size() == 0)
+    _num_y = widthsy.size();
 }
 
 
@@ -1506,6 +1516,11 @@ void Lattice::setWidthsY(std::vector<double> widthsy) {
  */
 void Lattice::setWidthsZ(std::vector<double> widthsz) {
   _widths_z = widthsz;
+
+  /* Set to non-uniform if the user forgot */
+  _non_uniform = true;
+  if (_universes.size() == 0)
+    _num_z = widthsz.size();
 }
 
 
@@ -2328,6 +2343,13 @@ void Lattice::setWidths(std::vector<double> widths_x,
   _widths_x = widths_x;
   _widths_y = widths_y;
   _widths_z = widths_z;
+
+  /* Convenient for mesh tally lattice */
+  if (_universes.size() == 0) {
+    _num_x = _widths_x.size();
+    _num_y = _widths_y.size();
+    _num_z = _widths_z.size();
+  }
 }
 
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -81,11 +81,8 @@
 #define MAX_LINEAR_SOLVE_ITERATIONS 10000
 
 #ifdef MPIx
-#ifndef ONLYVACUUMBC
-#define TRACKS_PER_BUFFER 1000
-#else
-#define TRACKS_PER_BUFFER 10000
-#endif
+//TODO Make tracks per buffer dependent on number of processes, and groups
+#define TRACKS_PER_BUFFER 2000
 #define CMFD_BUFFER_SIZE 10000
 #endif
 


### PR DESCRIPTION
Rework the communication of buffer sizes to reduce minimize synchronization between neighbor processes.

Add openmp threading on neighbor domains for packing buffers. This makes more sense since each buffer is a little too small to benefit from threading when packing it.

Easier input of mesh lattices
Easier to use a 2D track generator on a slide of a 3D geometry