### PR TITLE
Add normalization options for SPH calculations

### DIFF
--- a/config.py
+++ b/config.py
@@ -357,9 +357,10 @@ class configuration:
 
     # set CMFD precision and linear algebra solver tolerance
     for compiler in macros:
-        for precision in macros[compiler]:
-            macros[compiler][precision].append(('CMFD_PRECISION', 'float'))
-            macros[compiler][precision].append(('LINALG_TOL', 1E-7))
+        macros[compiler]['single'].append(('CMFD_PRECISION', 'float'))
+        macros[compiler]['single'].append(('LINALG_TOL', 1E-7))
+        macros[compiler]['double'].append(('CMFD_PRECISION', 'double'))
+        macros[compiler]['double'].append(('LINALG_TOL', 1E-15))
 
 
     def setup_extension_modules(self):

--- a/config.py
+++ b/config.py
@@ -358,8 +358,8 @@ class configuration:
     # set CMFD precision and linear algebra solver tolerance
     for compiler in macros:
         for precision in macros[compiler]:
-            macros[compiler][precision].append(('CMFD_PRECISION', 'double'))
-            macros[compiler][precision].append(('LINALG_TOL', 1E-15))
+            macros[compiler][precision].append(('CMFD_PRECISION', 'float'))
+            macros[compiler][precision].append(('LINALG_TOL', 1E-7))
 
 
     def setup_extension_modules(self):

