### PR TITLE
add continued fraction exponential

### DIFF
--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -2338,7 +2338,7 @@ void CPUSolver::tallyScalarFlux(segment* curr_segment,
 
         /* Compute the exponential */
         FP_PRECISION exponential;
-        expF1_fractional(tau, &exponential);
+        expF1_continued(tau, &exponential);
 
         /* Compute attenuation and tally the contribution to the scalar flux */
         FP_PRECISION delta_psi = (tau * track_flux[e] - length *
@@ -2355,7 +2355,7 @@ void CPUSolver::tallyScalarFlux(segment* curr_segment,
 
       /* Compute the exponential */
       FP_PRECISION exponential;
-      expF1_fractional(tau, &exponential);
+      expF1_continued(tau, &exponential);
 
       /* Compute attenuation and tally the contribution to the scalar flux */
       FP_PRECISION delta_psi = (tau * track_flux[e] - length *

--- a/src/ExpEvaluator.h
+++ b/src/ExpEvaluator.h
@@ -175,7 +175,7 @@ inline FP_PRECISION ExpEvaluator::computeExponential(FP_PRECISION tau,
   FP_PRECISION inv_sin_theta = _inverse_sin_theta_no_offset;
 #endif
   FP_PRECISION exp_F1;
-  expF1_fractional(tau * inv_sin_theta, &exp_F1);
+  expF1_continued(tau * inv_sin_theta, &exp_F1);
 
   return inv_sin_theta * exp_F1;
 }

--- a/src/exponentials.h
+++ b/src/exponentials.h
@@ -191,6 +191,23 @@ inline void expF1_fractional(FP_PRECISION x, FP_PRECISION* expF1) {
   *expF1 = num*den;
 }
 
+/**
+ * @brief Computes the F1 exponential term.
+ * @details Exact same as computeF1_exponential, but simplified the algebra
+ *          some. You'd think more divisions would be slower. But the compiler
+ *          optimizes this out with SIMD quite well.
+ * @param x the value at which to evaluate the function, usually tau
+ * @param expF1 a pointer to the exponential
+ */
+inline void expF1_continued(FP_PRECISION x, FP_PRECISION* expF1) {
+  FP_PRECISION t1 = -0.0007706618174095522f + x;
+  FP_PRECISION t2 = 430.4417106253813f + 8.065530110666254f*x;
+  FP_PRECISION t3 = -0.0014907526842255446f + 0.00007959230164620542f*x;
+  FP_PRECISION t4 = -909.733382360302f + 72.8109059813554f*x;
+  FP_PRECISION t5 = -0.002868787847637995f + 0.00030789156651464197f*x;
+  FP_PRECISION t6 = -1527.156986843306f + 200.5065021575783f*x;
+  *expF1 = 1.f/(t1 + 1.f/(t2 + 1.f/(t3 + 1.f/(t4 + 1.f/(t5 + 1.f/t6)))));
+}
 
 /**
  * @brief Computes the F2 exponential term.


### PR DESCRIPTION
So I stumbled across the interesting fact the other day that you can rearrange any rational polynomial into a continued fraction by recursively doing polynomial long division.

Got an **8% speedup on C5G7** on the transport sweeps by re-arranging the algebra of the rational approximation to the exponential. This is fast than using Horner's method on the numerator and denominator separately (as is currently done).

I tested the accuracy of the new method (it should be identical to Josey's Remez results aside from numerical evaluation error) and it's indistinguishable.

Similar stuff could be done for the other rational approximations!

Also, there's apparently some assembly instruction for an approximate reciprocal (which is likely acceptable accuracy to our rational approximation which is approximate as-is). This would be stupid fast if someone wrote the inline assembly to use that instruction.

On intel CPUs it should be "VRCP14PD" or "VRCP14PS" for SIMD reciprocals. I don't think any compiler will ever put these in your code since they're more meant for some lower level implementation of calculating square roots with newton's method and whatever else.