### PR TITLE
Support Python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ notifications:
   webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN
 matrix:
   include:
+    - python: "3.10"
+      env: OMP=n MPI=n
     - python: "3.6"
       env: OMP=n MPI=n
     - python: "3.6"

--- a/openmoc/checkvalue.py
+++ b/openmoc/checkvalue.py
@@ -1,5 +1,4 @@
 import sys
-from collections import Iterable
 from numbers import Integral, Real
 
 import numpy as np
@@ -10,6 +9,11 @@ if (sys.version_info[0] == 2):
 # For Python 3.X.X
 else:
     from openmoc.log import *
+
+if sys.version_info >= (3, 3):
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 
 
 def _isinstance(value, expected_type):
@@ -201,7 +205,7 @@ def check_value(name, value, accepted_values):
     ----------
     name : str
         Description of value being checked
-    value : collections.Iterable
+    value : Iterable
         Object to check
     accepted_values : collections.Container
         Container of acceptable values

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -1,13 +1,18 @@
 import os
 import sys
 from numbers import Integral, Real
-from collections import Iterable
 import warnings
 
 import numpy as np
 import numpy.random
 import matplotlib
 from mpl_toolkits.mplot3d import Axes3D
+
+# For Python 3.3.X and above
+if sys.version_info >= (3, 3):
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 
 # Force headless backend for plotting on clusters
 if "DISPLAY" not in os.environ:

--- a/openmoc/process.py
+++ b/openmoc/process.py
@@ -6,7 +6,6 @@ import math
 import datetime
 import operator
 from numbers import Integral, Real
-from collections import Iterable
 import pickle
 
 import numpy as np
@@ -22,6 +21,11 @@ if (sys.version_info[0] == 2):
 else:
     from openmoc.log import *
     import openmoc.checkvalue as cv
+
+if sys.version_info >= (3, 3):
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 
 # Store viable OpenMOC solver types for type checking
 solver_types = (openmoc.Solver,)


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working.

Addresses #475. Adds 3.10 to the test matrix.