--- a/openmoc/materialize.py
+++ b/openmoc/materialize.py
@@ -456,7 +456,8 @@ def compute_sph_factors(mgxs_lib, max_sph_iters=30, sph_tol=1E-5,
                         zcoord=0.0, num_threads=1, throttle_output=True,
                         geometry=None, track_generator=None, solver=None,
                         sph_domains=None, sph_mode="fixed source",
-                        normalization="fission"):
+                        normalization="fission", relax_factor=1.,
+                        return_library=True):
     """Compute SPH factors for an OpenMC multi-group cross section library.
 
     This routine coputes SuPerHomogenisation (SPH) factors for an OpenMC MGXS
@@ -507,8 +508,15 @@ def compute_sph_factors(mgxs_lib, max_sph_iters=30, sph_tol=1E-5,
         require knowing the source distribution everywhere
     normalization : string
         Which type of normalization should the solver use to compare fluxes
-        "fission" normalizes the fission source
-        "flux" normalizes the sum of fluxes in SPH domains
+        "fission" normalizes the fission source to 1
+        "flux" normalizes the sum of fluxes to 1
+        "SPH-flux" normalizes the sum of fluxes in SPH domains to 1
+    relax_factor : Real
+        Relaxation factor used to dampen the fixed point algorithm. Useful when
+        there are many SPH factors to converge
+    return_library : bool
+        Whether to return a copy of the MGXS library with SPH factors applied.
+        Creating the copy and loading SPH factors can be time consuming.
 
     Returns
     -------
@@ -581,13 +589,8 @@ def compute_sph_factors(mgxs_lib, max_sph_iters=30, sph_tol=1E-5,
             if openmoc_domain.isFissionable():
                 sph_domains.append(openmoc_domain.getId())
 
+    # Get reference fluxes ordered by domain
     openmc_fluxes = _load_openmc_src(mgxs_lib, solver, sph_mode)
-
-    # Normalize MC fluxes to the same convention as OpenMOC
-    if sph_mode == "eigenvalue" and normalization == "flux":
-        openmc_fluxes /= np.sum(openmc_fluxes[sph_to_domain_indices, :])
-    elif sph_mode == "eigenvalue" and normalization == "fission":
-        openmc_fluxes /= mgxs_lib.keff
 
     # Initialize SPH factors
     num_groups = geometry.getNumEnergyGroups()
@@ -616,12 +619,20 @@ def compute_sph_factors(mgxs_lib, max_sph_iters=30, sph_tol=1E-5,
     sph_to_domain_indices = []
     for i, openmc_domain in enumerate(mgxs_lib.domains):
         if openmc_domain.id in openmoc_domains:
-            openmoc_domain = openmoc_domains[openmc_domain.id]
-            if openmoc_domain.getId() in sph_domains:
+            if openmc_domain.id in sph_domains:
                 sph_to_domain_indices.append(i)
 
     py_printf('NORMAL', 'Computing SPH factors for %d "%s" domains',
                len(sph_to_domain_indices), mgxs_lib.domain_type)
+
+    # Normalize OpenMC fluxes
+    if sph_mode == "eigenvalue":
+        if normalization == "flux":
+            openmc_fluxes /= np.sum(openmc_fluxes)
+        if normalization == "SPH-flux":
+            openmc_fluxes /= np.sum(openmc_fluxes[sph_to_domain_indices, :])
+        elif normalization == "fission":
+            openmc_fluxes /= mgxs_lib.keff
 
     # Initialize array of domain-averaged fluxes and SPH factors
     num_domains = len(mgxs_lib.domains)
@@ -664,11 +675,14 @@ def compute_sph_factors(mgxs_lib, max_sph_iters=30, sph_tol=1E-5,
             #FIXME Should be volume averaged
 
         # Re-normalize MOC fluxes
-        if sph_mode == "eigenvalue" and normalization == "flux":
-            openmoc_fluxes /= np.nansum(openmoc_fluxes[sph_to_domain_indices, :])
-        elif sph_mode == "eigenvalue" and normalization == "fission":
-            openmoc_fluxes /= num_fsrs
-        print(np.nansum(openmoc_fluxes), np.sum(openmc_fluxes))
+        if sph_mode == "eigenvalue":
+            if normalization == "flux":
+                openmoc_fluxes /= np.nansum(openmoc_fluxes)
+            elif normalization == "SPH flux":
+                openmoc_fluxes /= np.nansum(openmoc_fluxes[
+                                            sph_to_domain_indices, :])
+            elif normalization == "fission":
+                openmoc_fluxes /= num_fsrs
 
         # Compute SPH factors
         if i > 0:
@@ -683,6 +697,9 @@ def compute_sph_factors(mgxs_lib, max_sph_iters=30, sph_tol=1E-5,
         # Compute SPH factor residuals
         res = np.abs((sph - old_sph) / old_sph)
         res = np.nan_to_num(res)
+
+        # Apply relaxation factors on SPH after computing residuals
+        sph = relax_factor * sph + (1.-relax_factor) * old_sph
 
         # Load SPH factors in geometry
         geometry.loadSPHFactors((sph/old_sph).flatten(),
@@ -707,7 +724,8 @@ def compute_sph_factors(mgxs_lib, max_sph_iters=30, sph_tol=1E-5,
 
     # Create a new MGXS library with cross sections updated by SPH factors
     sph = openmc_fluxes / openmoc_fluxes
-    sph_mgxs_lib = _apply_sph_factors(mgxs_lib, geometry, sph, sph_domains)
+    if return_library:
+        sph_mgxs_lib = _apply_sph_factors(mgxs_lib, geometry, sph, sph_domains)
 
     # Reset fixed sources in solver if one wants to compute the eigenvalue
     if sph_mode == "fixed source":
@@ -717,13 +735,14 @@ def compute_sph_factors(mgxs_lib, max_sph_iters=30, sph_tol=1E-5,
     fsrs_to_sph = np.ones((num_fsrs, num_groups), dtype=np.float)
     for i, openmc_domain in enumerate(mgxs_lib.domains):
         if openmc_domain.id in openmoc_domains:
-            openmoc_domain = openmoc_domains[openmc_domain.id]
-            if openmoc_domain.getId() in sph_domains:
+            if openmc_domain.id in sph_domains:
                 fsr_ids = domains_to_fsrs[openmc_domain.id]
                 fsrs_to_sph[fsr_ids,:] = sph[i,:]
 
-    return fsrs_to_sph, sph_mgxs_lib, np.array(sph_to_fsr_indices)
-
+    if return_library:
+        return fsrs_to_sph, sph_mgxs_lib, np.array(sph_to_fsr_indices)
+    else:
+        return fsrs_to_sph, np.array(sph_to_fsr_indices)
 
 def _load_openmc_src(mgxs_lib, solver, sph_mode):
     """Assign fixed sources to an OpenMOC model from an OpenMC MGXS library.
@@ -893,7 +912,7 @@ def _apply_sph_factors(mgxs_lib, geometry, sph, sph_domains):
         openmoc_domain = openmoc_domains[openmc_domain.id]
 
         # Ignore domains with no SPH factors
-        if openmoc_domain.getId() not in sph_domains:
+        if openmc_domain.id not in sph_domains:
             continue
 
         # Loop over all cross section types in the MGXS library

