### PR TITLE
Removing deprecated np.float_ for NumPy v2.0 Support

### DIFF
--- a/openmoc/checkvalue.py
+++ b/openmoc/checkvalue.py
@@ -31,7 +31,7 @@ def _isinstance(value, expected_type):
     # Declare numpy numeric types.
     np_ints = (np.int_, np.intc, np.intp, np.int8, np.int16, np.int32, np.int64,
                np.uint8, np.uint16, np.uint32, np.uint64)
-    np_floats = (np.float_, np.float16, np.float32, np.float64)
+    np_floats = (np.float16, np.float32, np.float64)
 
     # Include numpy integers, if necessary.
     if type(expected_type) is tuple:


### PR DESCRIPTION
Title says it all. Let me know if there are questions/concerns.