### PR TITLE
Add missing declarations to GPUSolver header

### DIFF
--- a/src/accel/cuda/GPUSolver.h
+++ b/src/accel/cuda/GPUSolver.h
@@ -170,6 +170,12 @@ public:
   double computeResidual(residualType res_type);
 
   void computeFSRFissionRates(double* fission_rates, long num_FSRs, bool nu = false);
+  
+  /// Missing implementations
+  void resetFixedSources() {};
+  void printCycle(long track_start, int domain_start, int length) {};
+  void printLoadBalancingReport() {};
+  void boundaryFluxChecker() {};
 };
 
 


### PR DESCRIPTION
Quick bugfix for missing declarations. 
Some of them should be moved from Solver to CPUSolver so that the GPUSolver does not have to declare them too