--- a/openmoc/materialize.py
+++ b/openmoc/materialize.py
@@ -678,7 +678,7 @@ def compute_sph_factors(mgxs_lib, max_sph_iters=30, sph_tol=1E-5,
         if sph_mode == "eigenvalue":
             if normalization == "flux":
                 openmoc_fluxes /= np.nansum(openmoc_fluxes)
-            elif normalization == "SPH flux":
+            elif normalization == "SPH-flux":
                 openmoc_fluxes /= np.nansum(openmoc_fluxes[
                                             sph_to_domain_indices, :])
             elif normalization == "fission":

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -1275,7 +1275,7 @@ def plot_spatial_data(domains_to_data, plot_params, get_figure=False):
         # Use domain IDs to appropriately index into FSR data
         # If domains-to-data was input as a Pandas DataFrame
         if pandas_df:
-            surface = domains_to_data.ix[:,i].values
+            surface = domains_to_data.iloc[:,i].values
             surface = surface.take(domains.flatten())
         # If domains-to-data was input as a NumPy array
         elif isinstance(domains_to_data, np.ndarray):

--- a/profile/models/c5g7/c5g7-3d-cmfd.cpp
+++ b/profile/models/c5g7/c5g7-3d-cmfd.cpp
@@ -14,17 +14,25 @@ int main(int argc, char* argv[]) {
 
   /* Define simulation parameters */
 #ifdef OPENMP
-  int num_threads = omp_get_num_threads();
+  int num_threads = omp_get_max_threads();
 #else
   int num_threads = 1;
 #endif
   double azim_spacing = 0.1;
   int num_azim = 16;
   double polar_spacing = 1.;
-  int num_polar = 14;
-  double tolerance = 1e-5;
-  int max_iters = 40;
+  int num_polar = 8;
+  double tolerance = 1e-4;
+  int max_iters = 2;
   int axial_refines = 15;
+
+  /* Domain decomposition / modular ray tracing */
+  int nx = 1;
+  int ny = 1;
+  int nz = 1;
+#ifdef MPIx
+  num_threads = std::max(1, num_threads / (nx*ny*nz));
+#endif
 
   /* Set logging information */
   set_log_level("NORMAL");
@@ -546,9 +554,10 @@ int main(int argc, char* argv[]) {
   Geometry geometry;
   geometry.setRootUniverse(root_universe);
 #ifdef MPIx
-  geometry.setDomainDecomposition(3, 3, 3, MPI_COMM_WORLD);
+  geometry.setDomainDecomposition(nx, ny, nz, MPI_COMM_WORLD);
+#else
+  geometry.setNumDomainModules(nx, ny, nz);
 #endif
-  geometry.setNumDomainModules(3,3,3);
   geometry.setCmfd(cmfd);
   geometry.initializeFlatSourceRegions();
 

--- a/profile/models/c5g7/c5g7-3d.cpp
+++ b/profile/models/c5g7/c5g7-3d.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* argv[]) {
 
   /* Define simulation parameters */
 #ifdef OPENMP
-  int num_threads = omp_get_num_threads();
+  int num_threads = omp_get_max_threads();
 #else
   int num_threads = 1;
 #endif
@@ -25,6 +25,14 @@ int main(int argc, char* argv[]) {
   double tolerance = 1e-5;
   int max_iters = 1000;
   int axial_refines = 1;
+
+  /* Domain decomposition / modular ray tracing */
+  int nx = 1;
+  int ny = 1;
+  int nz = 1;
+#ifdef MPIx
+  num_threads = std::max(1, num_threads / (nx*ny*nz));
+#endif
 
   /* Set logging information */
   set_log_level("NORMAL");
@@ -530,6 +538,11 @@ int main(int argc, char* argv[]) {
   log_printf(NORMAL, "Creating geometry...");
   Geometry geometry;
   geometry.setRootUniverse(root_universe);
+#ifdef MPIx
+  geometry.setDomainDecomposition(nx, ny, nz, MPI_COMM_WORLD);
+#else
+  geometry.setNumDomainModules(nx, ny, nz);
+#endif
   geometry.initializeFlatSourceRegions();
 
   /* Generate tracks */

--- a/profile/models/c5g7/c5g7-rodded-B-2x2.cpp
+++ b/profile/models/c5g7/c5g7-rodded-B-2x2.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) {
 
   /* Define simulation parameters */
 #ifdef OPENMP
-  int num_threads = omp_get_num_threads();
+  int num_threads = omp_get_max_threads();
 #else
   int num_threads = 1;
 #endif
@@ -26,6 +26,14 @@ int main(int argc, char* argv[]) {
   int max_iters = 50;
   int axial_refines = 1;
   int axial_zones = 3;
+
+  /* Domain decomposition / modular ray tracing */
+  int nx = 1;
+  int ny = 1;
+  int nz = 1;
+#ifdef MPIx
+  num_threads = std::max(1, num_threads / (nx*ny*nz));
+#endif
 
   /* Set logging information */
   set_log_level("NORMAL");
@@ -487,9 +495,10 @@ int main(int argc, char* argv[]) {
   Geometry geometry;
   geometry.setRootUniverse(root_universe);
 #ifdef MPIx
-  geometry.setDomainDecomposition(1, 1, 1, MPI_COMM_WORLD);
+  geometry.setDomainDecomposition(nx, ny, nz, MPI_COMM_WORLD);
+#else
+  geometry.setNumDomainModules(nx, ny, nz);
 #endif
-  geometry.setNumDomainModules(2,2,2);
   geometry.setCmfd(cmfd);
   geometry.initializeFlatSourceRegions();
 

--- a/profile/models/c5g7/c5g7-rodded-B.cpp
+++ b/profile/models/c5g7/c5g7-rodded-B.cpp
@@ -15,7 +15,7 @@ int main(int argc, char* argv[]) {
 
   /* Define simulation parameters */
 #ifdef OPENMP
-  int num_threads = omp_get_num_threads();
+  int num_threads = omp_get_max_threads();
 #else
   int num_threads = 1;
 #endif
@@ -26,6 +26,14 @@ int main(int argc, char* argv[]) {
   double tolerance = 1e-5;
   int max_iters = 40;
   int axial_refines = 5;
+
+  /* Domain decomposition / modular ray tracing */
+  int nx = 1;
+  int ny = 1;
+  int nz = 1;
+#ifdef MPIx
+  num_threads = std::max(1, num_threads / (nx*ny*nz));
+#endif
 
   /* Set logging information */
   set_log_level("NORMAL");
@@ -703,7 +711,9 @@ int main(int argc, char* argv[]) {
   Geometry geometry;
   geometry.setRootUniverse(root_universe);
 #ifdef MPIx
-  geometry.setDomainDecomposition(3, 3, 3, MPI_COMM_WORLD);
+  geometry.setDomainDecomposition(nx, ny, nz, MPI_COMM_WORLD);
+#else
+  geometry.setNumDomainModules(nx, ny, nz);
 #endif
   geometry.setCmfd(cmfd);
   geometry.initializeFlatSourceRegions();

--- a/profile/models/c5g7/c5g7-ws.cpp
+++ b/profile/models/c5g7/c5g7-ws.cpp
@@ -16,7 +16,7 @@ int main(int argc, char* argv[]) {
 
   /* Define simulation parameters */
 #ifdef OPENMP
-  int num_threads = omp_get_num_threads();
+  int num_threads = omp_get_max_threads();
 #else
   int num_threads = 1;
 #endif
@@ -27,6 +27,14 @@ int main(int argc, char* argv[]) {
   double tolerance = 1e-5;
   int max_iters = 50;
   int axial_refines = 1;
+
+  /* Domain decomposition / modular ray tracing */
+  int nx = 1;
+  int ny = 1;
+  int nz = 1;
+#ifdef MPIx
+  num_threads = std::max(1, num_threads / (nx*ny*nz));
+#endif
 
   /* Set logging information */
   set_log_level("NORMAL");
@@ -785,9 +793,10 @@ int main(int argc, char* argv[]) {
   Geometry geometry;
   geometry.setRootUniverse(root_universe);
 #ifdef MPIx
-  geometry.setDomainDecomposition(2, 2, 2, MPI_COMM_WORLD);
+  geometry.setDomainDecomposition(nx, ny, nz, MPI_COMM_WORLD);
+#else
+  geometry.setNumDomainModules(nx, ny, nz);
 #endif
-  geometry.setNumDomainModules(4,4,4);
   geometry.setCmfd(cmfd);
   geometry.initializeFlatSourceRegions();
 

--- a/tests/test_superhomogeneization_eigenvalue/test_superhomogeneization_eigenvalue.py
+++ b/tests/test_superhomogeneization_eigenvalue/test_superhomogeneization_eigenvalue.py
@@ -47,7 +47,7 @@ class ComputeMaterialSPHTestHarness(TestHarness):
             openmoc.materialize.compute_sph_factors(
                 mgxs_lib, azim_spacing=self.azim_spacing,
                 num_azim=self.num_azim, num_threads=self.num_threads,
-                sph_mode="eigenvalue")
+                sph_mode="eigenvalue", normalization="flux")
 
         # Create an OpenMOC Geometry from the OpenMOC Geometry
         openmoc_geometry = \


### PR DESCRIPTION
Normalizing SPH factors, and relaxation, avoids divergence when the reaction rate is being conserved, but factors are growing and fluxes decreasing. 