### PR TITLE
Optimize 2D solvers, set cache alignment and SIMD vector length default to AVX2

### DIFF
--- a/config.py
+++ b/config.py
@@ -86,11 +86,11 @@ class configuration:
     # that the number of energy groups is be fit too a multiple of this
     # vector_length, and restructuring the innermost loops in the solver to
     # loop from 0 to the vector length
-    vector_length = 32
+    vector_length = 8
 
     # The vector alignment used in the VectorizedSolver class when allocating
     # aligned data structures using MM_MALLOC and MM_FREE
-    vector_alignment = 32
+    vector_alignment = 64
 
     # List of C/C++/CUDA distutils.extension objects which are created based
     # on which flags are specified at compile time.
@@ -336,9 +336,10 @@ class configuration:
     # add flags for vector size and alignment for SIMD vectorization
     for compiler in macros:
         for precision in macros[compiler]:
-            macros[compiler][precision].append(('VEC_LENGTH', vector_length))
             macros[compiler][precision].append(('VEC_ALIGNMENT',
                                                 vector_alignment))
+        macros[compiler]['single'].append(('VEC_LENGTH', vector_length))
+        macros[compiler]['double'].append(('VEC_LENGTH', vector_length//2))
 
     # set extra flag for determining precision
     for compiler in macros:

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -175,8 +175,13 @@ ifeq ($(CMFD_PRECISION),double)
 endif
 
 # Vector Flags, take into account strip mining with VEC_LENGTH sized vectors
-CFLAGS += -DVEC_LENGTH=32
-CFLAGS += -DVEC_ALIGNMENT=32
+CFLAGS += -DVEC_ALIGNMENT=64
+ifeq ($(PRECISION),single)
+  CFLAGS += -DVEC_LENGTH=8
+endif
+ifeq ($(PRECISION),double)
+  CFLAGS += -DVEC_LENGTH=4
+endif
 
 # Optimization Flags
 ifeq ($(OPTIMIZE),yes)

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -2277,12 +2277,11 @@ void CPUSolver::transportSweep() {
  *          scalar flux, and updates the Track's angular flux.
  * @param curr_segment a pointer to the Track segment of interest
  * @param azim_index azimuthal angle index for this segment
- * @param polar_index polar angle index for this segment
  * @param fsr_flux buffer to store the contribution to the region's scalar flux
  * @param track_flux a pointer to the Track's angular flux
  */
 void CPUSolver::tallyScalarFlux(segment* curr_segment,
-                                int azim_index, int polar_index,
+                                int azim_index,
                                 FP_PRECISION* __restrict__ fsr_flux,
                                 float* track_flux) {
 
@@ -2335,7 +2334,7 @@ void CPUSolver::tallyScalarFlux(segment* curr_segment,
   }
   else {
 //FIXME: Implement strip mining for the 2D flat source solver
-    ExpEvaluator* exp_evaluator = _exp_evaluators[azim_index][polar_index];
+    ExpEvaluator* exp_evaluator = _exp_evaluators[azim_index][0];
     const int num_polar_2 = _num_polar / 2;
 
     /* Compute tau in advance to simplify attenuation loop */
@@ -2363,6 +2362,7 @@ void CPUSolver::tallyScalarFlux(segment* curr_segment,
       /* Compute attenuation of the track angular flux */
       delta_psi[pe] = (tau[pe] * track_flux[pe] - length *
                       _reduced_sources(fsr_id, pe%_NUM_GROUPS)) * exponential;
+
       track_flux[pe] -= delta_psi[pe];
       delta_psi[pe] *= wgt;
     }

--- a/src/CPUSolver.h
+++ b/src/CPUSolver.h
@@ -156,7 +156,7 @@ public:
                               bool nu = false);
   void printInputParamsSummary();
 
-  void tallyScalarFlux(segment* curr_segment, int azim_index, int polar_index,
+  void tallyScalarFlux(segment* curr_segment, int azim_index,
                        FP_PRECISION* fsr_flux, float* track_flux);
 
   void accumulateScalarFluxContribution(long fsr_id, FP_PRECISION weight,

--- a/src/ExpEvaluator.h
+++ b/src/ExpEvaluator.h
@@ -169,8 +169,8 @@ inline FP_PRECISION ExpEvaluator::computeExponential(FP_PRECISION tau,
                                                      int polar_offset) {
 
 #ifndef THREED
-  FP_PRECISION inv_sin_theta = 1.f / _quadrature->getSinThetaInline(_azim_index,
-                                                   _polar_index + polar_offset);
+  FP_PRECISION inv_sin_theta = _quadrature->getInvSinThetaInline(_azim_index,
+                                                  _polar_index + polar_offset);
 #else
   FP_PRECISION inv_sin_theta = _inverse_sin_theta_no_offset;
 #endif

--- a/src/ExpEvaluator.h
+++ b/src/ExpEvaluator.h
@@ -357,8 +357,8 @@ inline void ExpEvaluator::retrieveExponentialComponents(FP_PRECISION tau,
 #endif
 
 #ifndef THREED
-  FP_PRECISION inv_sin_theta = 1.f / _quadrature->getSinThetaInline(_azim_index,
-                                                   _polar_index + polar_offset);
+  FP_PRECISION inv_sin_theta = _quadrature->getInvSinThetaInline(_azim_index,
+                                                  _polar_index + polar_offset);
 #else
   FP_PRECISION inv_sin_theta = _inverse_sin_theta_no_offset;
 #endif
@@ -374,7 +374,6 @@ inline void ExpEvaluator::retrieveExponentialComponents(FP_PRECISION tau,
 
    exp_G *= inv_sin_theta;
    *exp_F2 = 2.f*exp_G - *exp_F1;
-   *exp_F2 *= inv_sin_theta;
 
    *exp_H = *exp_F1 - exp_G;
 

--- a/src/MOCKernel.cpp
+++ b/src/MOCKernel.cpp
@@ -394,8 +394,8 @@ void TransportKernel::execute(FP_PRECISION length, Material* mat, long fsr_id,
     curr_segment._region_id = fsr_id;
 
     /* Apply MOC equations */
-    _cpu_solver->tallyScalarFlux(&curr_segment, _azim_index, _polar_index,
-                                 fsr_flux, track_flux);
+    _cpu_solver->tallyScalarFlux(&curr_segment, _azim_index, fsr_flux,
+                                 track_flux);
 
     /* CMFD surfaces can only be on the segment ends, and the propagation is
        always in the forward direction */

--- a/src/Quadrature.cpp
+++ b/src/Quadrature.cpp
@@ -716,6 +716,7 @@ void Quadrature::precomputeWeights(bool solve_3D) {
 
   /* Allocate memory if it was not allocated previously */
   resize2D(_sin_thetas, _num_azim/2, _num_polar);
+  resize2D(_inv_sin_thetas, _num_azim/2, _num_polar);
   resize2D(_total_weights, _num_azim/2, _num_polar);
 
   /* Compute multiples of sine thetas and weights */
@@ -729,7 +730,8 @@ void Quadrature::precomputeWeights(bool solve_3D) {
       else
         weight *= 2.0 * sin_theta;
       setPolarValues(_sin_thetas, a, p, sin_theta);
-      setPolarValues(_total_weights, a, p, weight);
+      setPolarValues(_inv_sin_thetas, a, p, FP_PRECISION(1.f / sin_theta));
+      setPolarValues(_total_weights, a, p, FP_PRECISION(weight));
     }
   }
 }

--- a/src/Quadrature.h
+++ b/src/Quadrature.h
@@ -42,6 +42,7 @@ enum QuadratureType {
 
 /** Shorthand for vectors of floats */
 typedef std::vector<double> DoubleVec;
+typedef std::vector<FP_PRECISION> FloatVec;
 typedef DoubleVec::const_iterator DVCI;
 
 /** Template function for writing vectors to a stream */
@@ -89,6 +90,9 @@ protected:
   /** An array of the sines of quadrature polar angles */
   std::vector<DoubleVec> _sin_thetas;
 
+  /** An array of the inverse sines of quadrature polar angles */
+  std::vector<FloatVec> _inv_sin_thetas;
+
   /** An array of the quadrature polar angles */
   std::vector<DoubleVec> _thetas;
 
@@ -108,7 +112,7 @@ protected:
   std::vector<DoubleVec> _polar_weights;
 
   /** An array of the total weights for each azimuthal/polar angle pair */
-  std::vector<DoubleVec> _total_weights;
+  std::vector<FloatVec> _total_weights;
 
   /* Templates for setting the same values to complimentary and supplementary
    * angles */
@@ -147,12 +151,13 @@ public:
   size_t getNumAzimAngles() const;
   double getSinTheta(size_t azim, size_t polar) const;
   double getSinThetaInline(size_t azim, size_t polar) const;
+  FP_PRECISION getInvSinThetaInline(size_t azim, size_t polar) const;
   double getTheta(size_t azim, size_t polar) const;
   double getPhi(size_t azim) const;
   double getAzimWeight(size_t azim) const;
   double getPolarWeight(size_t azim, size_t polar) const;
   double getWeight(size_t azim, size_t polar) const;
-  double getWeightInline(size_t azim, size_t polar) const;
+  FP_PRECISION getWeightInline(size_t azim, size_t polar) const;
   const std::vector<DoubleVec>& getSinThetas() const;
   const std::vector<DoubleVec>& getThetas() const;
   const DoubleVec& getPhis() const;
@@ -303,6 +308,22 @@ inline double Quadrature::getSinThetaInline(size_t azim, size_t polar) const {
 
 
 /**
+ * @brief Returns the \f$ 1/sin(\theta)\f$ value for a particular polar angle.
+ * @param azim index of the azimthal angle of interest
+ * @param polar index of the polar angle of interest
+ * @return the value of \f$ 1 / \sin(\theta) \f$ for this azimuthal and polar angle
+ * @details azim must be between 0 and _num_azim / 2
+ */
+inline FP_PRECISION Quadrature::getInvSinThetaInline(size_t azim, size_t polar) const {
+
+  if (azim >= _num_azim/2)
+    azim = _num_azim - azim - 1;
+
+  return _inv_sin_thetas[azim][polar];
+}
+
+
+/**
  * @brief Returns the total weight for Tracks with the given azimuthal and
  *        polar indexes without error checking and inlined
  * @details Angular weights are multiplied by Track spacings
@@ -310,7 +331,7 @@ inline double Quadrature::getSinThetaInline(size_t azim, size_t polar) const {
  * @param polar index of the polar angle of interest
  * @return the total weight of each Track with the given indexes
  */
-inline double Quadrature::getWeightInline(size_t azim, size_t polar) const {
+inline FP_PRECISION Quadrature::getWeightInline(size_t azim, size_t polar) const {
   return _total_weights[azim][polar];
 }
 

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -946,8 +946,9 @@ void TransportSweep::onTrack(Track* track, segment* segments) {
 #else
   const int num_moments = 4;
 #endif
-  int num_groups_aligned = (_NUM_GROUPS / VEC_ALIGNMENT +
-                            (_NUM_GROUPS % VEC_ALIGNMENT != 0)) * VEC_ALIGNMENT;
+  int vec_alignment = VEC_ALIGNMENT / sizeof(FP_PRECISION);
+  int num_groups_aligned = (_NUM_GROUPS / vec_alignment +
+                            (_NUM_GROUPS % vec_alignment != 0)) * vec_alignment;
 
   /* Allocate an aligned buffer on the stack */
   FP_PRECISION fsr_flux[num_moments * num_groups_aligned] __attribute__

--- a/src/TrackTraversingAlgorithms.cpp
+++ b/src/TrackTraversingAlgorithms.cpp
@@ -969,8 +969,8 @@ void TransportSweep::onTrack(Track* track, segment* segments) {
     /* Apply MOC equations */
 #ifndef LINEARSOURCE
     if (_ls_solver == NULL)
-      _cpu_solver->tallyScalarFlux(curr_segment, azim_index, polar_index,
-                                   fsr_flux, track_flux);
+      _cpu_solver->tallyScalarFlux(curr_segment, azim_index, fsr_flux,
+                                   track_flux);
     else
 #endif
       _ls_solver->tallyLSScalarFlux(curr_segment, azim_index, polar_index,
@@ -1017,8 +1017,8 @@ void TransportSweep::onTrack(Track* track, segment* segments) {
     /* Apply MOC equations */
 #ifndef LINEARSOURCE
     if (_ls_solver == NULL)
-      _cpu_solver->tallyScalarFlux(curr_segment, azim_index, polar_index,
-                                   fsr_flux, track_flux);
+      _cpu_solver->tallyScalarFlux(curr_segment, azim_index, fsr_flux,
+                                   track_flux);
     else
 #endif
       _ls_solver->tallyLSScalarFlux(curr_segment, azim_index, polar_index,


### PR DESCRIPTION
Roughly 25% speedup on the 2D CPU solvers by storing weights in single precision and with small tweaks.

Cache alignment parameters may need to be changed if using an architecture with longer cache lines.