### PR TITLE
Update from np.float to np.float64

### DIFF
--- a/openmoc/materialize.py
+++ b/openmoc/materialize.py
@@ -761,7 +761,7 @@ def compute_sph_factors(mgxs_lib, max_sph_iters=30, sph_tol=1E-5,
         solver.resetFixedSources()
 
     # Collect SPH factors for each FSR, energy group
-    fsrs_to_sph = np.ones((num_fsrs, num_groups), dtype=np.float)
+    fsrs_to_sph = np.ones((num_fsrs, num_groups), dtype=np.float64)
     for i, openmc_domain in enumerate(mgxs_lib.domains):
         if openmc_domain.id in openmoc_domains:
             if openmc_domain.id in sph_domains:

--- a/openmoc/plotter.py
+++ b/openmoc/plotter.py
@@ -609,7 +609,7 @@ def plot_flat_source_regions(geometry, gridsize=250, xlim=None, ylim=None,
         if centroids:
 
             # Populate a NumPy array with the FSR centroid coordinates
-            centroids = np.zeros((num_fsrs, 2), dtype=np.float)
+            centroids = np.zeros((num_fsrs, 2), dtype=np.float64)
             for fsr_id in range(num_fsrs):
                 coords = geometry.getGlobalFSRCentroidData(fsr_id)
                 if plane == 'xy':
@@ -952,7 +952,7 @@ def plot_energy_fluxes(solver, fsrs, group_bounds=None, norm=True,
     for fsr in fsrs:
 
         # Allocate memory for an array of this FSR's fluxes
-        fluxes = np.zeros(num_groups, dtype=np.float)
+        fluxes = np.zeros(num_groups, dtype=np.float64)
 
         # Extract the flux in each energy group
         for group in range(num_groups):
@@ -1317,7 +1317,7 @@ def plot_spatial_data(domains_to_data, plot_params, get_figure=False):
             surface = domains_to_data.take(domains.flatten())
         # If domains-to-data was input as a Python dictionary
         else:
-            surface = np.zeros(domains.shape, dtype=np.float)
+            surface = np.zeros(domains.shape, dtype=np.float64)
             for domain_id in domains_to_data:
                 indices = np.where(domains == domain_id)
                 surface[indices] = domains_to_data[domain_id]
@@ -1947,7 +1947,7 @@ def _get_pil_image(array, plot_params):
     from PIL import Image
 
     # Convert array to a normalized array of floating point values
-    float_array = np.zeros(array.shape, dtype=np.float)
+    float_array = np.zeros(array.shape, dtype=np.float64)
     float_array[:,:] = array[:,:]
     float_array[:,:] /= np.max(float_array)
 

--- a/openmoc/process.py
+++ b/openmoc/process.py
@@ -993,7 +993,7 @@ class Mesh(object):
             solver.computeFSRFissionRates(int(geometry.getNumTotalFSRs()), nu)
 
         # Initialize a 2D or 3D NumPy array in which to tally
-        tally = np.zeros(tuple(self.dimension), dtype=np.float)
+        tally = np.zeros(tuple(self.dimension), dtype=np.float64)
 
         # Tally the fission rates in each FSR to the corresponding mesh cell
         for fsr in range(num_fsrs):
@@ -1116,7 +1116,7 @@ class Mesh(object):
 
         # Initialize a 2D or 3D NumPy array in which to tally
         tally_shape = tuple(self.dimension) + (num_groups,)
-        tally = np.zeros(tally_shape, dtype=np.float)
+        tally = np.zeros(tally_shape, dtype=np.float64)
 
         # Compute product of fluxes with domains-to-coeffs mapping by group, FSR
         for fsr in range(num_fsrs):
@@ -1127,7 +1127,7 @@ class Mesh(object):
                 continue
 
             volume = solver.getFSRVolume(fsr)
-            fsr_tally = np.zeros(num_groups, dtype=np.float)
+            fsr_tally = np.zeros(num_groups, dtype=np.float64)
 
             # Determine domain ID (material, cell or FSR) for this FSR
             if domain_type == 'fsr':

--- a/sample-input/sph-factors/slab/sph-factors.py
+++ b/sample-input/sph-factors/slab/sph-factors.py
@@ -86,8 +86,8 @@ openmoc.log.py_printf('NORMAL', 'Plotting data...')
 # Allocate arrays for FSR-specific data to extract from OpenMOC model
 num_fsrs = openmoc_geometry.getNumFSRs()
 cell_ids = np.zeros(num_fsrs, dtype=np.int)
-centroids = np.zeros(num_fsrs, dtype=np.float)
-volumes = np.zeros(num_fsrs, dtype=np.float)
+centroids = np.zeros(num_fsrs, dtype=np.float64)
+volumes = np.zeros(num_fsrs, dtype=np.float64)
 
 # Find the cell IDs, volumes, centroids and fluxes for each FSR
 for fsr_id in range(num_fsrs):

--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -166,7 +166,7 @@ void CPUSolver::setNumThreads(int num_threads) {
  *          routine may be used as follows from within Python:
  *
  * @code
- *          fluxes = numpy.random.rand(num_FSRs * num_groups, dtype=np.float)
+ *          fluxes = numpy.random.rand(num_FSRs * num_groups, dtype=np.float64)
  *          solver.setFluxes(fluxes)
  * @endcode
  *

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1061,7 +1061,7 @@ void GPUSolver::setTrackGenerator(TrackGenerator* track_generator) {
  * @code
  *          num_FSRs = solver.getGeometry.getNumFSRs()
  *          NUM_GROUPS = solver.getGeometry.getNumEnergyGroups()
- *          fluxes = numpy.random.rand(num_FSRs * NUM_GROUPS, dtype=np.float)
+ *          fluxes = numpy.random.rand(num_FSRs * NUM_GROUPS, dtype=np.float64)
  *          solver.setFluxes(fluxes)
  * @endcode
  *


### PR DESCRIPTION
The use of `np.float` as a NumPy `dtype` was deprecated in 1.20. This updates any use of `np.float` to np.float64`. I noted that there were some uses of `np.float32` in the code, so let me know if that would be preferred in some cases.

I tested this locally and couldn't get everything to pass, but that was true before these changes.